### PR TITLE
Add Feishu pull request review notifications

### DIFF
--- a/.github/workflows/feishu-pr-notify.yml
+++ b/.github/workflows/feishu-pr-notify.yml
@@ -1,0 +1,46 @@
+name: feishu-pr-notify
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+
+jobs:
+  feishu-pr-notify:
+    name: feishu-pr-notify
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
+
+    steps:
+      - name: Send Feishu notification
+        env:
+          FEISHU_WEBHOOK_URL: ${{ secrets.FEISHU_WEBHOOK_URL }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO_NAME: ${{ github.repository }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          ACTION_NAME: ${{ github.event.action }}
+        run: |
+          if [ -z "$FEISHU_WEBHOOK_URL" ]; then
+            echo "FEISHU_WEBHOOK_URL is not configured; skipping notification."
+            exit 0
+          fi
+
+          payload=$(cat <<EOF
+          {
+            "msg_type": "text",
+            "content": {
+              "text": "[OpenPrecedent] PR ready for review\nRepo: ${REPO_NAME}\nPR: #${PR_NUMBER} ${PR_TITLE}\nAuthor: ${PR_AUTHOR}\nAction: ${ACTION_NAME}\nBranch: ${HEAD_REF} -> ${BASE_REF}\nLink: ${PR_URL}"
+            }
+          }
+          EOF
+          )
+
+          curl -sS -X POST "$FEISHU_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -d "$payload"

--- a/docs/engineering/feishu-pr-notifications.md
+++ b/docs/engineering/feishu-pr-notifications.md
@@ -1,0 +1,58 @@
+# Feishu PR Notifications
+
+## Goal
+
+Send a Feishu bot notification whenever a pull request becomes ready for review.
+
+This repository uses a GitHub Actions based notification flow:
+
+1. GitHub pull request event occurs
+2. workflow formats a short message
+3. workflow posts to a Feishu bot webhook
+
+This is preferred over having a coding agent actively send notifications because PR review is an event-driven repository concern, not a session-scoped agent concern.
+
+## Current Trigger Scope
+
+The first implementation notifies on:
+
+- `pull_request.opened`
+- `pull_request.reopened`
+- `pull_request.ready_for_review`
+
+Draft pull requests are ignored.
+
+## Required Secret
+
+Configure this repository secret in GitHub:
+
+- `FEISHU_WEBHOOK_URL`
+
+Path:
+
+1. GitHub repository
+2. `Settings`
+3. `Secrets and variables`
+4. `Actions`
+5. `New repository secret`
+
+## Message Shape
+
+The current message includes:
+
+- repository name
+- PR number
+- PR title
+- author
+- action type
+- source and target branch
+- PR link
+
+## Future Improvements
+
+Possible later extensions:
+
+- notify again when all required checks pass
+- notify only for PRs targeting `main`
+- include CI status summary
+- support richer Feishu card messages

--- a/docs/engineering/tooling-setup.md
+++ b/docs/engineering/tooling-setup.md
@@ -6,6 +6,7 @@ The repository already includes:
 
 - `markdownlint` GitHub Actions workflow for Markdown review
 - `python-ci` GitHub Actions workflow for dependency install and tests
+- `feishu-pr-notify` GitHub Actions workflow for pull request review notifications
 - a local Git pre-push hook that requires a Codex review note
 
 To enable the local hook:
@@ -41,6 +42,7 @@ Recommended rollout:
 
 1. enable repository-local Markdown checks
 2. enable Python CI checks on pull requests
-3. enable Codex pre-push review hook
-4. install CodeFactor
-5. install CodeAnt AI
+3. configure `FEISHU_WEBHOOK_URL` for review notifications
+4. enable Codex pre-push review hook
+5. install CodeFactor
+6. install CodeAnt AI


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that sends Feishu notifications when a pull request is opened, reopened, or marked ready for review
- add repository documentation for Feishu PR notification setup
- update tooling docs to include the required Feishu webhook secret

## Why
PR review notifications are a repository event concern and should be handled by GitHub-driven automation rather than a session-scoped coding agent. This change creates a stable notification path from pull request events to Feishu.

## Notes
- requires the `FEISHU_WEBHOOK_URL` repository secret to actually send notifications
- draft pull requests are ignored
- the first version uses a simple text message format