### PR TITLE
Add public project standards and dependency policy

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.py]
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing
+
+## Workflow
+
+OpenPrecedent uses a fork-and-pull-request workflow.
+
+Expected flow:
+
+1. fork the repository
+2. create a feature branch
+3. make a focused change
+4. run local checks when possible
+5. complete a local Codex review note before push
+6. open a pull request into `openprecedent/openprecedent`
+
+## Before Opening a PR
+
+- update docs if schemas, APIs, or repository rules changed
+- keep terminology consistent with:
+  - `case`
+  - `event`
+  - `decision`
+  - `artifact`
+  - `precedent`
+- avoid broad refactors unless explicitly scoped
+
+## Review Expectations
+
+- required checks must pass
+- the pull request review gate must pass
+- conversations should be resolved before merge
+
+## Scope Discipline
+
+Prefer small changes that clearly move one of these forward:
+
+- event capture
+- decision extraction
+- replay and explanation
+- precedent retrieval
+
+Avoid reframing the project as:
+
+- a generic graph database
+- a generic memory graph
+- a generic trace viewer

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Scope
+
+OpenPrecedent is still in an early stage. Security expectations should still be treated seriously, especially for:
+
+- event payload handling
+- secrets in repository configuration
+- webhook integrations
+- future storage of case data and artifacts
+
+## Reporting
+
+Do not open public GitHub issues for sensitive vulnerabilities.
+
+For now, report security concerns privately to the repository maintainer through a private channel you already use with the project owner.
+
+## Early Security Rules
+
+- never commit secrets
+- use repository secrets for webhook credentials
+- prefer least-privilege tokens and webhooks
+- redact sensitive payload fields before long-term storage where possible


### PR DESCRIPTION
## Summary
- add CONTRIBUTING guidance for fork-and-PR based collaboration
- add a minimal SECURITY policy for early-stage repository handling
- add an editorconfig for consistent formatting defaults
- add Dependabot configuration for GitHub Actions and Python dependency updates

## Why
This is a useful repository-wide standards PR that also serves as a real test of the Feishu pull request notification flow. The changes are low-risk, broadly useful, and improve project readiness before feature development starts.

## Notes
- no runtime behavior changes
- no schema or API changes
- intended as a governance and developer-experience baseline
