### PR TITLE
Allow Feishu notifications for fork pull requests

### DIFF
--- a/.github/workflows/feishu-pr-notify.yml
+++ b/.github/workflows/feishu-pr-notify.yml
@@ -1,7 +1,7 @@
 name: feishu-pr-notify
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened


### PR DESCRIPTION
## Summary
- switch the Feishu notification workflow from `pull_request` to `pull_request_target`

## Why
The repository uses a fork-and-pull-request workflow. On fork-originated pull requests, workflows triggered by `pull_request` cannot access repository secrets, so the Feishu webhook URL is unavailable. Using `pull_request_target` lets the notification workflow read the target repository secret while still only processing pull request metadata.

## Safety
- this workflow does not check out or execute untrusted pull request code
- it only reads pull request metadata and posts a webhook notification