### PR TITLE
Validate Feishu review notifications

### DIFF
--- a/docs/engineering/feishu-pr-notifications.md
+++ b/docs/engineering/feishu-pr-notifications.md
@@ -56,3 +56,4 @@ Possible later extensions:
 - notify only for PRs targeting `main`
 - include CI status summary
 - support richer Feishu card messages
+- include a repository-specific review handbook link in the message


### PR DESCRIPTION
## Summary
- add one small follow-up note to the Feishu notification documentation

## Why
This PR intentionally serves as a real validation of the Feishu pull request notification workflow after configuring the repository webhook secret.

## Notes
- no runtime code changes
- safe to merge or close after notification delivery is confirmed
