### PR TITLE
Implement MVP ingestion, replay, and CLI loop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ dependencies = [
   "uvicorn>=0.35.0,<1.0.0",
 ]
 
+[project.scripts]
+openprecedent = "openprecedent.cli:run"
+
 [dependency-groups]
 dev = [
   "httpx>=0.28.0,<1.0.0",

--- a/src/openprecedent/api.py
+++ b/src/openprecedent/api.py
@@ -1,18 +1,36 @@
-from fastapi import FastAPI
+from __future__ import annotations
 
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, ConfigDict
+
+from openprecedent.config import get_db_path
 from openprecedent.schemas import Artifact, Case, Decision, Event, Precedent
+from openprecedent.services import (
+    AppendEventInput,
+    ConflictError,
+    CreateCaseInput,
+    OpenPrecedentService,
+    ReplayResponse,
+)
 
 
 app = FastAPI(title="OpenPrecedent", version="0.1.0")
 
 
+class ExtractionResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    case_id: str
+    decisions: list[Decision]
+
+
 @app.get("/healthz")
-def healthcheck() -> dict[str, str]:
+async def healthcheck() -> dict[str, str]:
     return {"status": "ok"}
 
 
 @app.get("/schemas")
-def schema_catalog() -> dict[str, object]:
+async def schema_catalog() -> dict[str, object]:
     return {
         "case": Case.model_json_schema(),
         "event": Event.model_json_schema(),
@@ -20,3 +38,79 @@ def schema_catalog() -> dict[str, object]:
         "artifact": Artifact.model_json_schema(),
         "precedent": Precedent.model_json_schema(),
     }
+
+
+def get_service() -> OpenPrecedentService:
+    return OpenPrecedentService.from_path(get_db_path())
+
+
+@app.post("/cases", response_model=Case, status_code=201)
+async def create_case(payload: CreateCaseInput) -> Case:
+    try:
+        return get_service().create_case(payload)
+    except ConflictError as error:
+        raise HTTPException(status_code=409, detail=str(error)) from error
+
+
+@app.get("/cases", response_model=list[Case])
+async def list_cases() -> list[Case]:
+    return get_service().list_cases()
+
+
+@app.get("/cases/{case_id}", response_model=Case)
+async def get_case(case_id: str) -> Case:
+    case = get_service().get_case(case_id)
+    if case is None:
+        raise HTTPException(status_code=404, detail="case not found")
+    return case
+
+
+@app.post("/cases/{case_id}/events", response_model=Event, status_code=201)
+async def append_event(case_id: str, payload: AppendEventInput) -> Event:
+    try:
+        return get_service().append_event(case_id, payload)
+    except KeyError as error:
+        raise HTTPException(status_code=404, detail="case not found") from error
+    except ConflictError as error:
+        raise HTTPException(status_code=409, detail=str(error)) from error
+
+
+@app.get("/cases/{case_id}/events", response_model=list[Event])
+async def list_events(case_id: str) -> list[Event]:
+    try:
+        return get_service().list_events(case_id)
+    except KeyError as error:
+        raise HTTPException(status_code=404, detail="case not found") from error
+
+
+@app.get("/cases/{case_id}/replay", response_model=ReplayResponse)
+async def replay_case(case_id: str) -> ReplayResponse:
+    try:
+        return get_service().replay_case(case_id)
+    except KeyError as error:
+        raise HTTPException(status_code=404, detail="case not found") from error
+
+
+@app.post("/cases/{case_id}/extract-decisions", response_model=ExtractionResponse)
+async def extract_decisions(case_id: str) -> ExtractionResponse:
+    try:
+        decisions = get_service().extract_decisions(case_id)
+    except KeyError as error:
+        raise HTTPException(status_code=404, detail="case not found") from error
+    return ExtractionResponse(case_id=case_id, decisions=decisions)
+
+
+@app.get("/cases/{case_id}/decisions", response_model=list[Decision])
+async def list_decisions(case_id: str) -> list[Decision]:
+    try:
+        return get_service().list_decisions(case_id)
+    except KeyError as error:
+        raise HTTPException(status_code=404, detail="case not found") from error
+
+
+@app.get("/cases/{case_id}/precedents", response_model=list[Precedent])
+async def find_precedents(case_id: str, limit: int = 3) -> list[Precedent]:
+    try:
+        return get_service().find_precedents(case_id, limit=limit)
+    except KeyError as error:
+        raise HTTPException(status_code=404, detail="case not found") from error

--- a/src/openprecedent/cli.py
+++ b/src/openprecedent/cli.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from openprecedent.config import get_db_path
+from openprecedent.schemas import EventActor, EventType
+from openprecedent.services import AppendEventInput, CreateCaseInput, OpenPrecedentService
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="openprecedent")
+    subparsers = parser.add_subparsers(dest="resource", required=True)
+
+    case_parser = subparsers.add_parser("case")
+    case_subparsers = case_parser.add_subparsers(dest="action", required=True)
+    case_create = case_subparsers.add_parser("create")
+    case_create.add_argument("--title", required=True)
+    case_create.add_argument("--case-id")
+    case_create.add_argument("--user-id")
+    case_create.add_argument("--agent-id")
+    case_subparsers.add_parser("list")
+    case_show = case_subparsers.add_parser("show")
+    case_show.add_argument("case_id")
+
+    event_parser = subparsers.add_parser("event")
+    event_subparsers = event_parser.add_subparsers(dest="action", required=True)
+    event_append = event_subparsers.add_parser("append")
+    event_append.add_argument("case_id")
+    event_append.add_argument("event_type", choices=[item.value for item in EventType])
+    event_append.add_argument("actor", choices=[item.value for item in EventActor])
+    event_append.add_argument("--payload", default="{}")
+    event_append.add_argument("--event-id")
+    event_import = event_subparsers.add_parser("import-jsonl")
+    event_import.add_argument("path")
+    event_import.add_argument("--case-id")
+
+    replay_parser = subparsers.add_parser("replay")
+    replay_subparsers = replay_parser.add_subparsers(dest="action", required=True)
+    replay_case = replay_subparsers.add_parser("case")
+    replay_case.add_argument("case_id")
+    replay_case.add_argument("--json", action="store_true", dest="as_json")
+
+    extract_parser = subparsers.add_parser("extract")
+    extract_subparsers = extract_parser.add_subparsers(dest="action", required=True)
+    extract_decisions = extract_subparsers.add_parser("decisions")
+    extract_decisions.add_argument("case_id")
+
+    decisions_parser = subparsers.add_parser("decisions")
+    decisions_subparsers = decisions_parser.add_subparsers(dest="action", required=True)
+    decisions_show = decisions_subparsers.add_parser("show")
+    decisions_show.add_argument("case_id")
+
+    precedent_parser = subparsers.add_parser("precedent")
+    precedent_subparsers = precedent_parser.add_subparsers(dest="action", required=True)
+    precedent_find = precedent_subparsers.add_parser("find")
+    precedent_find.add_argument("case_id")
+    precedent_find.add_argument("--limit", type=int, default=3)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    service = OpenPrecedentService.from_path(get_db_path())
+
+    try:
+        if args.resource == "case":
+            return _handle_case(args, service)
+        if args.resource == "event":
+            return _handle_event(args, service)
+        if args.resource == "replay":
+            return _handle_replay(args, service)
+        if args.resource == "extract":
+            return _handle_extract(args, service)
+        if args.resource == "decisions":
+            return _handle_decisions(args, service)
+        if args.resource == "precedent":
+            return _handle_precedent(args, service)
+    except KeyError as error:
+        print(f"case not found: {error.args[0]}", file=sys.stderr)
+        return 1
+    except ValueError as error:
+        print(str(error), file=sys.stderr)
+        return 1
+
+    parser.error("unknown command")
+    return 2
+
+
+def run() -> None:
+    raise SystemExit(main())
+
+
+def _handle_case(args: argparse.Namespace, service: OpenPrecedentService) -> int:
+    if args.action == "create":
+        case = service.create_case(
+            CreateCaseInput(
+                case_id=args.case_id,
+                title=args.title,
+                user_id=args.user_id,
+                agent_id=args.agent_id,
+            )
+        )
+        _print_json(case.model_dump(mode="json"))
+        return 0
+    if args.action == "list":
+        _print_json([case.model_dump(mode="json") for case in service.list_cases()])
+        return 0
+    if args.action == "show":
+        case = service.get_case(args.case_id)
+        if case is None:
+            print(f"case not found: {args.case_id}", file=sys.stderr)
+            return 1
+        _print_json(case.model_dump(mode="json"))
+        return 0
+    return 2
+
+
+def _handle_event(args: argparse.Namespace, service: OpenPrecedentService) -> int:
+    if args.action == "append":
+        payload = json.loads(args.payload)
+        event = service.append_event(
+            args.case_id,
+            AppendEventInput(
+                event_id=args.event_id,
+                event_type=EventType(args.event_type),
+                actor=EventActor(args.actor),
+                payload=payload,
+            ),
+        )
+        _print_json(event.model_dump(mode="json"))
+        return 0
+    if args.action == "import-jsonl":
+        imported = service.import_events_jsonl(Path(args.path), default_case_id=args.case_id)
+        _print_json([event.model_dump(mode="json") for event in imported])
+        return 0
+    return 2
+
+
+def _handle_replay(args: argparse.Namespace, service: OpenPrecedentService) -> int:
+    replay = service.replay_case(args.case_id)
+    if args.as_json:
+        _print_json(replay.model_dump(mode="json"))
+        return 0
+
+    print(f"Case {replay.case.case_id}: {replay.case.title}")
+    print(f"Status: {replay.case.status.value}")
+    print("Events:")
+    for event in replay.events:
+        print(f"  [{event.sequence_no}] {event.event_type.value} ({event.actor.value})")
+    print("Decisions:")
+    for decision in replay.decisions:
+        print(f"  [{decision.sequence_no}] {decision.decision_type.value}: {decision.title}")
+    if replay.summary:
+        print(f"Summary: {replay.summary}")
+    return 0
+
+
+def _handle_extract(args: argparse.Namespace, service: OpenPrecedentService) -> int:
+    decisions = service.extract_decisions(args.case_id)
+    _print_json([decision.model_dump(mode="json") for decision in decisions])
+    return 0
+
+
+def _handle_decisions(args: argparse.Namespace, service: OpenPrecedentService) -> int:
+    decisions = service.list_decisions(args.case_id)
+    _print_json([decision.model_dump(mode="json") for decision in decisions])
+    return 0
+
+
+def _handle_precedent(args: argparse.Namespace, service: OpenPrecedentService) -> int:
+    precedents = service.find_precedents(args.case_id, limit=args.limit)
+    _print_json([precedent.model_dump(mode="json") for precedent in precedents])
+    return 0
+
+
+def _print_json(data: object) -> None:
+    print(json.dumps(data, ensure_ascii=True, indent=2, sort_keys=True))

--- a/src/openprecedent/config.py
+++ b/src/openprecedent/config.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+DEFAULT_DB_NAME = "openprecedent.db"
+DB_ENV_VAR = "OPENPRECEDENT_DB"
+
+
+def get_db_path() -> Path:
+    configured = os.environ.get(DB_ENV_VAR)
+    if configured:
+        return Path(configured).expanduser().resolve()
+
+    return Path.cwd() / DEFAULT_DB_NAME

--- a/src/openprecedent/services.py
+++ b/src/openprecedent/services.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections import Counter
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import uuid4
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from openprecedent.schemas import Case, CaseStatus, Decision, DecisionType, Event, EventActor, EventType, Precedent
+from openprecedent.storage import SQLiteStore
+
+
+class CreateCaseInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    case_id: str | None = None
+    title: str
+    user_id: str | None = None
+    agent_id: str | None = None
+
+
+class AppendEventInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    event_id: str | None = None
+    event_type: EventType
+    actor: EventActor
+    timestamp: datetime | None = None
+    parent_event_id: str | None = None
+    sequence_no: int | None = None
+    payload: dict[str, object] = Field(default_factory=dict)
+
+
+class ReplayResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    case: Case
+    events: list[Event]
+    decisions: list[Decision]
+    summary: str | None = None
+
+
+class ConflictError(ValueError):
+    pass
+
+
+@dataclass
+class OpenPrecedentService:
+    store: SQLiteStore
+
+    @classmethod
+    def from_path(cls, db_path: Path) -> "OpenPrecedentService":
+        return cls(store=SQLiteStore(db_path))
+
+    def create_case(self, payload: CreateCaseInput) -> Case:
+        case_id = payload.case_id or f"case_{uuid4().hex[:12]}"
+        case = Case(
+            case_id=case_id,
+            title=payload.title,
+            status=CaseStatus.STARTED,
+            user_id=payload.user_id,
+            agent_id=payload.agent_id,
+            started_at=datetime.now(UTC),
+            ended_at=None,
+            final_summary=None,
+        )
+        try:
+            return self.store.create_case(case)
+        except sqlite3.IntegrityError as error:
+            raise ConflictError(f"case already exists: {case_id}") from error
+
+    def list_cases(self) -> list[Case]:
+        return self.store.list_cases()
+
+    def get_case(self, case_id: str) -> Case | None:
+        return self.store.get_case(case_id)
+
+    def append_event(self, case_id: str, payload: AppendEventInput) -> Event:
+        case = self.store.get_case(case_id)
+        if case is None:
+            raise KeyError(case_id)
+
+        event = Event(
+            event_id=payload.event_id or f"evt_{uuid4().hex[:12]}",
+            case_id=case_id,
+            event_type=payload.event_type,
+            actor=payload.actor,
+            timestamp=payload.timestamp or datetime.now(UTC),
+            sequence_no=payload.sequence_no or self.store.next_event_sequence(case_id),
+            parent_event_id=payload.parent_event_id,
+            payload=payload.payload,
+        )
+        try:
+            return self.store.append_event(event)
+        except sqlite3.IntegrityError as error:
+            raise ConflictError(
+                f"event conflict for case {case_id}: event_id or sequence_no already exists"
+            ) from error
+
+    def import_events_jsonl(self, path: Path, default_case_id: str | None = None) -> list[Event]:
+        imported: list[Event] = []
+        with path.open("r", encoding="utf-8") as handle:
+            for line_no, line in enumerate(handle, start=1):
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                item = json.loads(stripped)
+                case_id = item.get("case_id") or default_case_id
+                if not isinstance(case_id, str) or not case_id:
+                    raise ValueError(f"line {line_no}: case_id is required")
+                normalized_item = dict(item)
+                normalized_item.pop("case_id", None)
+                payload = AppendEventInput.model_validate(normalized_item)
+                imported.append(self.append_event(case_id, payload))
+        return imported
+
+    def list_events(self, case_id: str) -> list[Event]:
+        case = self.store.get_case(case_id)
+        if case is None:
+            raise KeyError(case_id)
+        return self.store.list_events(case_id)
+
+    def extract_decisions(self, case_id: str) -> list[Decision]:
+        events = self.list_events(case_id)
+        extracted: list[Decision] = []
+        seen_plan = False
+
+        for event in events:
+            event_payload = event.payload
+            if event.event_type == EventType.USER_CONFIRMED:
+                extracted.append(
+                    self._build_decision(
+                        case_id=case_id,
+                        decision_type=DecisionType.CLARIFY,
+                        title="User confirmation recorded",
+                        question="Did the user confirm a constraint or proposed next step?",
+                        chosen_action="Continue with confirmed instruction",
+                        evidence_event_ids=[event.event_id],
+                        outcome=_string_or_none(event_payload.get("message")),
+                    )
+                )
+            elif event.event_type == EventType.MESSAGE_AGENT and not seen_plan:
+                extracted.append(
+                    self._build_decision(
+                        case_id=case_id,
+                        decision_type=DecisionType.PLAN,
+                        title="Initial execution plan",
+                        question="What path should the agent take first?",
+                        chosen_action=_string_or_default(event_payload.get("message"), "Proceed with the first stated plan"),
+                        evidence_event_ids=[event.event_id],
+                        outcome="Initial plan captured from agent response",
+                    )
+                )
+                seen_plan = True
+            elif event.event_type == EventType.TOOL_CALLED:
+                tool_name = _string_or_default(event_payload.get("tool_name"), "unknown_tool")
+                extracted.append(
+                    self._build_decision(
+                        case_id=case_id,
+                        decision_type=DecisionType.SELECT_TOOL,
+                        title=f"Selected tool: {tool_name}",
+                        question="Which tool should be used next?",
+                        chosen_action=f"Use {tool_name}",
+                        evidence_event_ids=[event.event_id],
+                        outcome=_string_or_none(event_payload.get("reason")),
+                    )
+                )
+            elif event.event_type == EventType.FILE_WRITE:
+                file_path = _string_or_default(event_payload.get("path"), "unknown_path")
+                extracted.append(
+                    self._build_decision(
+                        case_id=case_id,
+                        decision_type=DecisionType.APPLY_CHANGE,
+                        title=f"Applied file change: {file_path}",
+                        question="Should the agent modify repository state?",
+                        chosen_action=f"Write {file_path}",
+                        evidence_event_ids=[event.event_id],
+                        outcome=_string_or_none(event_payload.get("summary")),
+                    )
+                )
+            elif event.event_type == EventType.COMMAND_COMPLETED:
+                exit_code = event_payload.get("exit_code")
+                if isinstance(exit_code, int) and exit_code != 0:
+                    extracted.append(
+                        self._build_decision(
+                            case_id=case_id,
+                            decision_type=DecisionType.RETRY_OR_RECOVER,
+                            title="Recovered from command failure",
+                            question="How should execution proceed after a failing command?",
+                            chosen_action="Inspect failure and choose a narrower recovery path",
+                            evidence_event_ids=[event.event_id],
+                            outcome=_string_or_none(event_payload.get("stderr")) or f"exit_code={exit_code}",
+                        )
+                    )
+            elif event.event_type == EventType.CASE_COMPLETED:
+                extracted.append(
+                    self._build_decision(
+                        case_id=case_id,
+                        decision_type=DecisionType.FINALIZE,
+                        title="Case finalized successfully",
+                        question="Is the case ready to conclude?",
+                        chosen_action="Return the final result",
+                        evidence_event_ids=[event.event_id],
+                        outcome=_string_or_none(event_payload.get("summary")) or "Case completed",
+                    )
+                )
+            elif event.event_type == EventType.CASE_FAILED:
+                extracted.append(
+                    self._build_decision(
+                        case_id=case_id,
+                        decision_type=DecisionType.FINALIZE,
+                        title="Case finalized with failure",
+                        question="Should the case terminate with a failure outcome?",
+                        chosen_action="Stop execution and surface failure",
+                        evidence_event_ids=[event.event_id],
+                        outcome=_string_or_none(event_payload.get("summary")) or "Case failed",
+                    )
+                )
+
+        numbered: list[Decision] = []
+        for index, decision in enumerate(extracted, start=1):
+            numbered.append(decision.model_copy(update={"sequence_no": index}))
+
+        self.store.replace_decisions(case_id, numbered)
+        return numbered
+
+    def list_decisions(self, case_id: str) -> list[Decision]:
+        case = self.store.get_case(case_id)
+        if case is None:
+            raise KeyError(case_id)
+        return self.store.list_decisions(case_id)
+
+    def replay_case(self, case_id: str) -> ReplayResponse:
+        case = self.store.get_case(case_id)
+        if case is None:
+            raise KeyError(case_id)
+        events = self.store.list_events(case_id)
+        decisions = self.store.list_decisions(case_id)
+        summary = case.final_summary or self._build_case_summary(case, events, decisions)
+        return ReplayResponse(case=case, events=events, decisions=decisions, summary=summary)
+
+    def find_precedents(self, case_id: str, limit: int = 3) -> list[Precedent]:
+        current_case = self.store.get_case(case_id)
+        if current_case is None:
+            raise KeyError(case_id)
+
+        current_events = self.store.list_events(case_id)
+        current_decisions = self.store.list_decisions(case_id)
+        current_fingerprint = self._fingerprint(current_case, current_events, current_decisions)
+
+        candidates: list[tuple[int, Precedent]] = []
+        for other_case in self.store.list_cases():
+            if other_case.case_id == case_id:
+                continue
+            other_events = self.store.list_events(other_case.case_id)
+            other_decisions = self.store.list_decisions(other_case.case_id)
+            other_fingerprint = self._fingerprint(other_case, other_events, other_decisions)
+            score, reason, differences = self._compare_fingerprints(
+                current_fingerprint,
+                other_fingerprint,
+            )
+            if score <= 0:
+                continue
+            candidates.append(
+                (
+                    score,
+                    Precedent(
+                        case_id=other_case.case_id,
+                        title=other_case.title,
+                        similarity_reason=reason,
+                        differences=differences,
+                        historical_outcome=other_case.final_summary,
+                    ),
+                )
+            )
+
+        candidates.sort(key=lambda item: (-item[0], item[1].case_id))
+        return [precedent for _, precedent in candidates[:limit]]
+
+    def _build_decision(
+        self,
+        *,
+        case_id: str,
+        decision_type: DecisionType,
+        title: str,
+        question: str,
+        chosen_action: str,
+        evidence_event_ids: list[str],
+        outcome: str | None,
+    ) -> Decision:
+        return Decision(
+            decision_id=f"dec_{uuid4().hex[:12]}",
+            case_id=case_id,
+            decision_type=decision_type,
+            title=title,
+            question=question,
+            chosen_action=chosen_action,
+            alternatives=[],
+            evidence_event_ids=evidence_event_ids,
+            constraint_summary=None,
+            requires_human_confirmation=False,
+            outcome=outcome,
+            sequence_no=0,
+        )
+
+    def _build_case_summary(self, case: Case, events: list[Event], decisions: list[Decision]) -> str:
+        event_count = len(events)
+        decision_count = len(decisions)
+        return (
+            f"{case.title}: {event_count} events, {decision_count} decisions, "
+            f"status={case.status.value}"
+        )
+
+    def _fingerprint(self, case: Case, events: list[Event], decisions: list[Decision]) -> dict[str, object]:
+        event_types = Counter(event.event_type.value for event in events)
+        decision_types = Counter(decision.decision_type.value for decision in decisions)
+        return {
+            "status": case.status.value,
+            "has_file_write": event_types[EventType.FILE_WRITE.value] > 0,
+            "has_recovery": decision_types[DecisionType.RETRY_OR_RECOVER.value] > 0,
+            "tool_count": event_types[EventType.TOOL_CALLED.value],
+            "decision_types": dict(decision_types),
+        }
+
+    def _compare_fingerprints(
+        self,
+        current: dict[str, object],
+        other: dict[str, object],
+    ) -> tuple[int, str, list[str]]:
+        score = 0
+        reasons: list[str] = []
+        differences: list[str] = []
+
+        for key in ("has_file_write", "has_recovery", "status"):
+            if current[key] == other[key]:
+                score += 2
+                reasons.append(f"same {key}")
+            else:
+                differences.append(f"different {key}")
+
+        current_decisions = current["decision_types"]
+        other_decisions = other["decision_types"]
+        if current_decisions == other_decisions:
+            score += 3
+            reasons.append("same decision shape")
+        else:
+            differences.append("different decision shape")
+
+        tool_delta = abs(int(current["tool_count"]) - int(other["tool_count"]))
+        if tool_delta == 0:
+            score += 2
+            reasons.append("same tool call count")
+        elif tool_delta == 1:
+            score += 1
+            reasons.append("nearby tool call count")
+        else:
+            differences.append("different tool call count")
+
+        return score, ", ".join(reasons) or "similar case structure", differences
+
+
+def _string_or_none(value: object) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value
+    return None
+
+
+def _string_or_default(value: object, default: str) -> str:
+    parsed = _string_or_none(value)
+    return parsed or default

--- a/src/openprecedent/storage.py
+++ b/src/openprecedent/storage.py
@@ -1,0 +1,350 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Iterable
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from pathlib import Path
+
+from openprecedent.schemas import (
+    Artifact,
+    ArtifactType,
+    Case,
+    CaseStatus,
+    Decision,
+    DecisionType,
+    Event,
+    EventActor,
+    EventType,
+)
+
+
+def utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _serialize_json(value: object) -> str:
+    return json.dumps(value, ensure_ascii=True, sort_keys=True)
+
+
+def _parse_datetime(value: str | None) -> datetime | None:
+    if value is None:
+        return None
+    return datetime.fromisoformat(value)
+
+
+class SQLiteStore:
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = db_path
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._initialize()
+
+    @contextmanager
+    def connect(self) -> Iterable[sqlite3.Connection]:
+        connection = sqlite3.connect(self.db_path)
+        connection.row_factory = sqlite3.Row
+        try:
+            yield connection
+            connection.commit()
+        finally:
+            connection.close()
+
+    def _initialize(self) -> None:
+        with self.connect() as connection:
+            connection.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS cases (
+                    case_id TEXT PRIMARY KEY,
+                    title TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    user_id TEXT,
+                    agent_id TEXT,
+                    started_at TEXT NOT NULL,
+                    ended_at TEXT,
+                    final_summary TEXT
+                );
+
+                CREATE TABLE IF NOT EXISTS events (
+                    event_id TEXT PRIMARY KEY,
+                    case_id TEXT NOT NULL,
+                    event_type TEXT NOT NULL,
+                    actor TEXT NOT NULL,
+                    timestamp TEXT NOT NULL,
+                    sequence_no INTEGER NOT NULL,
+                    parent_event_id TEXT,
+                    payload_json TEXT NOT NULL,
+                    FOREIGN KEY(case_id) REFERENCES cases(case_id)
+                );
+
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_events_case_sequence
+                ON events(case_id, sequence_no);
+
+                CREATE TABLE IF NOT EXISTS decisions (
+                    decision_id TEXT PRIMARY KEY,
+                    case_id TEXT NOT NULL,
+                    decision_type TEXT NOT NULL,
+                    title TEXT NOT NULL,
+                    question TEXT NOT NULL,
+                    chosen_action TEXT NOT NULL,
+                    alternatives_json TEXT NOT NULL,
+                    evidence_event_ids_json TEXT NOT NULL,
+                    constraint_summary TEXT,
+                    requires_human_confirmation INTEGER NOT NULL,
+                    outcome TEXT,
+                    sequence_no INTEGER NOT NULL,
+                    FOREIGN KEY(case_id) REFERENCES cases(case_id)
+                );
+
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_decisions_case_sequence
+                ON decisions(case_id, sequence_no);
+
+                CREATE TABLE IF NOT EXISTS artifacts (
+                    artifact_id TEXT PRIMARY KEY,
+                    case_id TEXT NOT NULL,
+                    artifact_type TEXT NOT NULL,
+                    uri_or_path TEXT NOT NULL,
+                    summary TEXT,
+                    FOREIGN KEY(case_id) REFERENCES cases(case_id)
+                );
+                """
+            )
+
+    def create_case(self, case: Case) -> Case:
+        with self.connect() as connection:
+            connection.execute(
+                """
+                INSERT INTO cases (
+                    case_id, title, status, user_id, agent_id, started_at, ended_at, final_summary
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    case.case_id,
+                    case.title,
+                    case.status.value,
+                    case.user_id,
+                    case.agent_id,
+                    case.started_at.isoformat(),
+                    case.ended_at.isoformat() if case.ended_at else None,
+                    case.final_summary,
+                ),
+            )
+        return case
+
+    def list_cases(self) -> list[Case]:
+        with self.connect() as connection:
+            rows = connection.execute(
+                "SELECT * FROM cases ORDER BY started_at DESC, case_id DESC"
+            ).fetchall()
+        return [self._row_to_case(row) for row in rows]
+
+    def get_case(self, case_id: str) -> Case | None:
+        with self.connect() as connection:
+            row = connection.execute(
+                "SELECT * FROM cases WHERE case_id = ?",
+                (case_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return self._row_to_case(row)
+
+    def append_event(self, event: Event) -> Event:
+        with self.connect() as connection:
+            connection.execute(
+                """
+                INSERT INTO events (
+                    event_id, case_id, event_type, actor, timestamp, sequence_no,
+                    parent_event_id, payload_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    event.event_id,
+                    event.case_id,
+                    event.event_type.value,
+                    event.actor.value,
+                    event.timestamp.isoformat(),
+                    event.sequence_no,
+                    event.parent_event_id,
+                    _serialize_json(event.payload),
+                ),
+            )
+
+            if event.event_type == EventType.CASE_COMPLETED:
+                connection.execute(
+                    """
+                    UPDATE cases
+                    SET status = ?, ended_at = ?, final_summary = COALESCE(?, final_summary)
+                    WHERE case_id = ?
+                    """,
+                    (
+                        CaseStatus.COMPLETED.value,
+                        event.timestamp.isoformat(),
+                        _payload_summary(event.payload),
+                        event.case_id,
+                    ),
+                )
+            elif event.event_type == EventType.CASE_FAILED:
+                connection.execute(
+                    """
+                    UPDATE cases
+                    SET status = ?, ended_at = ?, final_summary = COALESCE(?, final_summary)
+                    WHERE case_id = ?
+                    """,
+                    (
+                        CaseStatus.FAILED.value,
+                        event.timestamp.isoformat(),
+                        _payload_summary(event.payload),
+                        event.case_id,
+                    ),
+                )
+        return event
+
+    def list_events(self, case_id: str) -> list[Event]:
+        with self.connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT * FROM events
+                WHERE case_id = ?
+                ORDER BY sequence_no ASC, timestamp ASC, event_id ASC
+                """,
+                (case_id,),
+            ).fetchall()
+        return [self._row_to_event(row) for row in rows]
+
+    def next_event_sequence(self, case_id: str) -> int:
+        with self.connect() as connection:
+            row = connection.execute(
+                "SELECT COALESCE(MAX(sequence_no), 0) AS max_sequence FROM events WHERE case_id = ?",
+                (case_id,),
+            ).fetchone()
+        return int(row["max_sequence"]) + 1
+
+    def replace_decisions(self, case_id: str, decisions: list[Decision]) -> None:
+        with self.connect() as connection:
+            connection.execute("DELETE FROM decisions WHERE case_id = ?", (case_id,))
+            for decision in decisions:
+                connection.execute(
+                    """
+                    INSERT INTO decisions (
+                        decision_id, case_id, decision_type, title, question, chosen_action,
+                        alternatives_json, evidence_event_ids_json, constraint_summary,
+                        requires_human_confirmation, outcome, sequence_no
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        decision.decision_id,
+                        decision.case_id,
+                        decision.decision_type.value,
+                        decision.title,
+                        decision.question,
+                        decision.chosen_action,
+                        _serialize_json(decision.alternatives),
+                        _serialize_json(decision.evidence_event_ids),
+                        decision.constraint_summary,
+                        int(decision.requires_human_confirmation),
+                        decision.outcome,
+                        decision.sequence_no,
+                    ),
+                )
+
+    def list_decisions(self, case_id: str) -> list[Decision]:
+        with self.connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT * FROM decisions
+                WHERE case_id = ?
+                ORDER BY sequence_no ASC, decision_id ASC
+                """,
+                (case_id,),
+            ).fetchall()
+        return [self._row_to_decision(row) for row in rows]
+
+    def list_artifacts(self, case_id: str) -> list[Artifact]:
+        with self.connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT * FROM artifacts
+                WHERE case_id = ?
+                ORDER BY artifact_id ASC
+                """,
+                (case_id,),
+            ).fetchall()
+        return [self._row_to_artifact(row) for row in rows]
+
+    def upsert_artifact(self, artifact: Artifact) -> Artifact:
+        with self.connect() as connection:
+            connection.execute(
+                """
+                INSERT INTO artifacts (artifact_id, case_id, artifact_type, uri_or_path, summary)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(artifact_id) DO UPDATE SET
+                    case_id = excluded.case_id,
+                    artifact_type = excluded.artifact_type,
+                    uri_or_path = excluded.uri_or_path,
+                    summary = excluded.summary
+                """,
+                (
+                    artifact.artifact_id,
+                    artifact.case_id,
+                    artifact.artifact_type.value,
+                    artifact.uri_or_path,
+                    artifact.summary,
+                ),
+            )
+        return artifact
+
+    def _row_to_case(self, row: sqlite3.Row) -> Case:
+        return Case(
+            case_id=row["case_id"],
+            title=row["title"],
+            status=CaseStatus(row["status"]),
+            user_id=row["user_id"],
+            agent_id=row["agent_id"],
+            started_at=_parse_datetime(row["started_at"]),
+            ended_at=_parse_datetime(row["ended_at"]),
+            final_summary=row["final_summary"],
+        )
+
+    def _row_to_event(self, row: sqlite3.Row) -> Event:
+        return Event(
+            event_id=row["event_id"],
+            case_id=row["case_id"],
+            event_type=EventType(row["event_type"]),
+            actor=EventActor(row["actor"]),
+            timestamp=_parse_datetime(row["timestamp"]),
+            sequence_no=row["sequence_no"],
+            parent_event_id=row["parent_event_id"],
+            payload=json.loads(row["payload_json"]),
+        )
+
+    def _row_to_decision(self, row: sqlite3.Row) -> Decision:
+        return Decision(
+            decision_id=row["decision_id"],
+            case_id=row["case_id"],
+            decision_type=DecisionType(row["decision_type"]),
+            title=row["title"],
+            question=row["question"],
+            chosen_action=row["chosen_action"],
+            alternatives=json.loads(row["alternatives_json"]),
+            evidence_event_ids=json.loads(row["evidence_event_ids_json"]),
+            constraint_summary=row["constraint_summary"],
+            requires_human_confirmation=bool(row["requires_human_confirmation"]),
+            outcome=row["outcome"],
+            sequence_no=row["sequence_no"],
+        )
+
+    def _row_to_artifact(self, row: sqlite3.Row) -> Artifact:
+        return Artifact(
+            artifact_id=row["artifact_id"],
+            case_id=row["case_id"],
+            artifact_type=ArtifactType(row["artifact_type"]),
+            uri_or_path=row["uri_or_path"],
+            summary=row["summary"],
+        )
+
+
+def _payload_summary(payload: dict[str, object]) -> str | None:
+    summary = payload.get("summary")
+    if isinstance(summary, str) and summary.strip():
+        return summary
+    return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def db_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    path = tmp_path / "openprecedent.db"
+    monkeypatch.setenv("OPENPRECEDENT_DB", str(path))
+    return path

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,25 +1,101 @@
-from fastapi.testclient import TestClient
+import httpx
+import pytest
 
 from openprecedent.api import app
 
 
-client = TestClient(app)
+async def _client() -> httpx.AsyncClient:
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
 
 
-def test_healthcheck() -> None:
-    response = client.get("/healthz")
+@pytest.mark.anyio
+async def test_healthcheck() -> None:
+    async with await _client() as client:
+        response = await client.get("/healthz")
 
-    assert response.status_code == 200
-    assert response.json() == {"status": "ok"}
+        assert response.status_code == 200
+        assert response.json() == {"status": "ok"}
 
 
-def test_schema_catalog_contains_core_objects() -> None:
-    response = client.get("/schemas")
+@pytest.mark.anyio
+async def test_schema_catalog_contains_core_objects() -> None:
+    async with await _client() as client:
+        response = await client.get("/schemas")
 
-    assert response.status_code == 200
-    body = response.json()
-    assert "case" in body
-    assert "event" in body
-    assert "decision" in body
-    assert "artifact" in body
-    assert "precedent" in body
+        assert response.status_code == 200
+        body = response.json()
+        assert "case" in body
+        assert "event" in body
+        assert "decision" in body
+        assert "artifact" in body
+        assert "precedent" in body
+
+
+@pytest.mark.anyio
+async def test_case_ingestion_replay_and_precedent_flow(db_path) -> None:
+    async with await _client() as client:
+        first_case = await client.post(
+            "/cases",
+            json={"case_id": "case_alpha", "title": "Alpha task", "user_id": "u1", "agent_id": "openclaw"},
+        )
+        assert first_case.status_code == 201
+
+        second_case = await client.post(
+            "/cases",
+            json={"case_id": "case_beta", "title": "Beta task", "user_id": "u1", "agent_id": "openclaw"},
+        )
+        assert second_case.status_code == 201
+
+        alpha_events = [
+            {"event_type": "message.user", "actor": "user", "payload": {"message": "Summarize docs"}},
+            {"event_type": "message.agent", "actor": "agent", "payload": {"message": "I will inspect docs and summarize."}},
+            {"event_type": "tool.called", "actor": "agent", "payload": {"tool_name": "rg", "reason": "search files"}},
+            {"event_type": "file.write", "actor": "agent", "payload": {"path": "docs/out.md", "summary": "wrote summary"}},
+            {"event_type": "case.completed", "actor": "system", "payload": {"summary": "summary delivered"}},
+        ]
+        for event in alpha_events:
+            response = await client.post("/cases/case_alpha/events", json=event)
+            assert response.status_code == 201
+
+        beta_events = [
+            {"event_type": "message.user", "actor": "user", "payload": {"message": "Summarize docs again"}},
+            {"event_type": "message.agent", "actor": "agent", "payload": {"message": "I will inspect docs and summarize."}},
+            {"event_type": "tool.called", "actor": "agent", "payload": {"tool_name": "rg", "reason": "search files"}},
+            {"event_type": "file.write", "actor": "agent", "payload": {"path": "docs/out-2.md", "summary": "wrote summary"}},
+            {"event_type": "case.completed", "actor": "system", "payload": {"summary": "second summary delivered"}},
+        ]
+        for event in beta_events:
+            response = await client.post("/cases/case_beta/events", json=event)
+            assert response.status_code == 201
+
+        extracted = await client.post("/cases/case_alpha/extract-decisions")
+        assert extracted.status_code == 200
+        assert len(extracted.json()["decisions"]) >= 3
+
+        extracted_beta = await client.post("/cases/case_beta/extract-decisions")
+        assert extracted_beta.status_code == 200
+
+        replay = await client.get("/cases/case_alpha/replay")
+        assert replay.status_code == 200
+        body = replay.json()
+        assert body["case"]["case_id"] == "case_alpha"
+        assert len(body["events"]) == 5
+        assert len(body["decisions"]) >= 3
+        assert body["summary"] == "summary delivered"
+
+        precedents = await client.get("/cases/case_alpha/precedents")
+        assert precedents.status_code == 200
+        precedent_body = precedents.json()
+        assert len(precedent_body) == 1
+        assert precedent_body[0]["case_id"] == "case_beta"
+
+
+@pytest.mark.anyio
+async def test_duplicate_case_returns_conflict(db_path) -> None:
+    async with await _client() as client:
+        response = await client.post("/cases", json={"case_id": "case_dup", "title": "Duplicate"})
+        assert response.status_code == 201
+
+        duplicate = await client.post("/cases", json={"case_id": "case_dup", "title": "Duplicate"})
+        assert duplicate.status_code == 409

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from openprecedent.cli import main
+
+
+def test_cli_end_to_end(capsys, db_path) -> None:
+    result = main(["case", "create", "--case-id", "case_cli", "--title", "CLI task"])
+    assert result == 0
+    created = json.loads(capsys.readouterr().out)
+    assert created["case_id"] == "case_cli"
+
+    result = main(
+        [
+            "event",
+            "append",
+            "case_cli",
+            "message.agent",
+            "agent",
+            "--payload",
+            '{"message":"I will inspect files first."}',
+        ]
+    )
+    assert result == 0
+    capsys.readouterr()
+
+    result = main(
+        [
+            "event",
+            "append",
+            "case_cli",
+            "tool.called",
+            "agent",
+            "--payload",
+            '{"tool_name":"rg","reason":"search"}',
+        ]
+    )
+    assert result == 0
+    capsys.readouterr()
+
+    result = main(
+        [
+            "event",
+            "append",
+            "case_cli",
+            "case.completed",
+            "system",
+            "--payload",
+            '{"summary":"done"}',
+        ]
+    )
+    assert result == 0
+    capsys.readouterr()
+
+    result = main(["extract", "decisions", "case_cli"])
+    assert result == 0
+    decisions = json.loads(capsys.readouterr().out)
+    assert len(decisions) >= 2
+
+    result = main(["replay", "case", "case_cli", "--json"])
+    assert result == 0
+    replay = json.loads(capsys.readouterr().out)
+    assert replay["case"]["case_id"] == "case_cli"
+    assert replay["summary"] == "done"
+
+
+def test_cli_import_jsonl(capsys, db_path, tmp_path: Path) -> None:
+    result = main(["case", "create", "--case-id", "case_import", "--title", "Import task"])
+    assert result == 0
+    capsys.readouterr()
+
+    payload_path = tmp_path / "events.jsonl"
+    payload_path.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "case_id": "case_import",
+                        "event_type": "message.user",
+                        "actor": "user",
+                        "payload": {"message": "hello"},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "case_id": "case_import",
+                        "event_type": "case.completed",
+                        "actor": "system",
+                        "payload": {"summary": "imported"},
+                    }
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = main(["event", "import-jsonl", str(payload_path)])
+    assert result == 0
+    imported = json.loads(capsys.readouterr().out)
+    assert len(imported) == 2


### PR DESCRIPTION
## Summary
- add SQLite-backed case, event, decision, and artifact persistence
- add API and CLI flows for case ingestion, replay, extraction, and precedent lookup
- add tests for API and CLI end-to-end MVP behavior and verify them locally

## Validation
- .venv/bin/python -m pytest -q

## Notes
- API routes are async to avoid the threadpool hang seen in this environment with sync FastAPI handlers
- decision extraction and precedent matching remain intentionally heuristic v1 logic