### PR TITLE
Add decision explanations and richer precedent output

### DIFF
--- a/src/openprecedent/schemas/__init__.py
+++ b/src/openprecedent/schemas/__init__.py
@@ -1,6 +1,6 @@
 from .artifact import Artifact, ArtifactType
 from .case import Case, CaseStatus
-from .decision import Decision, DecisionType
+from .decision import Decision, DecisionExplanation, DecisionType
 from .event import Event, EventActor, EventType
 from .precedent import Precedent
 
@@ -10,6 +10,7 @@ __all__ = [
     "Case",
     "CaseStatus",
     "Decision",
+    "DecisionExplanation",
     "DecisionType",
     "Event",
     "EventActor",

--- a/src/openprecedent/schemas/decision.py
+++ b/src/openprecedent/schemas/decision.py
@@ -12,6 +12,16 @@ class DecisionType(StrEnum):
     FINALIZE = "finalize"
 
 
+class DecisionExplanation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    goal: str
+    evidence: list[str] = Field(default_factory=list)
+    constraints: list[str] = Field(default_factory=list)
+    selection_reason: str
+    result: str | None = None
+
+
 class Decision(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -26,4 +36,6 @@ class Decision(BaseModel):
     constraint_summary: str | None = None
     requires_human_confirmation: bool = False
     outcome: str | None = None
+    confidence: float = 0.5
+    explanation: DecisionExplanation
     sequence_no: int

--- a/src/openprecedent/schemas/precedent.py
+++ b/src/openprecedent/schemas/precedent.py
@@ -6,6 +6,9 @@ class Precedent(BaseModel):
 
     case_id: str
     title: str
-    similarity_reason: str
+    summary: str
+    similarity_score: int
+    similarities: list[str]
     differences: list[str]
+    reusable_takeaway: str | None = None
     historical_outcome: str | None = None

--- a/src/openprecedent/services.py
+++ b/src/openprecedent/services.py
@@ -10,7 +10,17 @@ from uuid import uuid4
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from openprecedent.schemas import Case, CaseStatus, Decision, DecisionType, Event, EventActor, EventType, Precedent
+from openprecedent.schemas import (
+    Case,
+    CaseStatus,
+    Decision,
+    DecisionExplanation,
+    DecisionType,
+    Event,
+    EventActor,
+    EventType,
+    Precedent,
+)
 from openprecedent.storage import SQLiteStore
 
 
@@ -140,7 +150,10 @@ class OpenPrecedentService:
                         question="Did the user confirm a constraint or proposed next step?",
                         chosen_action="Continue with confirmed instruction",
                         evidence_event_ids=[event.event_id],
+                        constraints=["User confirmation received"],
+                        selection_reason="The user explicitly confirmed the next step or constraint.",
                         outcome=_string_or_none(event_payload.get("message")),
+                        confidence=0.9,
                     )
                 )
             elif event.event_type == EventType.MESSAGE_AGENT and not seen_plan:
@@ -152,7 +165,10 @@ class OpenPrecedentService:
                         question="What path should the agent take first?",
                         chosen_action=_string_or_default(event_payload.get("message"), "Proceed with the first stated plan"),
                         evidence_event_ids=[event.event_id],
+                        constraints=["Use the first explicit agent plan as the baseline path"],
+                        selection_reason="The first substantive agent response usually establishes the initial execution path.",
                         outcome="Initial plan captured from agent response",
+                        confidence=0.7,
                     )
                 )
                 seen_plan = True
@@ -166,7 +182,10 @@ class OpenPrecedentService:
                         question="Which tool should be used next?",
                         chosen_action=f"Use {tool_name}",
                         evidence_event_ids=[event.event_id],
+                        constraints=["Prefer the tool explicitly chosen by the runtime"],
+                        selection_reason=f"The runtime selected {tool_name} for the next operation.",
                         outcome=_string_or_none(event_payload.get("reason")),
+                        confidence=0.8,
                     )
                 )
             elif event.event_type == EventType.FILE_WRITE:
@@ -179,7 +198,10 @@ class OpenPrecedentService:
                         question="Should the agent modify repository state?",
                         chosen_action=f"Write {file_path}",
                         evidence_event_ids=[event.event_id],
+                        constraints=["File write indicates a committed repository change"],
+                        selection_reason=f"The runtime wrote {file_path}, which marks an applied change decision.",
                         outcome=_string_or_none(event_payload.get("summary")),
+                        confidence=0.85,
                     )
                 )
             elif event.event_type == EventType.COMMAND_COMPLETED:
@@ -193,7 +215,10 @@ class OpenPrecedentService:
                             question="How should execution proceed after a failing command?",
                             chosen_action="Inspect failure and choose a narrower recovery path",
                             evidence_event_ids=[event.event_id],
+                            constraints=["Non-zero command exit indicates recovery is required"],
+                            selection_reason="The command failed, so the next meaningful step is a recovery choice rather than normal continuation.",
                             outcome=_string_or_none(event_payload.get("stderr")) or f"exit_code={exit_code}",
+                            confidence=0.9,
                         )
                     )
             elif event.event_type == EventType.CASE_COMPLETED:
@@ -205,7 +230,10 @@ class OpenPrecedentService:
                         question="Is the case ready to conclude?",
                         chosen_action="Return the final result",
                         evidence_event_ids=[event.event_id],
+                        constraints=["Case completion event closes execution"],
+                        selection_reason="The runtime emitted a completion event, so the case should be finalized successfully.",
                         outcome=_string_or_none(event_payload.get("summary")) or "Case completed",
+                        confidence=0.95,
                     )
                 )
             elif event.event_type == EventType.CASE_FAILED:
@@ -217,7 +245,10 @@ class OpenPrecedentService:
                         question="Should the case terminate with a failure outcome?",
                         chosen_action="Stop execution and surface failure",
                         evidence_event_ids=[event.event_id],
+                        constraints=["Case failure event closes execution with an error state"],
+                        selection_reason="The runtime emitted a failure event, so execution should stop and surface the failure.",
                         outcome=_string_or_none(event_payload.get("summary")) or "Case failed",
+                        confidence=0.95,
                     )
                 )
 
@@ -259,7 +290,7 @@ class OpenPrecedentService:
             other_events = self.store.list_events(other_case.case_id)
             other_decisions = self.store.list_decisions(other_case.case_id)
             other_fingerprint = self._fingerprint(other_case, other_events, other_decisions)
-            score, reason, differences = self._compare_fingerprints(
+            score, similarities, differences = self._compare_fingerprints(
                 current_fingerprint,
                 other_fingerprint,
             )
@@ -271,8 +302,11 @@ class OpenPrecedentService:
                     Precedent(
                         case_id=other_case.case_id,
                         title=other_case.title,
-                        similarity_reason=reason,
+                        summary=self._build_case_summary(other_case, other_events, other_decisions),
+                        similarity_score=score,
+                        similarities=similarities,
                         differences=differences,
+                        reusable_takeaway=self._build_reusable_takeaway(other_case, other_decisions),
                         historical_outcome=other_case.final_summary,
                     ),
                 )
@@ -290,8 +324,18 @@ class OpenPrecedentService:
         question: str,
         chosen_action: str,
         evidence_event_ids: list[str],
+        constraints: list[str],
+        selection_reason: str,
         outcome: str | None,
+        confidence: float,
     ) -> Decision:
+        explanation = DecisionExplanation(
+            goal=question,
+            evidence=[f"event:{event_id}" for event_id in evidence_event_ids],
+            constraints=constraints,
+            selection_reason=selection_reason,
+            result=outcome,
+        )
         return Decision(
             decision_id=f"dec_{uuid4().hex[:12]}",
             case_id=case_id,
@@ -301,9 +345,11 @@ class OpenPrecedentService:
             chosen_action=chosen_action,
             alternatives=[],
             evidence_event_ids=evidence_event_ids,
-            constraint_summary=None,
+            constraint_summary="; ".join(constraints) if constraints else None,
             requires_human_confirmation=False,
             outcome=outcome,
+            confidence=confidence,
+            explanation=explanation,
             sequence_no=0,
         )
 
@@ -330,15 +376,15 @@ class OpenPrecedentService:
         self,
         current: dict[str, object],
         other: dict[str, object],
-    ) -> tuple[int, str, list[str]]:
+    ) -> tuple[int, list[str], list[str]]:
         score = 0
-        reasons: list[str] = []
+        similarities: list[str] = []
         differences: list[str] = []
 
         for key in ("has_file_write", "has_recovery", "status"):
             if current[key] == other[key]:
                 score += 2
-                reasons.append(f"same {key}")
+                similarities.append(f"same {key}")
             else:
                 differences.append(f"different {key}")
 
@@ -346,21 +392,28 @@ class OpenPrecedentService:
         other_decisions = other["decision_types"]
         if current_decisions == other_decisions:
             score += 3
-            reasons.append("same decision shape")
+            similarities.append("same decision shape")
         else:
             differences.append("different decision shape")
 
         tool_delta = abs(int(current["tool_count"]) - int(other["tool_count"]))
         if tool_delta == 0:
             score += 2
-            reasons.append("same tool call count")
+            similarities.append("same tool call count")
         elif tool_delta == 1:
             score += 1
-            reasons.append("nearby tool call count")
+            similarities.append("nearby tool call count")
         else:
             differences.append("different tool call count")
 
-        return score, ", ".join(reasons) or "similar case structure", differences
+        return score, similarities or ["similar case structure"], differences
+
+    def _build_reusable_takeaway(self, case: Case, decisions: list[Decision]) -> str | None:
+        if decisions:
+            return decisions[-1].chosen_action
+        if case.final_summary:
+            return case.final_summary
+        return None
 
 
 def _string_or_none(value: object) -> str | None:

--- a/src/openprecedent/storage.py
+++ b/src/openprecedent/storage.py
@@ -13,6 +13,7 @@ from openprecedent.schemas import (
     Case,
     CaseStatus,
     Decision,
+    DecisionExplanation,
     DecisionType,
     Event,
     EventActor,
@@ -92,6 +93,8 @@ class SQLiteStore:
                     constraint_summary TEXT,
                     requires_human_confirmation INTEGER NOT NULL,
                     outcome TEXT,
+                    confidence REAL NOT NULL,
+                    explanation_json TEXT NOT NULL,
                     sequence_no INTEGER NOT NULL,
                     FOREIGN KEY(case_id) REFERENCES cases(case_id)
                 );
@@ -109,6 +112,8 @@ class SQLiteStore:
                 );
                 """
             )
+            self._ensure_column(connection, "decisions", "confidence", "REAL NOT NULL DEFAULT 0.5")
+            self._ensure_column(connection, "decisions", "explanation_json", "TEXT NOT NULL DEFAULT '{}'")
 
     def create_case(self, case: Case) -> Case:
         with self.connect() as connection:
@@ -228,8 +233,8 @@ class SQLiteStore:
                     INSERT INTO decisions (
                         decision_id, case_id, decision_type, title, question, chosen_action,
                         alternatives_json, evidence_event_ids_json, constraint_summary,
-                        requires_human_confirmation, outcome, sequence_no
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        requires_human_confirmation, outcome, confidence, explanation_json, sequence_no
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         decision.decision_id,
@@ -243,6 +248,8 @@ class SQLiteStore:
                         decision.constraint_summary,
                         int(decision.requires_human_confirmation),
                         decision.outcome,
+                        decision.confidence,
+                        _serialize_json(decision.explanation.model_dump(mode="json")),
                         decision.sequence_no,
                     ),
                 )
@@ -330,6 +337,8 @@ class SQLiteStore:
             constraint_summary=row["constraint_summary"],
             requires_human_confirmation=bool(row["requires_human_confirmation"]),
             outcome=row["outcome"],
+            confidence=row["confidence"],
+            explanation=DecisionExplanation.model_validate(json.loads(row["explanation_json"])),
             sequence_no=row["sequence_no"],
         )
 
@@ -341,6 +350,13 @@ class SQLiteStore:
             uri_or_path=row["uri_or_path"],
             summary=row["summary"],
         )
+
+    def _ensure_column(self, connection: sqlite3.Connection, table: str, column: str, ddl: str) -> None:
+        rows = connection.execute(f"PRAGMA table_info({table})").fetchall()
+        existing = {row["name"] for row in rows}
+        if column in existing:
+            return
+        connection.execute(f"ALTER TABLE {table} ADD COLUMN {column} {ddl}")
 
 
 def _payload_summary(payload: dict[str, object]) -> str | None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -72,6 +72,11 @@ async def test_case_ingestion_replay_and_precedent_flow(db_path) -> None:
         extracted = await client.post("/cases/case_alpha/extract-decisions")
         assert extracted.status_code == 200
         assert len(extracted.json()["decisions"]) >= 3
+        first_decision = extracted.json()["decisions"][0]
+        assert "explanation" in first_decision
+        assert "goal" in first_decision["explanation"]
+        assert "selection_reason" in first_decision["explanation"]
+        assert isinstance(first_decision["confidence"], float)
 
         extracted_beta = await client.post("/cases/case_beta/extract-decisions")
         assert extracted_beta.status_code == 200
@@ -89,6 +94,9 @@ async def test_case_ingestion_replay_and_precedent_flow(db_path) -> None:
         precedent_body = precedents.json()
         assert len(precedent_body) == 1
         assert precedent_body[0]["case_id"] == "case_beta"
+        assert precedent_body[0]["similarity_score"] > 0
+        assert precedent_body[0]["similarities"]
+        assert "summary" in precedent_body[0]
 
 
 @pytest.mark.anyio

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,12 +58,67 @@ def test_cli_end_to_end(capsys, db_path) -> None:
     assert result == 0
     decisions = json.loads(capsys.readouterr().out)
     assert len(decisions) >= 2
+    assert "explanation" in decisions[0]
+    assert "selection_reason" in decisions[0]["explanation"]
 
     result = main(["replay", "case", "case_cli", "--json"])
     assert result == 0
     replay = json.loads(capsys.readouterr().out)
     assert replay["case"]["case_id"] == "case_cli"
     assert replay["summary"] == "done"
+
+
+def test_cli_precedent_output(capsys, db_path) -> None:
+    for case_id, title, summary in (
+        ("case_prev_a", "Previous A", "done a"),
+        ("case_prev_b", "Previous B", "done b"),
+    ):
+        result = main(["case", "create", "--case-id", case_id, "--title", title])
+        assert result == 0
+        capsys.readouterr()
+        for command in (
+            [
+                "event",
+                "append",
+                case_id,
+                "message.agent",
+                "agent",
+                "--payload",
+                '{"message":"I will inspect files first."}',
+            ],
+            [
+                "event",
+                "append",
+                case_id,
+                "tool.called",
+                "agent",
+                "--payload",
+                '{"tool_name":"rg","reason":"search"}',
+            ],
+            [
+                "event",
+                "append",
+                case_id,
+                "case.completed",
+                "system",
+                "--payload",
+                f'{{"summary":"{summary}"}}',
+            ],
+        ):
+            result = main(command)
+            assert result == 0
+            capsys.readouterr()
+        result = main(["extract", "decisions", case_id])
+        assert result == 0
+        capsys.readouterr()
+
+    result = main(["precedent", "find", "case_prev_a"])
+    assert result == 0
+    precedents = json.loads(capsys.readouterr().out)
+    assert len(precedents) == 1
+    assert precedents[0]["case_id"] == "case_prev_b"
+    assert precedents[0]["similarities"]
+    assert precedents[0]["similarity_score"] > 0
 
 
 def test_cli_import_jsonl(capsys, db_path, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- extend decisions with explanation and confidence fields to make replay outputs auditable
- enrich precedent results with summary, similarities, score, and reusable takeaway
- add storage compatibility handling and expand API/CLI test coverage for the new output contract

## Validation
- .venv/bin/python -m pytest -q

## Notes
- explanations remain heuristic v1 objects derived from events
- precedent scoring is still structural and case-oriented rather than embedding-based