### PR TITLE
Add OpenClaw-style runtime trace import

### DIFF
--- a/src/openprecedent/cli.py
+++ b/src/openprecedent/cli.py
@@ -59,6 +59,15 @@ def build_parser() -> argparse.ArgumentParser:
     precedent_find.add_argument("case_id")
     precedent_find.add_argument("--limit", type=int, default=3)
 
+    runtime_parser = subparsers.add_parser("runtime")
+    runtime_subparsers = runtime_parser.add_subparsers(dest="action", required=True)
+    runtime_import = runtime_subparsers.add_parser("import-openclaw")
+    runtime_import.add_argument("path")
+    runtime_import.add_argument("--case-id", required=True)
+    runtime_import.add_argument("--title", required=True)
+    runtime_import.add_argument("--user-id")
+    runtime_import.add_argument("--agent-id", default="openclaw")
+
     return parser
 
 
@@ -80,6 +89,8 @@ def main(argv: list[str] | None = None) -> int:
             return _handle_decisions(args, service)
         if args.resource == "precedent":
             return _handle_precedent(args, service)
+        if args.resource == "runtime":
+            return _handle_runtime(args, service)
     except KeyError as error:
         print(f"case not found: {error.args[0]}", file=sys.stderr)
         return 1
@@ -176,6 +187,26 @@ def _handle_precedent(args: argparse.Namespace, service: OpenPrecedentService) -
     precedents = service.find_precedents(args.case_id, limit=args.limit)
     _print_json([precedent.model_dump(mode="json") for precedent in precedents])
     return 0
+
+
+def _handle_runtime(args: argparse.Namespace, service: OpenPrecedentService) -> int:
+    if args.action == "import-openclaw":
+        result = service.import_openclaw_jsonl(
+            Path(args.path),
+            case_id=args.case_id,
+            title=args.title,
+            user_id=args.user_id,
+            agent_id=args.agent_id,
+        )
+        _print_json(
+            {
+                "case": result.case.model_dump(mode="json"),
+                "imported_event_count": len(result.imported_events),
+                "events": [event.model_dump(mode="json") for event in result.imported_events],
+            }
+        )
+        return 0
+    return 2
 
 
 def _print_json(data: object) -> None:

--- a/src/openprecedent/services.py
+++ b/src/openprecedent/services.py
@@ -58,6 +58,13 @@ class ConflictError(ValueError):
     pass
 
 
+class RuntimeTraceImportResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    case: Case
+    imported_events: list[Event]
+
+
 @dataclass
 class OpenPrecedentService:
     store: SQLiteStore
@@ -127,6 +134,38 @@ class OpenPrecedentService:
                 payload = AppendEventInput.model_validate(normalized_item)
                 imported.append(self.append_event(case_id, payload))
         return imported
+
+    def import_openclaw_jsonl(
+        self,
+        path: Path,
+        *,
+        case_id: str,
+        title: str,
+        user_id: str | None = None,
+        agent_id: str = "openclaw",
+    ) -> RuntimeTraceImportResult:
+        case = self.store.get_case(case_id)
+        if case is None:
+            case = self.create_case(
+                CreateCaseInput(
+                    case_id=case_id,
+                    title=title,
+                    user_id=user_id,
+                    agent_id=agent_id,
+                )
+            )
+
+        imported: list[Event] = []
+        with path.open("r", encoding="utf-8") as handle:
+            for line_no, line in enumerate(handle, start=1):
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                raw_item = json.loads(stripped)
+                normalized = self._normalize_openclaw_trace_line(raw_item, line_no)
+                imported.append(self.append_event(case_id, normalized))
+
+        return RuntimeTraceImportResult(case=case, imported_events=imported)
 
     def list_events(self, case_id: str) -> list[Event]:
         case = self.store.get_case(case_id)
@@ -414,6 +453,134 @@ class OpenPrecedentService:
         if case.final_summary:
             return case.final_summary
         return None
+
+    def _normalize_openclaw_trace_line(
+        self,
+        raw_item: dict[str, object],
+        line_no: int,
+    ) -> AppendEventInput:
+        kind = raw_item.get("kind")
+        if not isinstance(kind, str) or not kind:
+            raise ValueError(f"line {line_no}: kind is required for openclaw import")
+
+        timestamp = self._parse_optional_timestamp(raw_item.get("timestamp"), line_no)
+        event_id = _string_or_none(raw_item.get("event_id"))
+        payload = dict(raw_item)
+        payload.pop("kind", None)
+        payload.pop("timestamp", None)
+        payload.pop("event_id", None)
+
+        if kind == "user_message":
+            return AppendEventInput(
+                event_id=event_id,
+                event_type=EventType.MESSAGE_USER,
+                actor=EventActor.USER,
+                timestamp=timestamp,
+                payload={
+                    "message": _string_or_default(raw_item.get("content"), ""),
+                    "source": "openclaw",
+                },
+            )
+        if kind == "agent_message":
+            return AppendEventInput(
+                event_id=event_id,
+                event_type=EventType.MESSAGE_AGENT,
+                actor=EventActor.AGENT,
+                timestamp=timestamp,
+                payload={
+                    "message": _string_or_default(raw_item.get("content"), ""),
+                    "source": "openclaw",
+                },
+            )
+        if kind == "tool_call":
+            return AppendEventInput(
+                event_id=event_id,
+                event_type=EventType.TOOL_CALLED,
+                actor=EventActor.AGENT,
+                timestamp=timestamp,
+                payload={
+                    "tool_name": _string_or_default(raw_item.get("tool_name"), "unknown_tool"),
+                    "reason": _string_or_none(raw_item.get("reason")),
+                    "arguments": raw_item.get("arguments") if isinstance(raw_item.get("arguments"), dict) else {},
+                    "source": "openclaw",
+                },
+            )
+        if kind == "tool_result":
+            return AppendEventInput(
+                event_id=event_id,
+                event_type=EventType.TOOL_COMPLETED,
+                actor=EventActor.TOOL,
+                timestamp=timestamp,
+                payload=payload,
+            )
+        if kind == "command":
+            return AppendEventInput(
+                event_id=event_id,
+                event_type=EventType.COMMAND_COMPLETED,
+                actor=EventActor.SYSTEM,
+                timestamp=timestamp,
+                payload={
+                    "command": _string_or_default(raw_item.get("command"), ""),
+                    "exit_code": int(raw_item.get("exit_code", 0)),
+                    "stdout": _string_or_none(raw_item.get("stdout")),
+                    "stderr": _string_or_none(raw_item.get("stderr")),
+                    "source": "openclaw",
+                },
+            )
+        if kind == "file_write":
+            return AppendEventInput(
+                event_id=event_id,
+                event_type=EventType.FILE_WRITE,
+                actor=EventActor.AGENT,
+                timestamp=timestamp,
+                payload={
+                    "path": _string_or_default(raw_item.get("path"), "unknown_path"),
+                    "summary": _string_or_none(raw_item.get("summary")),
+                    "source": "openclaw",
+                },
+            )
+        if kind == "confirmation":
+            return AppendEventInput(
+                event_id=event_id,
+                event_type=EventType.USER_CONFIRMED,
+                actor=EventActor.USER,
+                timestamp=timestamp,
+                payload={
+                    "message": _string_or_default(raw_item.get("content"), ""),
+                    "source": "openclaw",
+                },
+            )
+        if kind == "completed":
+            return AppendEventInput(
+                event_id=event_id,
+                event_type=EventType.CASE_COMPLETED,
+                actor=EventActor.SYSTEM,
+                timestamp=timestamp,
+                payload={
+                    "summary": _string_or_none(raw_item.get("summary")) or "OpenClaw task completed",
+                    "source": "openclaw",
+                },
+            )
+        if kind == "failed":
+            return AppendEventInput(
+                event_id=event_id,
+                event_type=EventType.CASE_FAILED,
+                actor=EventActor.SYSTEM,
+                timestamp=timestamp,
+                payload={
+                    "summary": _string_or_none(raw_item.get("summary")) or "OpenClaw task failed",
+                    "source": "openclaw",
+                },
+            )
+
+        raise ValueError(f"line {line_no}: unsupported openclaw kind '{kind}'")
+
+    def _parse_optional_timestamp(self, value: object, line_no: int) -> datetime | None:
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            raise ValueError(f"line {line_no}: timestamp must be an ISO-8601 string")
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
 
 
 def _string_or_none(value: object) -> str | None:

--- a/tests/fixtures/openclaw_trace.jsonl
+++ b/tests/fixtures/openclaw_trace.jsonl
@@ -1,0 +1,6 @@
+{"timestamp":"2026-03-09T12:00:00Z","kind":"user_message","content":"Summarize the main context-graph document."}
+{"timestamp":"2026-03-09T12:00:03Z","kind":"agent_message","content":"I will inspect the repository docs and summarize the main document."}
+{"timestamp":"2026-03-09T12:00:04Z","kind":"tool_call","tool_name":"rg","reason":"find relevant markdown files","arguments":{"pattern":"context-graph","path":"/workspace"}}
+{"timestamp":"2026-03-09T12:00:05Z","kind":"command","command":"rg --files /workspace","exit_code":0,"stdout":"01-product/01-strategy/2026-03-context-graph-product-strategy.md","stderr":""}
+{"timestamp":"2026-03-09T12:00:07Z","kind":"file_write","path":"notes/context-graph-summary.md","summary":"saved a short summary for the user"}
+{"timestamp":"2026-03-09T12:00:09Z","kind":"completed","summary":"Provided the context-graph document summary."}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,10 @@
 import httpx
 import pytest
+from pathlib import Path
 
 from openprecedent.api import app
+from openprecedent.services import OpenPrecedentService
+from openprecedent.config import get_db_path
 
 
 async def _client() -> httpx.AsyncClient:
@@ -107,3 +110,25 @@ async def test_duplicate_case_returns_conflict(db_path) -> None:
 
         duplicate = await client.post("/cases", json={"case_id": "case_dup", "title": "Duplicate"})
         assert duplicate.status_code == 409
+
+
+def test_service_imports_openclaw_runtime_trace(db_path) -> None:
+    service = OpenPrecedentService.from_path(get_db_path())
+    fixture_path = Path(__file__).parent / "fixtures" / "openclaw_trace.jsonl"
+
+    result = service.import_openclaw_jsonl(
+        fixture_path,
+        case_id="case_runtime",
+        title="Runtime import",
+        user_id="u1",
+    )
+
+    assert result.case.case_id == "case_runtime"
+    assert len(result.imported_events) == 6
+
+    decisions = service.extract_decisions("case_runtime")
+    assert len(decisions) >= 4
+
+    replay = service.replay_case("case_runtime")
+    assert replay.case.status.value == "completed"
+    assert replay.summary == "Provided the context-graph document summary."

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -155,3 +155,39 @@ def test_cli_import_jsonl(capsys, db_path, tmp_path: Path) -> None:
     assert result == 0
     imported = json.loads(capsys.readouterr().out)
     assert len(imported) == 2
+
+
+def test_cli_import_openclaw_runtime_trace(capsys, db_path) -> None:
+    fixture_path = Path(__file__).parent / "fixtures" / "openclaw_trace.jsonl"
+
+    result = main(
+        [
+            "runtime",
+            "import-openclaw",
+            str(fixture_path),
+            "--case-id",
+            "case_openclaw",
+            "--title",
+            "OpenClaw imported trace",
+            "--user-id",
+            "u1",
+        ]
+    )
+    assert result == 0
+    imported = json.loads(capsys.readouterr().out)
+    assert imported["case"]["case_id"] == "case_openclaw"
+    assert imported["imported_event_count"] == 6
+
+    result = main(["extract", "decisions", "case_openclaw"])
+    assert result == 0
+    decisions = json.loads(capsys.readouterr().out)
+    assert any(item["decision_type"] == "plan" for item in decisions)
+    assert any(item["decision_type"] == "select_tool" for item in decisions)
+    assert any(item["decision_type"] == "apply_change" for item in decisions)
+    assert any(item["decision_type"] == "finalize" for item in decisions)
+
+    result = main(["replay", "case", "case_openclaw", "--json"])
+    assert result == 0
+    replay = json.loads(capsys.readouterr().out)
+    assert replay["case"]["status"] == "completed"
+    assert replay["summary"] == "Provided the context-graph document summary."


### PR DESCRIPTION
## Summary
- add a runtime import path that normalizes OpenClaw-style JSONL traces into the shared event model
- add a CLI command to import runtime traces directly into a case and run them through the existing replay/extraction loop
- add a sample runtime fixture and end-to-end tests for imported traces

## Validation
- .venv/bin/python -m pytest -q

## Notes
- this importer defines the repository’s first OpenClaw-style trace contract
- the exact mapping may need adjustment once connected to a real exported runtime trace