### PR TITLE
Improve CLI replay views and derive artifacts

### DIFF
--- a/src/openprecedent/cli.py
+++ b/src/openprecedent/cli.py
@@ -52,6 +52,7 @@ def build_parser() -> argparse.ArgumentParser:
     decisions_subparsers = decisions_parser.add_subparsers(dest="action", required=True)
     decisions_show = decisions_subparsers.add_parser("show")
     decisions_show.add_argument("case_id")
+    decisions_show.add_argument("--json", action="store_true", dest="as_json")
 
     precedent_parser = subparsers.add_parser("precedent")
     precedent_subparsers = precedent_parser.add_subparsers(dest="action", required=True)
@@ -166,6 +167,14 @@ def _handle_replay(args: argparse.Namespace, service: OpenPrecedentService) -> i
     print("Decisions:")
     for decision in replay.decisions:
         print(f"  [{decision.sequence_no}] {decision.decision_type.value}: {decision.title}")
+        print(f"      why: {decision.explanation.selection_reason}")
+        if decision.explanation.result:
+            print(f"      result: {decision.explanation.result}")
+    print("Artifacts:")
+    for artifact in replay.artifacts:
+        print(f"  - {artifact.artifact_type.value}: {artifact.uri_or_path}")
+        if artifact.summary:
+            print(f"      summary: {artifact.summary}")
     if replay.summary:
         print(f"Summary: {replay.summary}")
     return 0
@@ -179,7 +188,23 @@ def _handle_extract(args: argparse.Namespace, service: OpenPrecedentService) -> 
 
 def _handle_decisions(args: argparse.Namespace, service: OpenPrecedentService) -> int:
     decisions = service.list_decisions(args.case_id)
-    _print_json([decision.model_dump(mode="json") for decision in decisions])
+    if args.as_json:
+        _print_json([decision.model_dump(mode="json") for decision in decisions])
+        return 0
+
+    for decision in decisions:
+        print(f"[{decision.sequence_no}] {decision.decision_type.value}: {decision.title}")
+        print(f"  question: {decision.question}")
+        print(f"  chosen_action: {decision.chosen_action}")
+        print(f"  confidence: {decision.confidence:.2f}")
+        print(f"  goal: {decision.explanation.goal}")
+        print(f"  why: {decision.explanation.selection_reason}")
+        if decision.explanation.evidence:
+            print(f"  evidence: {', '.join(decision.explanation.evidence)}")
+        if decision.explanation.constraints:
+            print(f"  constraints: {', '.join(decision.explanation.constraints)}")
+        if decision.explanation.result:
+            print(f"  result: {decision.explanation.result}")
     return 0
 
 

--- a/src/openprecedent/services.py
+++ b/src/openprecedent/services.py
@@ -11,6 +11,8 @@ from uuid import uuid4
 from pydantic import BaseModel, ConfigDict, Field
 
 from openprecedent.schemas import (
+    Artifact,
+    ArtifactType,
     Case,
     CaseStatus,
     Decision,
@@ -51,6 +53,7 @@ class ReplayResponse(BaseModel):
     case: Case
     events: list[Event]
     decisions: list[Decision]
+    artifacts: list[Artifact]
     summary: str | None = None
 
 
@@ -310,8 +313,9 @@ class OpenPrecedentService:
             raise KeyError(case_id)
         events = self.store.list_events(case_id)
         decisions = self.store.list_decisions(case_id)
+        artifacts = self._derive_artifacts(case_id, events)
         summary = case.final_summary or self._build_case_summary(case, events, decisions)
-        return ReplayResponse(case=case, events=events, decisions=decisions, summary=summary)
+        return ReplayResponse(case=case, events=events, decisions=decisions, artifacts=artifacts, summary=summary)
 
     def find_precedents(self, case_id: str, limit: int = 3) -> list[Precedent]:
         current_case = self.store.get_case(case_id)
@@ -453,6 +457,55 @@ class OpenPrecedentService:
         if case.final_summary:
             return case.final_summary
         return None
+
+    def _derive_artifacts(self, case_id: str, events: list[Event]) -> list[Artifact]:
+        derived: list[Artifact] = []
+        seen_ids: set[str] = set()
+
+        for event in events:
+            payload = event.payload
+            artifact: Artifact | None = None
+
+            if event.event_type == EventType.FILE_WRITE:
+                path = _string_or_none(payload.get("path"))
+                if path:
+                    artifact = Artifact(
+                        artifact_id=f"artifact_{event.event_id}",
+                        case_id=case_id,
+                        artifact_type=ArtifactType.FILE,
+                        uri_or_path=path,
+                        summary=_string_or_none(payload.get("summary")),
+                    )
+            elif event.event_type == EventType.COMMAND_COMPLETED:
+                command = _string_or_none(payload.get("command"))
+                if command:
+                    artifact = Artifact(
+                        artifact_id=f"artifact_{event.event_id}",
+                        case_id=case_id,
+                        artifact_type=ArtifactType.COMMAND_OUTPUT,
+                        uri_or_path=command,
+                        summary=_string_or_none(payload.get("stdout"))
+                        or _string_or_none(payload.get("stderr")),
+                    )
+            elif event.event_type in (EventType.MESSAGE_USER, EventType.MESSAGE_AGENT):
+                message = _string_or_none(payload.get("message"))
+                if message:
+                    artifact = Artifact(
+                        artifact_id=f"artifact_{event.event_id}",
+                        case_id=case_id,
+                        artifact_type=ArtifactType.MESSAGE,
+                        uri_or_path=f"{event.event_type.value}:{event.event_id}",
+                        summary=message,
+                    )
+
+            if artifact is None or artifact.artifact_id in seen_ids:
+                continue
+
+            self.store.upsert_artifact(artifact)
+            seen_ids.add(artifact.artifact_id)
+            derived.append(artifact)
+
+        return derived
 
     def _normalize_openclaw_trace_line(
         self,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -90,6 +90,7 @@ async def test_case_ingestion_replay_and_precedent_flow(db_path) -> None:
         assert body["case"]["case_id"] == "case_alpha"
         assert len(body["events"]) == 5
         assert len(body["decisions"]) >= 3
+        assert len(body["artifacts"]) >= 3
         assert body["summary"] == "summary delivered"
 
         precedents = await client.get("/cases/case_alpha/precedents")
@@ -132,3 +133,4 @@ def test_service_imports_openclaw_runtime_trace(db_path) -> None:
     replay = service.replay_case("case_runtime")
     assert replay.case.status.value == "completed"
     assert replay.summary == "Provided the context-graph document summary."
+    assert replay.artifacts

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -66,6 +66,13 @@ def test_cli_end_to_end(capsys, db_path) -> None:
     replay = json.loads(capsys.readouterr().out)
     assert replay["case"]["case_id"] == "case_cli"
     assert replay["summary"] == "done"
+    assert replay["artifacts"]
+
+    result = main(["decisions", "show", "case_cli"])
+    assert result == 0
+    rendered = capsys.readouterr().out
+    assert "chosen_action:" in rendered
+    assert "why:" in rendered
 
 
 def test_cli_precedent_output(capsys, db_path) -> None:
@@ -191,3 +198,4 @@ def test_cli_import_openclaw_runtime_trace(capsys, db_path) -> None:
     replay = json.loads(capsys.readouterr().out)
     assert replay["case"]["status"] == "completed"
     assert replay["summary"] == "Provided the context-graph document summary."
+    assert replay["artifacts"]


### PR DESCRIPTION
## Summary
- improve terminal replay output with decision explanations and derived artifact sections
- add a readable  view for case inspection without JSON parsing
- derive artifacts from runtime events and include them in replay responses

## Validation
- .venv/bin/python -m pytest -q

## Notes
- artifact derivation is still heuristic and event-pattern based
- this change is intentionally CLI-first and does not introduce UI work