### PR TITLE
Enforce branch hygiene for merged PR branches

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -3,6 +3,17 @@ set -euo pipefail
 
 repo_root="$(git rev-parse --show-toplevel)"
 review_file="$repo_root/.codex-review"
+current_branch="$(git branch --show-current)"
+origin_url="$(git remote get-url origin 2>/dev/null || true)"
+
+extract_owner() {
+  local remote_url="$1"
+  if [[ "$remote_url" =~ github\.com[:/]([^/]+)/[^/]+(\.git)?$ ]]; then
+    echo "${BASH_REMATCH[1]}"
+    return 0
+  fi
+  return 1
+}
 
 if [[ "${BYPASS_CODEX_REVIEW:-}" == "1" ]]; then
   echo "Bypassing Codex review hook because BYPASS_CODEX_REVIEW=1"
@@ -37,6 +48,28 @@ Include at least:
   - remaining risks
 EOF
   exit 1
+fi
+
+if [[ -n "$current_branch" ]] && owner="$(extract_owner "$origin_url")"; then
+  merged_pr_json="$(
+    gh pr list \
+      --repo openprecedent/openprecedent \
+      --head "$owner:$current_branch" \
+      --state merged \
+      --json number,url \
+      2>/dev/null || true
+  )"
+
+  if [[ "$merged_pr_json" != "[]" ]] && [[ -n "$merged_pr_json" ]]; then
+    cat <<EOF
+Push blocked: the current branch already has a merged PR in openprecedent/openprecedent.
+
+Branch: $current_branch
+
+Create a new branch from upstream/main for follow-up work instead of pushing more commits to a merged PR branch.
+EOF
+    exit 1
+  fi
 fi
 
 echo "Codex review note detected."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ The first implementation target is a local single-agent workflow. The current go
 - Prefer small, auditable changes over broad scaffolding.
 - Preserve a clear separation between raw events and derived decision records.
 - Prefer simple local-first development flows.
+- Once a PR branch has been merged, do not add new commits to that branch. Start a fresh branch from `upstream/main` for all follow-up work.
 
 ## Documentation Rules
 

--- a/docs/engineering/repository-governance.md
+++ b/docs/engineering/repository-governance.md
@@ -58,6 +58,7 @@ Expected local behavior:
 - authors run a Codex review before push
 - authors record the result in `.codex-review`
 - the local pre-push hook blocks the push if the review note is missing
+- the local pre-push hook also blocks pushes to branches whose PRs have already been merged into `openprecedent/openprecedent`
 
 This is a local reliability measure, not a substitute for repository review requirements.
 
@@ -68,6 +69,12 @@ Changes to repository governance should follow this rule:
 - repository content changes go through pull requests
 - GitHub settings changes are applied directly by an admin
 - any meaningful GitHub settings change should also be reflected in this document
+
+Additional branch hygiene rule:
+
+- once a pull request branch has been merged, that branch must be treated as closed
+- any follow-up work must start from a new branch created from the latest `upstream/main`
+- do not append new commits to a branch that already maps to a merged PR
 
 ## Review Gate Model
 


### PR DESCRIPTION
## Summary
- block pushes to branches whose PRs are already merged into openprecedent/openprecedent
- record the rule in AGENTS and repository governance docs
- make branch hygiene an explicit repository principle instead of relying on memory

## Notes
- this fixes a workflow mistake: follow-up commits must go to a fresh branch from upstream/main, not a branch whose PR is already merged