### PR TITLE
Add automated OpenClaw session collector

### DIFF
--- a/docs/architecture/openclaw-silent-collection.md
+++ b/docs/architecture/openclaw-silent-collection.md
@@ -46,6 +46,22 @@ The current CLI entry points are:
 - `openprecedent runtime import-openclaw-session --latest --case-id <id>`
 - `openprecedent runtime import-openclaw-session --session-id <id> --case-id <id>`
 - `openprecedent runtime import-openclaw-session --session-file <path> --case-id <id>`
+- `openprecedent runtime collect-openclaw-sessions`
+
+## Automated Collection
+
+For background collection, use:
+
+- `openprecedent runtime collect-openclaw-sessions --limit 1`
+
+This command:
+
+- reads the session index
+- imports the latest unseen session transcript
+- writes a local collector state file
+- skips sessions that were already collected
+
+This is the intended MVP path for cron-based silent collection.
 
 ## MVP Boundary
 

--- a/src/openprecedent/cli.py
+++ b/src/openprecedent/cli.py
@@ -5,7 +5,7 @@ import json
 import sys
 from pathlib import Path
 
-from openprecedent.config import get_db_path
+from openprecedent.config import get_collector_state_path, get_db_path
 from openprecedent.schemas import EventActor, EventType
 from openprecedent.services import AppendEventInput, CreateCaseInput, OpenPrecedentService
 
@@ -80,6 +80,12 @@ def build_parser() -> argparse.ArgumentParser:
     runtime_import_session.add_argument("--title")
     runtime_import_session.add_argument("--user-id")
     runtime_import_session.add_argument("--agent-id", default="openclaw")
+    runtime_collect = runtime_subparsers.add_parser("collect-openclaw-sessions")
+    runtime_collect.add_argument("--sessions-root")
+    runtime_collect.add_argument("--state-file")
+    runtime_collect.add_argument("--limit", type=int, default=1)
+    runtime_collect.add_argument("--user-id")
+    runtime_collect.add_argument("--agent-id", default="openclaw")
 
     return parser
 
@@ -268,6 +274,16 @@ def _handle_runtime(args: argparse.Namespace, service: OpenPrecedentService) -> 
             }
         )
         return 0
+    if args.action == "collect-openclaw-sessions":
+        result = service.collect_openclaw_sessions(
+            _resolve_openclaw_sessions_root(args.sessions_root),
+            state_path=_resolve_collector_state_path(args.state_file),
+            limit=args.limit,
+            user_id=args.user_id,
+            agent_id=args.agent_id,
+        )
+        _print_json(result.model_dump(mode="json"))
+        return 0
     return 2
 
 
@@ -279,6 +295,12 @@ def _resolve_openclaw_sessions_root(value: str | None) -> Path:
     if value:
         return Path(value)
     return Path.home() / ".openclaw" / "agents" / "main" / "sessions"
+
+
+def _resolve_collector_state_path(value: str | None) -> Path:
+    if value:
+        return Path(value)
+    return get_collector_state_path()
 
 
 def _resolve_openclaw_session_target(

--- a/src/openprecedent/config.py
+++ b/src/openprecedent/config.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 DEFAULT_DB_NAME = "openprecedent.db"
 DB_ENV_VAR = "OPENPRECEDENT_DB"
+DEFAULT_COLLECTOR_STATE_NAME = "openprecedent-collector-state.json"
+COLLECTOR_STATE_ENV_VAR = "OPENPRECEDENT_COLLECTOR_STATE"
 
 
 def get_db_path() -> Path:
@@ -14,3 +16,11 @@ def get_db_path() -> Path:
         return Path(configured).expanduser().resolve()
 
     return Path.cwd() / DEFAULT_DB_NAME
+
+
+def get_collector_state_path() -> Path:
+    configured = os.environ.get(COLLECTOR_STATE_ENV_VAR)
+    if configured:
+        return Path(configured).expanduser().resolve()
+
+    return get_db_path().with_name(DEFAULT_COLLECTOR_STATE_NAME)

--- a/src/openprecedent/services.py
+++ b/src/openprecedent/services.py
@@ -80,6 +80,30 @@ class OpenClawSessionReference(BaseModel):
     is_active: bool = False
 
 
+class OpenClawCollectionState(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    imported_session_ids: list[str] = Field(default_factory=list)
+
+
+class CollectedSessionResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    session_id: str
+    transcript_path: str
+    case_id: str
+    title: str
+    imported_event_count: int
+
+
+class OpenClawCollectionResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    imported: list[CollectedSessionResult]
+    skipped_session_ids: list[str] = Field(default_factory=list)
+    state_path: str
+
+
 @dataclass
 class OpenPrecedentService:
     store: SQLiteStore
@@ -268,6 +292,54 @@ class OpenPrecedentService:
                     imported.append(self.append_event(case_id, normalized))
 
         return RuntimeTraceImportResult(case=case, imported_events=imported)
+
+    def collect_openclaw_sessions(
+        self,
+        sessions_root: Path,
+        *,
+        state_path: Path,
+        limit: int = 1,
+        user_id: str | None = None,
+        agent_id: str = "openclaw",
+    ) -> OpenClawCollectionResult:
+        references = self.list_openclaw_sessions(sessions_root, limit=200)
+        state = self._load_openclaw_collection_state(state_path)
+        seen = set(state.imported_session_ids)
+
+        imported: list[CollectedSessionResult] = []
+        skipped: list[str] = []
+
+        for reference in references:
+            if reference.session_id in seen:
+                skipped.append(reference.session_id)
+                continue
+            result = self.import_openclaw_session(
+                Path(reference.transcript_path),
+                case_id=_case_id_for_openclaw_session(reference.session_id),
+                title=reference.label or f"OpenClaw session {reference.session_id}",
+                user_id=user_id,
+                agent_id=agent_id,
+            )
+            imported.append(
+                CollectedSessionResult(
+                    session_id=reference.session_id,
+                    transcript_path=reference.transcript_path,
+                    case_id=result.case.case_id,
+                    title=result.case.title,
+                    imported_event_count=len(result.imported_events),
+                )
+            )
+            seen.add(reference.session_id)
+            state.imported_session_ids.append(reference.session_id)
+            if len(imported) >= limit:
+                break
+
+        self._write_openclaw_collection_state(state_path, state)
+        return OpenClawCollectionResult(
+            imported=imported,
+            skipped_session_ids=skipped,
+            state_path=str(state_path),
+        )
 
     def list_events(self, case_id: str) -> list[Event]:
         case = self.store.get_case(case_id)
@@ -871,6 +943,22 @@ class OpenPrecedentService:
 
         return []
 
+    def _load_openclaw_collection_state(self, state_path: Path) -> OpenClawCollectionState:
+        if not state_path.exists():
+            return OpenClawCollectionState()
+        return OpenClawCollectionState.model_validate_json(state_path.read_text(encoding="utf-8"))
+
+    def _write_openclaw_collection_state(
+        self,
+        state_path: Path,
+        state: OpenClawCollectionState,
+    ) -> None:
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        state_path.write_text(
+            state.model_dump_json(indent=2),
+            encoding="utf-8",
+        )
+
     def _parse_optional_timestamp(self, value: object, line_no: int) -> datetime | None:
         if value is None:
             return None
@@ -935,3 +1023,8 @@ def _extract_openclaw_visible_assistant_text(content: list[object]) -> list[str]
                     if text:
                         segments.append(text)
     return segments
+
+
+def _case_id_for_openclaw_session(session_id: str) -> str:
+    normalized = "".join(ch for ch in session_id.lower() if ch.isalnum())
+    return f"openclaw_{normalized[:24]}"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -179,3 +179,43 @@ def test_service_lists_and_imports_openclaw_session(db_path, tmp_path: Path) -> 
 
     replay = service.replay_case("case_session")
     assert replay.summary == "Imported OpenClaw session: 7 events, 2 decisions, status=started"
+
+
+def test_service_collects_latest_unseen_openclaw_session(db_path, tmp_path: Path) -> None:
+    service = OpenPrecedentService.from_path(get_db_path())
+    fixture_dir = Path(__file__).parent / "fixtures" / "openclaw_sessions"
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    transcript_path = sessions_dir / "sample-session.jsonl"
+    transcript_path.write_text(
+        (fixture_dir / "sample-session.jsonl").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    (sessions_dir / "sessions.json").write_text(
+        (fixture_dir / "sessions.json").read_text(encoding="utf-8").replace(
+            "__FIXTURE_DIR__",
+            str(sessions_dir),
+        ),
+        encoding="utf-8",
+    )
+    state_path = tmp_path / "collector-state.json"
+
+    first = service.collect_openclaw_sessions(
+        sessions_dir,
+        state_path=state_path,
+        limit=1,
+        user_id="u1",
+    )
+    assert len(first.imported) == 1
+    assert first.imported[0].session_id == "sample-session"
+    assert first.imported[0].case_id == "openclaw_samplesession"
+    assert state_path.exists()
+
+    second = service.collect_openclaw_sessions(
+        sessions_dir,
+        state_path=state_path,
+        limit=1,
+        user_id="u1",
+    )
+    assert second.imported == []
+    assert "sample-session" in second.skipped_session_ids

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -253,3 +253,57 @@ def test_cli_lists_and_imports_openclaw_sessions(capsys, db_path, tmp_path: Path
     replay = json.loads(capsys.readouterr().out)
     assert replay["events"][0]["event_type"] == "case.started"
     assert any(event["event_type"] == "tool.called" for event in replay["events"])
+
+
+def test_cli_collects_openclaw_sessions(capsys, db_path, tmp_path: Path) -> None:
+    fixture_dir = Path(__file__).parent / "fixtures" / "openclaw_sessions"
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    transcript_path = sessions_dir / "sample-session.jsonl"
+    transcript_path.write_text(
+        (fixture_dir / "sample-session.jsonl").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    (sessions_dir / "sessions.json").write_text(
+        (fixture_dir / "sessions.json").read_text(encoding="utf-8").replace(
+            "__FIXTURE_DIR__",
+            str(sessions_dir),
+        ),
+        encoding="utf-8",
+    )
+    state_path = tmp_path / "collector-state.json"
+
+    result = main(
+        [
+            "runtime",
+            "collect-openclaw-sessions",
+            "--sessions-root",
+            str(sessions_dir),
+            "--state-file",
+            str(state_path),
+            "--limit",
+            "1",
+        ]
+    )
+    assert result == 0
+    collected = json.loads(capsys.readouterr().out)
+    assert len(collected["imported"]) == 1
+    assert collected["imported"][0]["session_id"] == "sample-session"
+    assert collected["imported"][0]["transcript_path"] == str(transcript_path)
+
+    result = main(
+        [
+            "runtime",
+            "collect-openclaw-sessions",
+            "--sessions-root",
+            str(sessions_dir),
+            "--state-file",
+            str(state_path),
+            "--limit",
+            "1",
+        ]
+    )
+    assert result == 0
+    collected_again = json.loads(capsys.readouterr().out)
+    assert collected_again["imported"] == []
+    assert "sample-session" in collected_again["skipped_session_ids"]


### PR DESCRIPTION
## Summary
- add a collector command that imports the latest unseen OpenClaw sessions using a local state cursor
- add state path configuration for background collection workflows
- extend silent collection tests and docs for cron-style operation

## Validation
- .venv/bin/python -m pytest -q
- python3 -m compileall src tests

## Review focus
- whether the collector state contract is enough for MVP background collection
- whether deterministic case ids per session are the right import strategy

## Risks
- collector state is local-only and not shared across machines
- transcript mapping still ignores some OpenClaw record types