### PR TITLE
Add MVP evaluation fixture suite

### DIFF
--- a/src/openprecedent/cli.py
+++ b/src/openprecedent/cli.py
@@ -87,6 +87,12 @@ def build_parser() -> argparse.ArgumentParser:
     runtime_collect.add_argument("--user-id")
     runtime_collect.add_argument("--agent-id", default="openclaw")
 
+    eval_parser = subparsers.add_parser("eval")
+    eval_subparsers = eval_parser.add_subparsers(dest="action", required=True)
+    eval_fixtures = eval_subparsers.add_parser("fixtures")
+    eval_fixtures.add_argument("path")
+    eval_fixtures.add_argument("--json", action="store_true", dest="as_json")
+
     return parser
 
 
@@ -110,6 +116,8 @@ def main(argv: list[str] | None = None) -> int:
             return _handle_precedent(args, service)
         if args.resource == "runtime":
             return _handle_runtime(args, service)
+        if args.resource == "eval":
+            return _handle_eval(args, service)
     except KeyError as error:
         print(f"case not found: {error.args[0]}", file=sys.stderr)
         return 1
@@ -283,6 +291,45 @@ def _handle_runtime(args: argparse.Namespace, service: OpenPrecedentService) -> 
             agent_id=args.agent_id,
         )
         _print_json(result.model_dump(mode="json"))
+        return 0
+    return 2
+
+
+def _handle_eval(args: argparse.Namespace, service: OpenPrecedentService) -> int:
+    if args.action == "fixtures":
+        report = service.evaluate_openclaw_fixture_suite(Path(args.path))
+        if args.as_json:
+            _print_json(report.model_dump(mode="json"))
+            return 0
+
+        print(
+            f"Evaluation: {report.passed_cases}/{report.total_cases} passed, "
+            f"{report.failed_cases} failed"
+        )
+        for result in report.results:
+            status = "PASS" if result.passed else "FAIL"
+            print(f"- {status} {result.case_id}")
+            print(
+                "  decisions: "
+                f"expected={','.join(item.value for item in result.expected_decision_types)} "
+                f"actual={','.join(item.value for item in result.actual_decision_types)}"
+            )
+            if result.expected_precedent_case_ids:
+                print(
+                    "  precedents: "
+                    f"expected={','.join(result.expected_precedent_case_ids)} "
+                    f"actual={','.join(result.actual_precedent_case_ids)}"
+                )
+            if result.missing_decision_types:
+                print(
+                    "  missing decisions: "
+                    + ",".join(item.value for item in result.missing_decision_types)
+                )
+            if result.missing_precedent_case_ids:
+                print(
+                    "  missing precedents: "
+                    + ",".join(result.missing_precedent_case_ids)
+                )
         return 0
     return 2
 

--- a/src/openprecedent/services.py
+++ b/src/openprecedent/services.py
@@ -104,6 +104,45 @@ class OpenClawCollectionResult(BaseModel):
     state_path: str
 
 
+class EvaluationCaseSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    case_id: str
+    title: str
+    trace_path: str
+    expected_decision_types: list[DecisionType]
+    expected_precedent_case_ids: list[str] = Field(default_factory=list)
+
+
+class EvaluationSuiteSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    cases: list[EvaluationCaseSpec]
+
+
+class EvaluationCaseResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    case_id: str
+    expected_decision_types: list[DecisionType]
+    actual_decision_types: list[DecisionType]
+    missing_decision_types: list[DecisionType]
+    extra_decision_types: list[DecisionType]
+    expected_precedent_case_ids: list[str]
+    actual_precedent_case_ids: list[str]
+    missing_precedent_case_ids: list[str]
+    passed: bool
+
+
+class EvaluationReport(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    total_cases: int
+    passed_cases: int
+    failed_cases: int
+    results: list[EvaluationCaseResult]
+
+
 @dataclass
 class OpenPrecedentService:
     store: SQLiteStore
@@ -339,6 +378,65 @@ class OpenPrecedentService:
             imported=imported,
             skipped_session_ids=skipped,
             state_path=str(state_path),
+        )
+
+    def evaluate_openclaw_fixture_suite(self, suite_path: Path) -> EvaluationReport:
+        suite = EvaluationSuiteSpec.model_validate_json(suite_path.read_text(encoding="utf-8"))
+        base_dir = suite_path.parent
+
+        imported_case_ids: list[str] = []
+        for case_spec in suite.cases:
+            trace_path = (base_dir / case_spec.trace_path).resolve()
+            self.import_openclaw_jsonl(
+                trace_path,
+                case_id=case_spec.case_id,
+                title=case_spec.title,
+            )
+            self.extract_decisions(case_spec.case_id)
+            imported_case_ids.append(case_spec.case_id)
+
+        results: list[EvaluationCaseResult] = []
+        for case_spec in suite.cases:
+            actual_decisions = self.list_decisions(case_spec.case_id)
+            actual_decision_types = [decision.decision_type for decision in actual_decisions]
+            expected_decision_types = case_spec.expected_decision_types
+
+            missing_decision_types = [
+                item for item in expected_decision_types if item not in actual_decision_types
+            ]
+            extra_decision_types = [
+                item for item in actual_decision_types if item not in expected_decision_types
+            ]
+
+            precedents = self.find_precedents(case_spec.case_id, limit=5)
+            actual_precedent_case_ids = [precedent.case_id for precedent in precedents]
+            missing_precedent_case_ids = [
+                item
+                for item in case_spec.expected_precedent_case_ids
+                if item not in actual_precedent_case_ids
+            ]
+
+            passed = not missing_decision_types and not missing_precedent_case_ids
+            results.append(
+                EvaluationCaseResult(
+                    case_id=case_spec.case_id,
+                    expected_decision_types=expected_decision_types,
+                    actual_decision_types=actual_decision_types,
+                    missing_decision_types=missing_decision_types,
+                    extra_decision_types=extra_decision_types,
+                    expected_precedent_case_ids=case_spec.expected_precedent_case_ids,
+                    actual_precedent_case_ids=actual_precedent_case_ids,
+                    missing_precedent_case_ids=missing_precedent_case_ids,
+                    passed=passed,
+                )
+            )
+
+        passed_cases = sum(1 for result in results if result.passed)
+        return EvaluationReport(
+            total_cases=len(results),
+            passed_cases=passed_cases,
+            failed_cases=len(results) - passed_cases,
+            results=results,
         )
 
     def list_events(self, case_id: str) -> list[Event]:

--- a/tests/fixtures/evaluation/openclaw_recovery.jsonl
+++ b/tests/fixtures/evaluation/openclaw_recovery.jsonl
@@ -1,0 +1,6 @@
+{"timestamp":"2026-03-09T14:00:00Z","kind":"user_message","content":"Run tests and fix the failure."}
+{"timestamp":"2026-03-09T14:00:02Z","kind":"agent_message","content":"I will run the relevant tests first."}
+{"timestamp":"2026-03-09T14:00:03Z","kind":"tool_call","tool_name":"exec_command","reason":"run the targeted test command","arguments":{"cmd":"pytest tests/test_api.py"}}
+{"timestamp":"2026-03-09T14:00:06Z","kind":"command","command":"pytest tests/test_api.py","exit_code":1,"stdout":"","stderr":"AssertionError: expected 200 got 500"}
+{"timestamp":"2026-03-09T14:00:08Z","kind":"agent_message","content":"The test failed, so I will inspect the failing path and recover with a narrower change."}
+{"timestamp":"2026-03-09T14:00:12Z","kind":"completed","summary":"Identified the failure and proposed a recovery path."}

--- a/tests/fixtures/evaluation/openclaw_summary_a.jsonl
+++ b/tests/fixtures/evaluation/openclaw_summary_a.jsonl
@@ -1,0 +1,5 @@
+{"timestamp":"2026-03-09T12:00:00Z","kind":"user_message","content":"Summarize the main context-graph document."}
+{"timestamp":"2026-03-09T12:00:03Z","kind":"agent_message","content":"I will inspect the repository docs and summarize the main document."}
+{"timestamp":"2026-03-09T12:00:04Z","kind":"tool_call","tool_name":"rg","reason":"find relevant markdown files","arguments":{"pattern":"context-graph","path":"/workspace"}}
+{"timestamp":"2026-03-09T12:00:07Z","kind":"file_write","path":"notes/context-graph-summary-a.md","summary":"saved a short summary for the user"}
+{"timestamp":"2026-03-09T12:00:09Z","kind":"completed","summary":"Provided the context-graph document summary."}

--- a/tests/fixtures/evaluation/openclaw_summary_b.jsonl
+++ b/tests/fixtures/evaluation/openclaw_summary_b.jsonl
@@ -1,0 +1,5 @@
+{"timestamp":"2026-03-09T13:00:00Z","kind":"user_message","content":"Summarize the context-graph strategy note."}
+{"timestamp":"2026-03-09T13:00:03Z","kind":"agent_message","content":"I will inspect the strategy notes and summarize the main document."}
+{"timestamp":"2026-03-09T13:00:04Z","kind":"tool_call","tool_name":"rg","reason":"find relevant markdown files","arguments":{"pattern":"strategy","path":"/workspace"}}
+{"timestamp":"2026-03-09T13:00:07Z","kind":"file_write","path":"notes/context-graph-summary-b.md","summary":"saved another short summary for the user"}
+{"timestamp":"2026-03-09T13:00:09Z","kind":"completed","summary":"Provided another context-graph document summary."}

--- a/tests/fixtures/evaluation/suite.json
+++ b/tests/fixtures/evaluation/suite.json
@@ -1,0 +1,25 @@
+{
+  "cases": [
+    {
+      "case_id": "eval_summary_a",
+      "title": "Evaluation summary case A",
+      "trace_path": "openclaw_summary_a.jsonl",
+      "expected_decision_types": ["plan", "select_tool", "apply_change", "finalize"],
+      "expected_precedent_case_ids": ["eval_summary_b"]
+    },
+    {
+      "case_id": "eval_summary_b",
+      "title": "Evaluation summary case B",
+      "trace_path": "openclaw_summary_b.jsonl",
+      "expected_decision_types": ["plan", "select_tool", "apply_change", "finalize"],
+      "expected_precedent_case_ids": ["eval_summary_a"]
+    },
+    {
+      "case_id": "eval_recovery",
+      "title": "Evaluation recovery case",
+      "trace_path": "openclaw_recovery.jsonl",
+      "expected_decision_types": ["plan", "select_tool", "retry_or_recover", "finalize"],
+      "expected_precedent_case_ids": []
+    }
+  ]
+}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -135,7 +135,6 @@ def test_service_imports_openclaw_runtime_trace(db_path) -> None:
     assert replay.summary == "Provided the context-graph document summary."
     assert replay.artifacts
 
-
 def test_service_lists_and_imports_openclaw_session(db_path, tmp_path: Path) -> None:
     service = OpenPrecedentService.from_path(get_db_path())
     fixture_dir = Path(__file__).parent / "fixtures" / "openclaw_sessions"
@@ -219,3 +218,14 @@ def test_service_collects_latest_unseen_openclaw_session(db_path, tmp_path: Path
     )
     assert second.imported == []
     assert "sample-session" in second.skipped_session_ids
+
+
+def test_service_evaluates_fixture_suite(db_path) -> None:
+    service = OpenPrecedentService.from_path(get_db_path())
+    suite_path = Path(__file__).parent / "fixtures" / "evaluation" / "suite.json"
+
+    report = service.evaluate_openclaw_fixture_suite(suite_path)
+
+    assert report.total_cases == 3
+    assert report.failed_cases == 0
+    assert report.passed_cases == 3

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -200,7 +200,6 @@ def test_cli_import_openclaw_runtime_trace(capsys, db_path) -> None:
     assert replay["summary"] == "Provided the context-graph document summary."
     assert replay["artifacts"]
 
-
 def test_cli_lists_and_imports_openclaw_sessions(capsys, db_path, tmp_path: Path) -> None:
     fixture_dir = Path(__file__).parent / "fixtures" / "openclaw_sessions"
     sessions_dir = tmp_path / "sessions"
@@ -307,3 +306,14 @@ def test_cli_collects_openclaw_sessions(capsys, db_path, tmp_path: Path) -> None
     collected_again = json.loads(capsys.readouterr().out)
     assert collected_again["imported"] == []
     assert "sample-session" in collected_again["skipped_session_ids"]
+
+
+def test_cli_evaluates_fixture_suite(capsys, db_path) -> None:
+    suite_path = Path(__file__).parent / "fixtures" / "evaluation" / "suite.json"
+
+    result = main(["eval", "fixtures", str(suite_path), "--json"])
+    assert result == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["total_cases"] == 3
+    assert report["failed_cases"] == 0
+    assert report["passed_cases"] == 3


### PR DESCRIPTION
## Summary
- add an eval CLI for running curated OpenClaw fixture suites against the current extraction and precedent logic
- add evaluation report types and service-side fixture suite execution
- add three baseline fixtures that cover summary and recovery trajectories

## Validation
- .venv/bin/python -m pytest -q
- python3 -m compileall src tests

## Review focus
- whether the evaluation report shape is enough for MVP regression tracking
- whether the current fixture suite covers the highest-value extraction and precedent paths

## Risks
- fixtures are still synthetic and smaller than real OpenClaw histories
- precedent expectations are derived from small curated samples rather than broader production-like corpora