### PR TITLE
Map OpenClaw exec_command events

### DIFF
--- a/docs/architecture/openclaw-silent-collection.md
+++ b/docs/architecture/openclaw-silent-collection.md
@@ -34,7 +34,9 @@ The current importer maps transcript records into OpenPrecedent events as follow
 - `message.role=user` -> `message.user`
 - `message.role=assistant` text/summary -> `message.agent`
 - `assistant.content[type=toolCall]` -> `tool.called`
+- `assistant.content[type=toolCall name=exec_command]` -> `command.started`
 - `message.role=toolResult` -> `tool.completed`
+- `message.role=toolResult toolName=exec_command` -> `command.completed`
 
 This is intentionally trajectory-first. We do not parse gateway stdout/stderr logs in MVP.
 

--- a/src/openprecedent/services.py
+++ b/src/openprecedent/services.py
@@ -1001,6 +1001,9 @@ class OpenPrecedentService:
                     continue
                 if item.get("type") != "toolCall":
                     continue
+                tool_name = _string_or_default(item.get("name"), "unknown_tool")
+                arguments = item.get("arguments") if isinstance(item.get("arguments"), dict) else {}
+                tool_call_id = _string_or_none(item.get("id"))
                 normalized_events.append(
                     AppendEventInput(
                         event_id=f"evt_tool_{record_id}_{index}",
@@ -1009,11 +1012,22 @@ class OpenPrecedentService:
                         timestamp=timestamp,
                         parent_event_id=parent_id,
                         payload={
-                            "tool_name": _string_or_default(item.get("name"), "unknown_tool"),
-                            "arguments": item.get("arguments") if isinstance(item.get("arguments"), dict) else {},
-                            "tool_call_id": _string_or_none(item.get("id")),
+                            "tool_name": tool_name,
+                            "arguments": arguments,
+                            "tool_call_id": tool_call_id,
                             "source": "openclaw.session",
                         },
+                    )
+                )
+                normalized_events.extend(
+                    _normalize_openclaw_tool_call_events(
+                        record_id=record_id,
+                        index=index,
+                        parent_id=parent_id,
+                        timestamp=timestamp,
+                        tool_name=tool_name,
+                        tool_call_id=tool_call_id,
+                        arguments=arguments,
                     )
                 )
             return normalized_events
@@ -1035,6 +1049,17 @@ class OpenPrecedentService:
                         "details": message.get("details") if isinstance(message.get("details"), dict) else {},
                         "source": "openclaw.session",
                     },
+                )
+            )
+            normalized_events.extend(
+                _normalize_openclaw_tool_result_events(
+                    record_id=record_id,
+                    parent_id=parent_id,
+                    timestamp=timestamp,
+                    tool_name=_string_or_none(message.get("toolName")),
+                    tool_call_id=_string_or_none(message.get("toolCallId")),
+                    text=text or None,
+                    details=message.get("details") if isinstance(message.get("details"), dict) else {},
                 )
             )
             return normalized_events
@@ -1121,6 +1146,79 @@ def _extract_openclaw_visible_assistant_text(content: list[object]) -> list[str]
                     if text:
                         segments.append(text)
     return segments
+
+
+def _normalize_openclaw_tool_call_events(
+    *,
+    record_id: str,
+    index: int,
+    parent_id: str | None,
+    timestamp: datetime | None,
+    tool_name: str,
+    tool_call_id: str | None,
+    arguments: dict[str, object],
+) -> list[AppendEventInput]:
+    if tool_name != "exec_command":
+        return []
+
+    command = _string_or_none(arguments.get("cmd"))
+    if command is None:
+        return []
+
+    return [
+        AppendEventInput(
+            event_id=f"evt_command_started_{record_id}_{index}",
+            event_type=EventType.COMMAND_STARTED,
+            actor=EventActor.AGENT,
+            timestamp=timestamp,
+            parent_event_id=parent_id,
+            payload={
+                "command": command,
+                "tool_call_id": tool_call_id,
+                "source": "openclaw.session",
+            },
+        )
+    ]
+
+
+def _normalize_openclaw_tool_result_events(
+    *,
+    record_id: str,
+    parent_id: str | None,
+    timestamp: datetime | None,
+    tool_name: str | None,
+    tool_call_id: str | None,
+    text: str | None,
+    details: dict[str, object],
+) -> list[AppendEventInput]:
+    if tool_name != "exec_command":
+        return []
+
+    command = _string_or_none(details.get("cmd")) or _string_or_none(details.get("command"))
+    exit_code = details.get("exit_code")
+    normalized_exit_code = exit_code if isinstance(exit_code, int) else 0
+    stderr = _string_or_none(details.get("stderr"))
+    stdout = text
+    if stdout is None and stderr is None:
+        return []
+
+    return [
+        AppendEventInput(
+            event_id=f"evt_command_completed_{record_id}",
+            event_type=EventType.COMMAND_COMPLETED,
+            actor=EventActor.SYSTEM,
+            timestamp=timestamp,
+            parent_event_id=parent_id,
+            payload={
+                "command": command or "exec_command",
+                "exit_code": normalized_exit_code,
+                "stdout": stdout,
+                "stderr": stderr,
+                "tool_call_id": tool_call_id,
+                "source": "openclaw.session",
+            },
+        )
+    ]
 
 
 def _case_id_for_openclaw_session(session_id: str) -> str:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -164,20 +164,22 @@ def test_service_lists_and_imports_openclaw_session(db_path, tmp_path: Path) -> 
         user_id="u1",
     )
     assert result.case.case_id == "case_session"
-    assert len(result.imported_events) == 7
+    assert len(result.imported_events) == 9
 
     events = service.list_events("case_session")
     assert events[0].event_type.value == "case.started"
     assert any(event.event_type.value == "message.user" for event in events)
     assert any(event.event_type.value == "tool.called" for event in events)
     assert any(event.event_type.value == "tool.completed" for event in events)
+    assert any(event.event_type.value == "command.started" for event in events)
+    assert any(event.event_type.value == "command.completed" for event in events)
 
     decisions = service.extract_decisions("case_session")
     assert any(item.decision_type.value == "plan" for item in decisions)
     assert any(item.decision_type.value == "select_tool" for item in decisions)
 
     replay = service.replay_case("case_session")
-    assert replay.summary == "Imported OpenClaw session: 7 events, 2 decisions, status=started"
+    assert replay.summary == "Imported OpenClaw session: 9 events, 2 decisions, status=started"
 
 
 def test_service_collects_latest_unseen_openclaw_session(db_path, tmp_path: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -244,7 +244,7 @@ def test_cli_lists_and_imports_openclaw_sessions(capsys, db_path, tmp_path: Path
     assert result == 0
     imported = json.loads(capsys.readouterr().out)
     assert imported["case"]["case_id"] == "case_session_cli"
-    assert imported["imported_event_count"] == 7
+    assert imported["imported_event_count"] == 9
     assert imported["transcript_path"] == str(transcript_path)
 
     result = main(["replay", "case", "case_session_cli", "--json"])
@@ -252,6 +252,8 @@ def test_cli_lists_and_imports_openclaw_sessions(capsys, db_path, tmp_path: Path
     replay = json.loads(capsys.readouterr().out)
     assert replay["events"][0]["event_type"] == "case.started"
     assert any(event["event_type"] == "tool.called" for event in replay["events"])
+    assert any(event["event_type"] == "command.started" for event in replay["events"])
+    assert any(event["event_type"] == "command.completed" for event in replay["events"])
 
 
 def test_cli_collects_openclaw_sessions(capsys, db_path, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- map OpenClaw session exec_command tool calls into command.started events
- map exec_command tool results into command.completed events
- update CLI/API tests and silent collection docs for the richer transcript mapping

## Testing
- .venv/bin/python -m pytest tests/test_api.py -q
- .venv/bin/python -m pytest tests/test_cli.py -q