### PR TITLE
Preserve silent exec command failures

### DIFF
--- a/src/openprecedent/services.py
+++ b/src/openprecedent/services.py
@@ -1199,7 +1199,8 @@ def _normalize_openclaw_tool_result_events(
     normalized_exit_code = exit_code if isinstance(exit_code, int) else 0
     stderr = _string_or_none(details.get("stderr"))
     stdout = text
-    if stdout is None and stderr is None:
+    # Preserve command completion for silent failures where OpenClaw records only an exit code.
+    if stdout is None and stderr is None and not isinstance(exit_code, int):
         return []
 
     return [

--- a/tests/fixtures/openclaw_sessions/failing-command-session.jsonl
+++ b/tests/fixtures/openclaw_sessions/failing-command-session.jsonl
@@ -1,0 +1,4 @@
+{"type":"session","version":3,"id":"failing-command-session","timestamp":"2026-03-09T02:00:00.000Z","cwd":"/root/.openclaw/workspace"}
+{"type":"message","id":"msg-user-fail","parentId":null,"timestamp":"2026-03-09T02:00:00.100Z","message":{"role":"user","content":[{"type":"text","text":"Try a command that will fail."}]}}
+{"type":"message","id":"msg-assistant-fail","parentId":"msg-user-fail","timestamp":"2026-03-09T02:00:01.000Z","message":{"role":"assistant","content":[{"type":"text","text":"I will run the failing command."},{"type":"toolCall","id":"call_fail","name":"exec_command","arguments":{"cmd":"false"}}]}}
+{"type":"message","id":"msg-tool-fail","parentId":"msg-assistant-fail","timestamp":"2026-03-09T02:00:01.200Z","message":{"role":"toolResult","toolCallId":"call_fail","toolName":"exec_command","content":[],"isError":true,"details":{"exit_code":1}}}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -182,6 +182,36 @@ def test_service_lists_and_imports_openclaw_session(db_path, tmp_path: Path) -> 
     assert replay.summary == "Imported OpenClaw session: 9 events, 2 decisions, status=started"
 
 
+def test_service_imports_failing_openclaw_command_without_output(db_path) -> None:
+    service = OpenPrecedentService.from_path(get_db_path())
+    transcript_path = (
+        Path(__file__).parent / "fixtures" / "openclaw_sessions" / "failing-command-session.jsonl"
+    )
+
+    result = service.import_openclaw_session(
+        transcript_path,
+        case_id="case_session_failure",
+        title="Imported failing OpenClaw session",
+        user_id="u1",
+    )
+
+    assert result.case.case_id == "case_session_failure"
+    assert len(result.imported_events) == 7
+
+    events = service.list_events("case_session_failure")
+    command_completed = [
+        event for event in events if event.event_type.value == "command.completed"
+    ]
+    assert len(command_completed) == 1
+    assert command_completed[0].payload["command"] == "exec_command"
+    assert command_completed[0].payload["exit_code"] == 1
+    assert command_completed[0].payload["stdout"] is None
+    assert command_completed[0].payload["stderr"] is None
+
+    decisions = service.extract_decisions("case_session_failure")
+    assert any(item.decision_type.value == "retry_or_recover" for item in decisions)
+
+
 def test_service_collects_latest_unseen_openclaw_session(db_path, tmp_path: Path) -> None:
     service = OpenPrecedentService.from_path(get_db_path())
     fixture_dir = Path(__file__).parent / "fixtures" / "openclaw_sessions"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -256,6 +256,41 @@ def test_cli_lists_and_imports_openclaw_sessions(capsys, db_path, tmp_path: Path
     assert any(event["event_type"] == "command.completed" for event in replay["events"])
 
 
+def test_cli_imports_failing_openclaw_command_without_output(capsys, db_path) -> None:
+    fixture_path = (
+        Path(__file__).parent / "fixtures" / "openclaw_sessions" / "failing-command-session.jsonl"
+    )
+
+    result = main(
+        [
+            "runtime",
+            "import-openclaw-session",
+            "--session-file",
+            str(fixture_path),
+            "--case-id",
+            "case_session_failure_cli",
+        ]
+    )
+    assert result == 0
+    imported = json.loads(capsys.readouterr().out)
+    assert imported["case"]["case_id"] == "case_session_failure_cli"
+    assert imported["imported_event_count"] == 7
+
+    result = main(["extract", "decisions", "case_session_failure_cli"])
+    assert result == 0
+    decisions = json.loads(capsys.readouterr().out)
+    assert any(item["decision_type"] == "retry_or_recover" for item in decisions)
+
+    result = main(["replay", "case", "case_session_failure_cli", "--json"])
+    assert result == 0
+    replay = json.loads(capsys.readouterr().out)
+    command_completed = [
+        event for event in replay["events"] if event["event_type"] == "command.completed"
+    ]
+    assert len(command_completed) == 1
+    assert command_completed[0]["payload"]["exit_code"] == 1
+
+
 def test_cli_collects_openclaw_sessions(capsys, db_path, tmp_path: Path) -> None:
     fixture_dir = Path(__file__).parent / "fixtures" / "openclaw_sessions"
     sessions_dir = tmp_path / "sessions"


### PR DESCRIPTION
## Summary
- preserve command.completed events for exec_command tool results that only record an exit code
- add a minimal failing OpenClaw session fixture with no stdout/stderr payload
- cover the fallback path in both service and CLI tests

## Testing
- .venv/bin/python -m pytest tests/test_api.py -q
- .venv/bin/python -m pytest tests/test_cli.py -q