### PR TITLE
Add OpenClaw collector assets and read coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,12 @@ openprecedent/
 
 ## Current Status
 
-The repository currently contains the first documentation set and Python project scaffold. Dependencies have not yet been installed in this environment.
+The repository now includes:
+
+- local import and collector flows for OpenClaw session transcripts
+- fixture-based evaluation
+- collected-session evaluation/reporting
+- operational `systemd` and `cron` templates plus installer script for collector scheduling
 
 ## License
 

--- a/deploy/cron/openprecedent-collector.cron
+++ b/deploy/cron/openprecedent-collector.cron
@@ -1,0 +1,9 @@
+SHELL=/bin/bash
+PATH=/usr/local/bin:/usr/bin:/bin
+
+OPENPRECEDENT_DB=__OPENPRECEDENT_ROOT__/runtime/openprecedent.db
+OPENPRECEDENT_COLLECTOR_STATE=__OPENPRECEDENT_ROOT__/runtime/openprecedent-collector-state.json
+OPENCLAW_SESSIONS_ROOT=$HOME/.openclaw/agents/main/sessions
+OPENPRECEDENT_COLLECT_LIMIT=1
+
+*/5 * * * * cd "__OPENPRECEDENT_ROOT__" && ./scripts/run-collector.sh >> "__OPENPRECEDENT_ROOT__/runtime/collector.log" 2>&1

--- a/deploy/systemd/openprecedent-collector.service
+++ b/deploy/systemd/openprecedent-collector.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=OpenPrecedent OpenClaw collector
+After=network.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=__OPENPRECEDENT_ROOT__
+Environment=OPENPRECEDENT_DB=__OPENPRECEDENT_ROOT__/runtime/openprecedent.db
+Environment=OPENPRECEDENT_COLLECTOR_STATE=__OPENPRECEDENT_ROOT__/runtime/openprecedent-collector-state.json
+Environment=OPENCLAW_SESSIONS_ROOT=%h/.openclaw/agents/main/sessions
+Environment=OPENPRECEDENT_COLLECT_LIMIT=1
+ExecStart=__OPENPRECEDENT_ROOT__/scripts/run-collector.sh

--- a/deploy/systemd/openprecedent-collector.timer
+++ b/deploy/systemd/openprecedent-collector.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run OpenPrecedent OpenClaw collector every 5 minutes
+
+[Timer]
+OnCalendar=*:0/5
+Persistent=true
+Unit=openprecedent-collector.service
+
+[Install]
+WantedBy=timers.target

--- a/docs/architecture/openclaw-silent-collection.md
+++ b/docs/architecture/openclaw-silent-collection.md
@@ -68,6 +68,15 @@ This command:
 
 This is the intended MVP path for cron-based silent collection.
 
+Operational assets now live in:
+
+- `scripts/run-collector.sh`
+- `scripts/install-collector-assets.sh`
+- `deploy/systemd/openprecedent-collector.service`
+- `deploy/systemd/openprecedent-collector.timer`
+- `deploy/cron/openprecedent-collector.cron`
+- `docs/engineering/openclaw-collector-operations.md`
+
 ## MVP Boundary
 
 This is an import-based silent collector, not a live hook into OpenClaw internals.

--- a/docs/engineering/openclaw-collector-operations.md
+++ b/docs/engineering/openclaw-collector-operations.md
@@ -1,0 +1,98 @@
+# OpenClaw Collector Operations
+
+## Goal
+
+This document is the operational landing path for the MVP collector.
+
+It covers:
+
+- the local wrapper used by automation
+- the recommended `systemd` timer setup
+- the fallback `cron` setup
+- the evaluation/report command for real collected sessions
+
+## Wrapper Script
+
+Use [`scripts/run-collector.sh`](/workspace/02-projects/incubation/openprecedent/scripts/run-collector.sh) as the single entrypoint for scheduled collection.
+
+Default environment variables:
+
+- `OPENPRECEDENT_DB`
+- `OPENPRECEDENT_COLLECTOR_STATE`
+- `OPENCLAW_SESSIONS_ROOT`
+- `OPENPRECEDENT_COLLECT_LIMIT`
+- `OPENPRECEDENT_AGENT_ID`
+
+The script runs:
+
+```bash
+openprecedent runtime collect-openclaw-sessions --limit 1
+```
+
+against the configured session root and collector state file.
+
+## systemd
+
+Render and install the user units with:
+
+```bash
+./scripts/install-collector-assets.sh systemd
+```
+
+This writes path-resolved unit files into `~/.config/systemd/user/` using the current repository root.
+
+The source templates live at:
+
+- [`deploy/systemd/openprecedent-collector.service`](/workspace/02-projects/incubation/openprecedent/deploy/systemd/openprecedent-collector.service)
+- [`deploy/systemd/openprecedent-collector.timer`](/workspace/02-projects/incubation/openprecedent/deploy/systemd/openprecedent-collector.timer)
+
+Then enable the timer:
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now openprecedent-collector.timer
+systemctl --user list-timers openprecedent-collector.timer
+```
+
+Useful checks:
+
+```bash
+systemctl --user status openprecedent-collector.timer
+journalctl --user -u openprecedent-collector.service -n 50 --no-pager
+```
+
+## cron
+
+If `systemd --user` is unavailable, use the template at
+[`deploy/cron/openprecedent-collector.cron`](/workspace/02-projects/incubation/openprecedent/deploy/cron/openprecedent-collector.cron).
+
+Render a repo-path-aware crontab file with:
+
+```bash
+./scripts/install-collector-assets.sh cron
+crontab runtime/openprecedent-collector.cron
+crontab -l
+```
+
+## Real Session Evaluation
+
+After the collector has imported a few sessions, generate a real-session report with:
+
+```bash
+openprecedent eval collected-openclaw-sessions \
+  --sessions-root "$HOME/.openclaw/agents/main/sessions" \
+  --state-file "$(pwd)/runtime/openprecedent-collector-state.json" \
+  --report-file "$(pwd)/runtime/collected-eval-report.json"
+```
+
+Run this from the repository root so the report reads the same collector state written by the installed wrapper.
+
+This report summarizes:
+
+- how many collected sessions were evaluated
+- completion/failure mix
+- average event and decision counts
+- decision-type distribution
+- whether each case produced file writes, recovery decisions, and usable precedents
+
+Use `--json` for machine-readable output to stdout.

--- a/docs/product/mvp-roadmap.md
+++ b/docs/product/mvp-roadmap.md
@@ -230,12 +230,15 @@ Completed work:
 - session discovery and `--latest` import flow
 - automated collector command with local state cursor for silent collection
 - curated evaluation suite for summary and recovery trajectories
+- operational collector assets for `systemd` / `cron`
+- path-aware installer script for collector scheduling assets
+- collected-session evaluation/report command for real imported sessions
 
 Remaining gaps:
 
 - run the collector on a real schedule in the target machine environment
 - validate replay/extraction/precedent quality on a growing set of real collected sessions
-- document the recommended cron/systemd setup once the collection loop is confirmed
+- keep improving precedent ranking as real history grows
 
 ## Next Tasks
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,3 +1,8 @@
 # Scripts
 
 Utility scripts for local development, setup, migration, and tooling live here.
+
+Notable operational entrypoints:
+
+- `run-collector.sh` runs one collector pass with local-first defaults
+- `install-collector-assets.sh` renders `systemd` / `cron` assets against the current repo path

--- a/scripts/install-collector-assets.sh
+++ b/scripts/install-collector-assets.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MODE="${1:-systemd}"
+
+render_template() {
+  local source_path="$1"
+  local escaped_root
+  escaped_root="$(printf '%s\n' "$ROOT_DIR" | sed 's/[&]/\\&/g')"
+  sed "s|__OPENPRECEDENT_ROOT__|$escaped_root|g" "$source_path"
+}
+
+install_systemd() {
+  local target_dir="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+  mkdir -p "$target_dir"
+
+  render_template "$ROOT_DIR/deploy/systemd/openprecedent-collector.service" \
+    > "$target_dir/openprecedent-collector.service"
+  cp "$ROOT_DIR/deploy/systemd/openprecedent-collector.timer" \
+    "$target_dir/openprecedent-collector.timer"
+
+  cat <<EOF
+Installed:
+- $target_dir/openprecedent-collector.service
+- $target_dir/openprecedent-collector.timer
+
+Next:
+  systemctl --user daemon-reload
+  systemctl --user enable --now openprecedent-collector.timer
+  systemctl --user list-timers openprecedent-collector.timer
+EOF
+}
+
+install_cron() {
+  local target_path="${1:-$ROOT_DIR/runtime/openprecedent-collector.cron}"
+  mkdir -p "$(dirname "$target_path")"
+  render_template "$ROOT_DIR/deploy/cron/openprecedent-collector.cron" > "$target_path"
+
+  cat <<EOF
+Rendered:
+- $target_path
+
+Next:
+  crontab "$target_path"
+  crontab -l
+EOF
+}
+
+case "$MODE" in
+  systemd)
+    install_systemd
+    ;;
+  cron)
+    install_cron "${2:-}"
+    ;;
+  *)
+    echo "usage: $0 [systemd|cron] [cron-output-path]" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/run-collector.sh
+++ b/scripts/run-collector.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+OPENPRECEDENT_BIN="${OPENPRECEDENT_BIN:-openprecedent}"
+OPENPRECEDENT_DB="${OPENPRECEDENT_DB:-$ROOT_DIR/runtime/openprecedent.db}"
+OPENPRECEDENT_COLLECTOR_STATE="${OPENPRECEDENT_COLLECTOR_STATE:-$ROOT_DIR/runtime/openprecedent-collector-state.json}"
+OPENCLAW_SESSIONS_ROOT="${OPENCLAW_SESSIONS_ROOT:-$HOME/.openclaw/agents/main/sessions}"
+OPENPRECEDENT_COLLECT_LIMIT="${OPENPRECEDENT_COLLECT_LIMIT:-1}"
+OPENPRECEDENT_AGENT_ID="${OPENPRECEDENT_AGENT_ID:-openclaw}"
+
+mkdir -p "$(dirname "$OPENPRECEDENT_DB")"
+mkdir -p "$(dirname "$OPENPRECEDENT_COLLECTOR_STATE")"
+
+export OPENPRECEDENT_DB
+export OPENPRECEDENT_COLLECTOR_STATE
+
+exec "$OPENPRECEDENT_BIN" runtime collect-openclaw-sessions \
+  --sessions-root "$OPENCLAW_SESSIONS_ROOT" \
+  --state-file "$OPENPRECEDENT_COLLECTOR_STATE" \
+  --limit "$OPENPRECEDENT_COLLECT_LIMIT" \
+  --agent-id "$OPENPRECEDENT_AGENT_ID"

--- a/src/openprecedent/cli.py
+++ b/src/openprecedent/cli.py
@@ -92,6 +92,14 @@ def build_parser() -> argparse.ArgumentParser:
     eval_fixtures = eval_subparsers.add_parser("fixtures")
     eval_fixtures.add_argument("path")
     eval_fixtures.add_argument("--json", action="store_true", dest="as_json")
+    eval_collected = eval_subparsers.add_parser("collected-openclaw-sessions")
+    eval_collected.add_argument("--sessions-root")
+    eval_collected.add_argument("--state-file")
+    eval_collected.add_argument("--limit", type=int)
+    eval_collected.add_argument("--user-id")
+    eval_collected.add_argument("--agent-id", default="openclaw")
+    eval_collected.add_argument("--report-file")
+    eval_collected.add_argument("--json", action="store_true", dest="as_json")
 
     return parser
 
@@ -329,6 +337,55 @@ def _handle_eval(args: argparse.Namespace, service: OpenPrecedentService) -> int
                 print(
                     "  missing precedents: "
                     + ",".join(result.missing_precedent_case_ids)
+                )
+        return 0
+    if args.action == "collected-openclaw-sessions":
+        report = service.evaluate_collected_openclaw_sessions(
+            _resolve_openclaw_sessions_root(args.sessions_root),
+            state_path=_resolve_collector_state_path(args.state_file),
+            limit=args.limit,
+            user_id=args.user_id,
+            agent_id=args.agent_id,
+        )
+        if args.report_file:
+            report_path = Path(args.report_file)
+            report_path.parent.mkdir(parents=True, exist_ok=True)
+            report_path.write_text(
+                json.dumps(report.model_dump(mode="json"), ensure_ascii=True, indent=2, sort_keys=True),
+                encoding="utf-8",
+            )
+        if args.as_json:
+            _print_json(report.model_dump(mode="json"))
+            return 0
+
+        print(
+            f"Collected evaluation: {report.evaluated_cases} cases, "
+            f"{report.completed_cases} completed, {report.failed_cases} failed"
+        )
+        print(
+            f"Average events={report.average_event_count:.2f}, "
+            f"average decisions={report.average_decision_count:.2f}"
+        )
+        if report.decision_type_counts:
+            print(
+                "Decision types: "
+                + ", ".join(
+                    f"{decision_type}={count}"
+                    for decision_type, count in report.decision_type_counts.items()
+                )
+            )
+        if report.missing_session_ids:
+            print("Missing sessions: " + ",".join(report.missing_session_ids))
+        for result in report.results:
+            print(
+                f"- {result.case_id} status={result.status} "
+                f"events={result.event_count} decisions={result.decision_count} "
+                f"precedents={result.precedent_count}"
+            )
+            if result.top_precedent_case_id is not None:
+                print(
+                    f"  top precedent: {result.top_precedent_case_id} "
+                    f"(score={result.top_precedent_score})"
                 )
         return 0
     return 2

--- a/src/openprecedent/services.py
+++ b/src/openprecedent/services.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import json
 import sqlite3
 import shlex
+import statistics
 from collections import Counter
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+import re
 from uuid import uuid4
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -142,6 +144,44 @@ class EvaluationReport(BaseModel):
     passed_cases: int
     failed_cases: int
     results: list[EvaluationCaseResult]
+
+
+class CollectedSessionEvaluationResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    session_id: str
+    case_id: str
+    title: str
+    transcript_path: str
+    status: str
+    event_count: int
+    decision_count: int
+    precedent_count: int
+    top_precedent_case_id: str | None = None
+    top_precedent_score: int | None = None
+    has_file_write: bool = False
+    has_recovery: bool = False
+    final_summary: str | None = None
+
+
+class CollectedSessionEvaluationReport(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    generated_at: datetime
+    sessions_root: str
+    state_path: str
+    total_sessions: int
+    evaluated_cases: int
+    completed_cases: int
+    failed_cases: int
+    cases_with_precedents: int
+    cases_with_file_writes: int
+    cases_with_recovery: int
+    average_event_count: float
+    average_decision_count: float
+    decision_type_counts: dict[str, int]
+    missing_session_ids: list[str] = Field(default_factory=list)
+    results: list[CollectedSessionEvaluationResult]
 
 
 @dataclass
@@ -440,6 +480,90 @@ class OpenPrecedentService:
             results=results,
         )
 
+    def evaluate_collected_openclaw_sessions(
+        self,
+        sessions_root: Path,
+        *,
+        state_path: Path,
+        limit: int | None = None,
+        user_id: str | None = None,
+        agent_id: str = "openclaw",
+    ) -> CollectedSessionEvaluationReport:
+        state = self._load_openclaw_collection_state(state_path)
+        imported_session_ids = set(state.imported_session_ids)
+        references = self.list_openclaw_sessions(sessions_root, limit=max(len(imported_session_ids), 1_000))
+        selected_references = [item for item in references if item.session_id in imported_session_ids]
+        if limit is not None:
+            selected_references = selected_references[:limit]
+
+        decision_type_counts: Counter[str] = Counter()
+        results: list[CollectedSessionEvaluationResult] = []
+        missing_session_ids: list[str] = []
+
+        for reference in selected_references:
+            case_id = _case_id_for_openclaw_session(reference.session_id)
+            case = self.store.get_case(case_id)
+            if case is None:
+                import_result = self.import_openclaw_session(
+                    Path(reference.transcript_path),
+                    case_id=case_id,
+                    title=reference.label or f"OpenClaw session {reference.session_id}",
+                    user_id=user_id,
+                    agent_id=agent_id,
+                )
+                case = import_result.case
+
+            events = self.list_events(case_id)
+            decisions = self.extract_decisions(case_id)
+            precedents = self.find_precedents(case_id, limit=3)
+            decision_type_counts.update(decision.decision_type.value for decision in decisions)
+
+            results.append(
+                CollectedSessionEvaluationResult(
+                    session_id=reference.session_id,
+                    case_id=case_id,
+                    title=case.title,
+                    transcript_path=reference.transcript_path,
+                    status=case.status.value,
+                    event_count=len(events),
+                    decision_count=len(decisions),
+                    precedent_count=len(precedents),
+                    top_precedent_case_id=precedents[0].case_id if precedents else None,
+                    top_precedent_score=precedents[0].similarity_score if precedents else None,
+                    has_file_write=any(event.event_type == EventType.FILE_WRITE for event in events),
+                    has_recovery=any(
+                        decision.decision_type == DecisionType.RETRY_OR_RECOVER
+                        for decision in decisions
+                    ),
+                    final_summary=case.final_summary,
+                )
+            )
+
+        selected_session_ids = {item.session_id for item in selected_references}
+        for session_id in state.imported_session_ids:
+            if session_id not in selected_session_ids:
+                missing_session_ids.append(session_id)
+
+        event_counts = [item.event_count for item in results]
+        decision_counts = [item.decision_count for item in results]
+        return CollectedSessionEvaluationReport(
+            generated_at=datetime.now(UTC),
+            sessions_root=str(sessions_root),
+            state_path=str(state_path),
+            total_sessions=len(state.imported_session_ids) if limit is None else len(selected_references),
+            evaluated_cases=len(results),
+            completed_cases=sum(1 for item in results if item.status == CaseStatus.COMPLETED.value),
+            failed_cases=sum(1 for item in results if item.status == CaseStatus.FAILED.value),
+            cases_with_precedents=sum(1 for item in results if item.precedent_count > 0),
+            cases_with_file_writes=sum(1 for item in results if item.has_file_write),
+            cases_with_recovery=sum(1 for item in results if item.has_recovery),
+            average_event_count=statistics.fmean(event_counts) if event_counts else 0.0,
+            average_decision_count=statistics.fmean(decision_counts) if decision_counts else 0.0,
+            decision_type_counts=dict(sorted(decision_type_counts.items())),
+            missing_session_ids=missing_session_ids,
+            results=results,
+        )
+
     def list_events(self, case_id: str) -> list[Event]:
         case = self.store.get_case(case_id)
         if case is None:
@@ -677,11 +801,29 @@ class OpenPrecedentService:
     def _fingerprint(self, case: Case, events: list[Event], decisions: list[Decision]) -> dict[str, object]:
         event_types = Counter(event.event_type.value for event in events)
         decision_types = Counter(decision.decision_type.value for decision in decisions)
+        tool_names = sorted(
+            {
+                tool_name
+                for event in events
+                if (tool_name := _string_or_none(event.payload.get("tool_name"))) is not None
+            }
+        )
+        file_paths = sorted(
+            {
+                Path(path).name
+                for event in events
+                if (path := _string_or_none(event.payload.get("path"))) is not None
+            }
+        )
+        keywords = sorted(self._case_keywords(case, events, decisions))
         return {
             "status": case.status.value,
             "has_file_write": event_types[EventType.FILE_WRITE.value] > 0,
             "has_recovery": decision_types[DecisionType.RETRY_OR_RECOVER.value] > 0,
             "tool_count": event_types[EventType.TOOL_CALLED.value],
+            "tool_names": tool_names,
+            "file_paths": file_paths,
+            "keywords": keywords,
             "decision_types": dict(decision_types),
         }
 
@@ -707,7 +849,14 @@ class OpenPrecedentService:
             score += 3
             similarities.append("same decision shape")
         else:
-            differences.append("different decision shape")
+            current_decision_keys = set(current_decisions)
+            other_decision_keys = set(other_decisions)
+            shared_decisions = sorted(current_decision_keys & other_decision_keys)
+            if shared_decisions:
+                score += min(len(shared_decisions), 3)
+                similarities.append("shared decision types: " + ",".join(shared_decisions))
+            else:
+                differences.append("different decision shape")
 
         tool_delta = abs(int(current["tool_count"]) - int(other["tool_count"]))
         if tool_delta == 0:
@@ -719,7 +868,48 @@ class OpenPrecedentService:
         else:
             differences.append("different tool call count")
 
+        shared_tools = sorted(set(current["tool_names"]) & set(other["tool_names"]))
+        if shared_tools:
+            score += min(len(shared_tools), 2)
+            similarities.append("shared tools: " + ",".join(shared_tools[:3]))
+        else:
+            differences.append("different tools")
+
+        shared_paths = sorted(set(current["file_paths"]) & set(other["file_paths"]))
+        if shared_paths:
+            score += min(len(shared_paths), 2)
+            similarities.append("shared file targets: " + ",".join(shared_paths[:3]))
+
+        shared_keywords = sorted(set(current["keywords"]) & set(other["keywords"]))
+        if shared_keywords:
+            score += min(len(shared_keywords), 4)
+            similarities.append("shared keywords: " + ",".join(shared_keywords[:4]))
+        else:
+            differences.append("different task keywords")
+
         return score, similarities or ["similar case structure"], differences
+
+    def _case_keywords(self, case: Case, events: list[Event], decisions: list[Decision]) -> set[str]:
+        texts: list[str] = [case.title]
+        if case.final_summary:
+            texts.append(case.final_summary)
+
+        for event in events:
+            for key in ("message", "path", "tool_name", "command"):
+                value = _string_or_none(event.payload.get(key))
+                if value:
+                    texts.append(value)
+
+        for decision in decisions:
+            texts.append(decision.title)
+            texts.append(decision.chosen_action)
+            if decision.outcome:
+                texts.append(decision.outcome)
+
+        keywords: set[str] = set()
+        for text in texts:
+            keywords.update(_tokenize_keywords(text))
+        return keywords
 
     def _build_reusable_takeaway(self, case: Case, decisions: list[Decision]) -> str | None:
         if decisions:
@@ -1108,6 +1298,24 @@ def _parse_epoch_millis(value: object) -> datetime | None:
     return None
 
 
+def _tokenize_keywords(text: str) -> set[str]:
+    tokens = {
+        item
+        for item in re.findall(r"[a-z0-9_./-]+", text.lower())
+        if len(item) >= 3 and item not in _STOP_WORDS
+    }
+    expanded: set[str] = set()
+    for token in tokens:
+        expanded.add(token)
+        if "/" in token or "." in token or "-" in token or "_" in token:
+            expanded.update(
+                part
+                for part in re.split(r"[/._-]+", token)
+                if len(part) >= 3 and part not in _STOP_WORDS
+            )
+    return expanded
+
+
 def _extract_openclaw_text_segments(content: list[object]) -> list[str]:
     segments: list[str] = []
     for item in content:
@@ -1279,6 +1487,28 @@ def _normalize_openclaw_tool_result_events(
             },
         )
     ]
+
+
+_STOP_WORDS = {
+    "the",
+    "and",
+    "for",
+    "with",
+    "that",
+    "this",
+    "from",
+    "into",
+    "will",
+    "then",
+    "case",
+    "openclaw",
+    "session",
+    "docs",
+    "file",
+    "tool",
+    "command",
+    "agent",
+}
 
 
 def _case_id_for_openclaw_session(session_id: str) -> str:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,10 +1,13 @@
+import json
 import httpx
 import pytest
 from pathlib import Path
 
 from openprecedent.api import app
 from openprecedent.services import OpenPrecedentService
+from openprecedent.services import AppendEventInput, CreateCaseInput
 from openprecedent.config import get_db_path
+from openprecedent.schemas import EventActor, EventType
 
 
 async def _client() -> httpx.AsyncClient:
@@ -337,3 +340,123 @@ def test_service_evaluates_fixture_suite(db_path) -> None:
     assert report.total_cases == 3
     assert report.failed_cases == 0
     assert report.passed_cases == 3
+
+
+def test_service_evaluates_collected_openclaw_sessions(db_path, tmp_path: Path) -> None:
+    service = OpenPrecedentService.from_path(get_db_path())
+    fixture_dir = Path(__file__).parent / "fixtures" / "openclaw_sessions"
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    for name in ("sample-session.jsonl", "failing-command-session.jsonl"):
+        (sessions_dir / name).write_text(
+            (fixture_dir / name).read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+    (sessions_dir / "sessions.json").write_text(
+        json.dumps(
+            [
+                {
+                    "sessionId": "sample-session",
+                    "sessionFile": str(sessions_dir / "sample-session.jsonl"),
+                    "updatedAt": 1741497000000,
+                    "label": "User session: summarize context graph",
+                },
+                {
+                    "sessionId": "failing-command-session",
+                    "sessionFile": str(sessions_dir / "failing-command-session.jsonl"),
+                    "updatedAt": 1741498000000,
+                    "label": "User session: failing command",
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+    state_path = tmp_path / "collector-state.json"
+    state_path.write_text(
+        json.dumps(
+            {
+                "imported_session_ids": [
+                    "failing-command-session",
+                    "sample-session",
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    report = service.evaluate_collected_openclaw_sessions(
+        sessions_dir,
+        state_path=state_path,
+        user_id="u1",
+    )
+
+    assert report.total_sessions == 2
+    assert report.evaluated_cases == 2
+    assert report.failed_cases == 0
+    assert report.cases_with_precedents >= 1
+    assert "retry_or_recover" in report.decision_type_counts
+    assert {item.session_id for item in report.results} == {
+        "sample-session",
+        "failing-command-session",
+    }
+    failing_result = next(item for item in report.results if item.session_id == "failing-command-session")
+    assert failing_result.has_recovery is True
+
+
+def test_service_precedent_prefers_semantically_related_case(db_path) -> None:
+    service = OpenPrecedentService.from_path(get_db_path())
+
+    cases = [
+        (
+            "case_semantic_current",
+            "Summarize roadmap docs",
+            [
+                ("message.user", "user", {"message": "Summarize the roadmap docs and collection guidance"}),
+                ("message.agent", "agent", {"message": "I will inspect the roadmap docs and summarize them."}),
+                ("tool.called", "agent", {"tool_name": "rg", "reason": "search roadmap docs"}),
+                ("file.write", "agent", {"path": "docs/roadmap-summary.md", "summary": "wrote roadmap summary"}),
+                ("case.completed", "system", {"summary": "roadmap summary delivered"}),
+            ],
+        ),
+        (
+            "case_semantic_related",
+            "Summarize collection docs",
+            [
+                ("message.user", "user", {"message": "Summarize the collection docs for OpenClaw"}),
+                ("message.agent", "agent", {"message": "I will inspect collection docs and summarize them."}),
+                ("tool.called", "agent", {"tool_name": "rg", "reason": "search collection docs"}),
+                ("file.write", "agent", {"path": "docs/collection-summary.md", "summary": "wrote collection summary"}),
+                ("case.completed", "system", {"summary": "collection summary delivered"}),
+            ],
+        ),
+        (
+            "case_semantic_irrelevant",
+            "Fix failing tests",
+            [
+                ("message.user", "user", {"message": "Fix the failing pytest suite"}),
+                ("message.agent", "agent", {"message": "I will inspect the failing tests and patch them."}),
+                ("tool.called", "agent", {"tool_name": "pytest", "reason": "run test suite"}),
+                ("file.write", "agent", {"path": "tests/test_cli.py", "summary": "fixed failing tests"}),
+                ("case.completed", "system", {"summary": "tests fixed"}),
+            ],
+        ),
+    ]
+
+    for case_id, title, events in cases:
+        service.create_case(CreateCaseInput(case_id=case_id, title=title))
+        for index, (event_type, actor, payload) in enumerate(events, start=1):
+            service.append_event(
+                case_id,
+                AppendEventInput(
+                    event_type=EventType(event_type),
+                    actor=EventActor(actor),
+                    payload=payload,
+                    sequence_no=index,
+                ),
+            )
+        service.extract_decisions(case_id)
+
+    precedents = service.find_precedents("case_semantic_current", limit=2)
+    assert len(precedents) == 2
+    assert precedents[0].case_id == "case_semantic_related"
+    assert precedents[0].similarity_score > precedents[1].similarity_score

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -455,3 +455,66 @@ def test_cli_evaluates_fixture_suite(capsys, db_path) -> None:
     assert report["total_cases"] == 3
     assert report["failed_cases"] == 0
     assert report["passed_cases"] == 3
+
+
+def test_cli_evaluates_collected_openclaw_sessions(capsys, db_path, tmp_path: Path) -> None:
+    fixture_dir = Path(__file__).parent / "fixtures" / "openclaw_sessions"
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    for name in ("sample-session.jsonl", "failing-command-session.jsonl"):
+        (sessions_dir / name).write_text(
+            (fixture_dir / name).read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+    (sessions_dir / "sessions.json").write_text(
+        json.dumps(
+            [
+                {
+                    "sessionId": "sample-session",
+                    "sessionFile": str(sessions_dir / "sample-session.jsonl"),
+                    "updatedAt": 1741497000000,
+                    "label": "User session: summarize context graph",
+                },
+                {
+                    "sessionId": "failing-command-session",
+                    "sessionFile": str(sessions_dir / "failing-command-session.jsonl"),
+                    "updatedAt": 1741498000000,
+                    "label": "User session: failing command",
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+    state_path = tmp_path / "collector-state.json"
+    state_path.write_text(
+        json.dumps(
+            {
+                "imported_session_ids": [
+                    "failing-command-session",
+                    "sample-session",
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    report_path = tmp_path / "collected-report.json"
+
+    result = main(
+        [
+            "eval",
+            "collected-openclaw-sessions",
+            "--sessions-root",
+            str(sessions_dir),
+            "--state-file",
+            str(state_path),
+            "--report-file",
+            str(report_path),
+            "--json",
+        ]
+    )
+    assert result == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["total_sessions"] == 2
+    assert report["evaluated_cases"] == 2
+    assert "retry_or_recover" in report["decision_type_counts"]
+    assert report_path.exists()


### PR DESCRIPTION
This change expands OpenClaw capture coverage and adds the first local collector assets needed to gather session material without broadening the project scope beyond decision capture and replay.

The immediate user impact is that read-only command activity is mapped more completely into the event model, collected session examples are available for evaluation, and operators now have documented scripts plus service definitions to install and run the collector on a local host. That reduces the amount of missing context during capture and makes the local-first collection loop more reproducible.

The root cause behind the gap was twofold. First, the command mapping covered only a narrower subset of safe read operations, which meant parts of an agent session could be omitted from the captured timeline even when they were relevant to later replay and explanation. Second, there was no packaged path for installing or scheduling the collector assets, so even with the runtime support in place the operational setup remained ad hoc.

The fix extends the OpenClaw read-only command mapping in the runtime and CLI surface, adds collector scripts and systemd or cron assets for local deployment, updates the operational and architecture documentation to match the new flow, and includes a collected session fixture plus API and CLI tests to lock in the behavior.

Validation for this branch is covered by the added automated tests in the API and CLI suites, along with the committed documentation and fixture updates that describe and exercise the collector workflow.
