### PR TITLE
Report unsupported OpenClaw session record types

### DIFF
--- a/docs/engineering/openclaw-collector-operations.md
+++ b/docs/engineering/openclaw-collector-operations.md
@@ -93,6 +93,7 @@ This report summarizes:
 - completion/failure mix
 - average event and decision counts
 - decision-type distribution
+- unsupported OpenClaw session record types that were skipped
 - whether each case produced file writes, recovery decisions, and usable precedents
 
 Use `--json` for machine-readable output to stdout.

--- a/src/openprecedent/cli.py
+++ b/src/openprecedent/cli.py
@@ -286,6 +286,7 @@ def _handle_runtime(args: argparse.Namespace, service: OpenPrecedentService) -> 
                 "case": result.case.model_dump(mode="json"),
                 "transcript_path": str(transcript_path),
                 "imported_event_count": len(result.imported_events),
+                "unsupported_record_type_counts": result.unsupported_record_type_counts,
                 "events": [event.model_dump(mode="json") for event in result.imported_events],
             }
         )
@@ -374,6 +375,14 @@ def _handle_eval(args: argparse.Namespace, service: OpenPrecedentService) -> int
                     for decision_type, count in report.decision_type_counts.items()
                 )
             )
+        if report.unsupported_record_type_counts:
+            print(
+                "Unsupported record types: "
+                + ", ".join(
+                    f"{record_type}={count}"
+                    for record_type, count in report.unsupported_record_type_counts.items()
+                )
+            )
         if report.missing_session_ids:
             print("Missing sessions: " + ",".join(report.missing_session_ids))
         for result in report.results:
@@ -382,6 +391,14 @@ def _handle_eval(args: argparse.Namespace, service: OpenPrecedentService) -> int
                 f"events={result.event_count} decisions={result.decision_count} "
                 f"precedents={result.precedent_count}"
             )
+            if result.unsupported_record_type_counts:
+                print(
+                    "  unsupported record types: "
+                    + ", ".join(
+                        f"{record_type}={count}"
+                        for record_type, count in result.unsupported_record_type_counts.items()
+                    )
+                )
             if result.top_precedent_case_id is not None:
                 print(
                     f"  top precedent: {result.top_precedent_case_id} "

--- a/src/openprecedent/services.py
+++ b/src/openprecedent/services.py
@@ -69,6 +69,7 @@ class RuntimeTraceImportResult(BaseModel):
 
     case: Case
     imported_events: list[Event]
+    unsupported_record_type_counts: dict[str, int] = Field(default_factory=dict)
 
 
 class OpenClawSessionReference(BaseModel):
@@ -97,6 +98,7 @@ class CollectedSessionResult(BaseModel):
     case_id: str
     title: str
     imported_event_count: int
+    unsupported_record_type_counts: dict[str, int] = Field(default_factory=dict)
 
 
 class OpenClawCollectionResult(BaseModel):
@@ -162,6 +164,7 @@ class CollectedSessionEvaluationResult(BaseModel):
     has_file_write: bool = False
     has_recovery: bool = False
     final_summary: str | None = None
+    unsupported_record_type_counts: dict[str, int] = Field(default_factory=dict)
 
 
 class CollectedSessionEvaluationReport(BaseModel):
@@ -180,6 +183,7 @@ class CollectedSessionEvaluationReport(BaseModel):
     average_event_count: float
     average_decision_count: float
     decision_type_counts: dict[str, int]
+    unsupported_record_type_counts: dict[str, int] = Field(default_factory=dict)
     missing_session_ids: list[str] = Field(default_factory=list)
     results: list[CollectedSessionEvaluationResult]
 
@@ -357,21 +361,28 @@ class OpenPrecedentService:
             )
 
         imported: list[Event] = []
+        unsupported_record_type_counts: Counter[str] = Counter()
         with transcript_path.open("r", encoding="utf-8") as handle:
             for line_no, line in enumerate(handle, start=1):
                 stripped = line.strip()
                 if not stripped:
                     continue
                 raw_item = json.loads(stripped)
-                normalized_events = self._normalize_openclaw_session_line(
+                normalized_events, unsupported_record_type = self._normalize_openclaw_session_line(
                     raw_item,
                     line_no,
                     transcript_path=transcript_path,
                 )
+                if unsupported_record_type is not None:
+                    unsupported_record_type_counts[unsupported_record_type] += 1
                 for normalized in normalized_events:
                     imported.append(self.append_event(case_id, normalized))
 
-        return RuntimeTraceImportResult(case=case, imported_events=imported)
+        return RuntimeTraceImportResult(
+            case=case,
+            imported_events=imported,
+            unsupported_record_type_counts=dict(sorted(unsupported_record_type_counts.items())),
+        )
 
     def collect_openclaw_sessions(
         self,
@@ -407,6 +418,7 @@ class OpenPrecedentService:
                     case_id=result.case.case_id,
                     title=result.case.title,
                     imported_event_count=len(result.imported_events),
+                    unsupported_record_type_counts=result.unsupported_record_type_counts,
                 )
             )
             seen.add(reference.session_id)
@@ -497,6 +509,7 @@ class OpenPrecedentService:
             selected_references = selected_references[:limit]
 
         decision_type_counts: Counter[str] = Counter()
+        unsupported_record_type_counts: Counter[str] = Counter()
         results: list[CollectedSessionEvaluationResult] = []
         missing_session_ids: list[str] = []
 
@@ -512,11 +525,20 @@ class OpenPrecedentService:
                     agent_id=agent_id,
                 )
                 case = import_result.case
+            else:
+                import_result = RuntimeTraceImportResult(
+                    case=case,
+                    imported_events=[],
+                    unsupported_record_type_counts=self._summarize_unsupported_openclaw_session_record_types(
+                        Path(reference.transcript_path)
+                    ),
+                )
 
             events = self.list_events(case_id)
             decisions = self.extract_decisions(case_id)
             precedents = self.find_precedents(case_id, limit=3)
             decision_type_counts.update(decision.decision_type.value for decision in decisions)
+            unsupported_record_type_counts.update(import_result.unsupported_record_type_counts)
 
             results.append(
                 CollectedSessionEvaluationResult(
@@ -536,6 +558,7 @@ class OpenPrecedentService:
                         for decision in decisions
                     ),
                     final_summary=case.final_summary,
+                    unsupported_record_type_counts=import_result.unsupported_record_type_counts,
                 )
             )
 
@@ -560,6 +583,7 @@ class OpenPrecedentService:
             average_event_count=statistics.fmean(event_counts) if event_counts else 0.0,
             average_decision_count=statistics.fmean(decision_counts) if decision_counts else 0.0,
             decision_type_counts=dict(sorted(decision_type_counts.items())),
+            unsupported_record_type_counts=dict(sorted(unsupported_record_type_counts.items())),
             missing_session_ids=missing_session_ids,
             results=results,
         )
@@ -1094,7 +1118,7 @@ class OpenPrecedentService:
         line_no: int,
         *,
         transcript_path: Path,
-    ) -> list[AppendEventInput]:
+    ) -> tuple[list[AppendEventInput], str | None]:
         record_type = raw_item.get("type")
         if not isinstance(record_type, str) or not record_type:
             raise ValueError(f"line {line_no}: type is required for openclaw session import")
@@ -1104,7 +1128,7 @@ class OpenPrecedentService:
         parent_id = _string_or_none(raw_item.get("parentId"))
 
         if record_type == "session":
-            return [
+            return ([
                 AppendEventInput(
                     event_id=f"evt_session_{record_id}",
                     event_type=EventType.CASE_STARTED,
@@ -1118,10 +1142,10 @@ class OpenPrecedentService:
                         "source": "openclaw.session",
                     },
                 )
-            ]
+            ], None)
 
         if record_type == "model_change":
-            return [
+            return ([
                 AppendEventInput(
                     event_id=f"evt_model_{record_id}",
                     event_type=EventType.MODEL_COMPLETED,
@@ -1134,14 +1158,14 @@ class OpenPrecedentService:
                         "source": "openclaw.session",
                     },
                 )
-            ]
+            ], None)
 
         if record_type != "message":
-            return []
+            return [], record_type
 
         message = raw_item.get("message")
         if not isinstance(message, dict):
-            return []
+            return [], None
 
         role = _string_or_none(message.get("role"))
         content = message.get("content")
@@ -1167,7 +1191,7 @@ class OpenPrecedentService:
                         },
                     )
                 )
-            return normalized_events
+            return normalized_events, None
 
         if role == "assistant":
             visible_chunks = _extract_openclaw_visible_assistant_text(content)
@@ -1221,7 +1245,7 @@ class OpenPrecedentService:
                         arguments=arguments,
                     )
                 )
-            return normalized_events
+            return normalized_events, None
 
         if role == "toolResult":
             text = "\n".join(text_chunks).strip()
@@ -1253,9 +1277,29 @@ class OpenPrecedentService:
                     details=message.get("details") if isinstance(message.get("details"), dict) else {},
                 )
             )
-            return normalized_events
+            return normalized_events, None
 
-        return []
+        return [], None
+
+    def _summarize_unsupported_openclaw_session_record_types(
+        self,
+        transcript_path: Path,
+    ) -> dict[str, int]:
+        unsupported_record_type_counts: Counter[str] = Counter()
+        with transcript_path.open("r", encoding="utf-8") as handle:
+            for line_no, line in enumerate(handle, start=1):
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                raw_item = json.loads(stripped)
+                _, unsupported_record_type = self._normalize_openclaw_session_line(
+                    raw_item,
+                    line_no,
+                    transcript_path=transcript_path,
+                )
+                if unsupported_record_type is not None:
+                    unsupported_record_type_counts[unsupported_record_type] += 1
+        return dict(sorted(unsupported_record_type_counts.items()))
 
     def _load_openclaw_collection_state(self, state_path: Path) -> OpenClawCollectionState:
         if not state_path.exists():

--- a/tests/fixtures/openclaw_sessions/unsupported-record-session.jsonl
+++ b/tests/fixtures/openclaw_sessions/unsupported-record-session.jsonl
@@ -1,0 +1,5 @@
+{"type":"session","version":3,"id":"unsupported-record-session","timestamp":"2026-03-09T06:00:00.000Z","cwd":"/root/.openclaw/workspace"}
+{"type":"model_change","id":"unsupported-model-1","parentId":null,"timestamp":"2026-03-09T06:00:00.001Z","provider":"openai-codex","modelId":"gpt-5.3-codex"}
+{"type":"checkpoint","id":"unsupported-checkpoint-1","parentId":"unsupported-model-1","timestamp":"2026-03-09T06:00:00.002Z","status":"saved"}
+{"type":"message","id":"unsupported-msg-user","parentId":"unsupported-model-1","timestamp":"2026-03-09T06:00:01.000Z","message":{"role":"user","content":[{"type":"text","text":"Summarize the roadmap."}]}}
+{"type":"message","id":"unsupported-msg-assistant","parentId":"unsupported-msg-user","timestamp":"2026-03-09T06:00:02.000Z","message":{"role":"assistant","content":[{"type":"text","text":"I will summarize the roadmap."}]}}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -215,6 +215,24 @@ def test_service_imports_failing_openclaw_command_without_output(db_path) -> Non
     assert any(item.decision_type.value == "retry_or_recover" for item in decisions)
 
 
+def test_service_reports_unsupported_openclaw_session_record_types(db_path) -> None:
+    service = OpenPrecedentService.from_path(get_db_path())
+    transcript_path = (
+        Path(__file__).parent / "fixtures" / "openclaw_sessions" / "unsupported-record-session.jsonl"
+    )
+
+    result = service.import_openclaw_session(
+        transcript_path,
+        case_id="case_session_unsupported_record",
+        title="Imported OpenClaw session with unsupported record",
+        user_id="u1",
+    )
+
+    assert result.case.case_id == "case_session_unsupported_record"
+    assert len(result.imported_events) == 4
+    assert result.unsupported_record_type_counts == {"checkpoint": 1}
+
+
 def test_service_imports_openclaw_file_operations(db_path) -> None:
     service = OpenPrecedentService.from_path(get_db_path())
     transcript_path = Path(__file__).parent / "fixtures" / "openclaw_sessions" / "file-ops-session.jsonl"
@@ -347,7 +365,11 @@ def test_service_evaluates_collected_openclaw_sessions(db_path, tmp_path: Path) 
     fixture_dir = Path(__file__).parent / "fixtures" / "openclaw_sessions"
     sessions_dir = tmp_path / "sessions"
     sessions_dir.mkdir()
-    for name in ("sample-session.jsonl", "failing-command-session.jsonl"):
+    for name in (
+        "sample-session.jsonl",
+        "failing-command-session.jsonl",
+        "unsupported-record-session.jsonl",
+    ):
         (sessions_dir / name).write_text(
             (fixture_dir / name).read_text(encoding="utf-8"),
             encoding="utf-8",
@@ -367,6 +389,12 @@ def test_service_evaluates_collected_openclaw_sessions(db_path, tmp_path: Path) 
                     "updatedAt": 1741498000000,
                     "label": "User session: failing command",
                 },
+                {
+                    "sessionId": "unsupported-record-session",
+                    "sessionFile": str(sessions_dir / "unsupported-record-session.jsonl"),
+                    "updatedAt": 1741499000000,
+                    "label": "User session: unsupported record",
+                },
             ]
         ),
         encoding="utf-8",
@@ -378,6 +406,7 @@ def test_service_evaluates_collected_openclaw_sessions(db_path, tmp_path: Path) 
                 "imported_session_ids": [
                     "failing-command-session",
                     "sample-session",
+                    "unsupported-record-session",
                 ]
             }
         ),
@@ -390,17 +419,21 @@ def test_service_evaluates_collected_openclaw_sessions(db_path, tmp_path: Path) 
         user_id="u1",
     )
 
-    assert report.total_sessions == 2
-    assert report.evaluated_cases == 2
+    assert report.total_sessions == 3
+    assert report.evaluated_cases == 3
     assert report.failed_cases == 0
     assert report.cases_with_precedents >= 1
     assert "retry_or_recover" in report.decision_type_counts
+    assert report.unsupported_record_type_counts == {"checkpoint": 1}
     assert {item.session_id for item in report.results} == {
         "sample-session",
         "failing-command-session",
+        "unsupported-record-session",
     }
     failing_result = next(item for item in report.results if item.session_id == "failing-command-session")
     assert failing_result.has_recovery is True
+    unsupported_result = next(item for item in report.results if item.session_id == "unsupported-record-session")
+    assert unsupported_result.unsupported_record_type_counts == {"checkpoint": 1}
 
 
 def test_service_precedent_prefers_semantically_related_case(db_path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -331,6 +331,28 @@ def test_cli_imports_openclaw_file_operations(capsys, db_path) -> None:
     )
 
 
+def test_cli_reports_unsupported_openclaw_session_record_types(capsys, db_path) -> None:
+    fixture_path = (
+        Path(__file__).parent / "fixtures" / "openclaw_sessions" / "unsupported-record-session.jsonl"
+    )
+
+    result = main(
+        [
+            "runtime",
+            "import-openclaw-session",
+            "--session-file",
+            str(fixture_path),
+            "--case-id",
+            "case_session_unsupported_record_cli",
+        ]
+    )
+    assert result == 0
+    imported = json.loads(capsys.readouterr().out)
+    assert imported["case"]["case_id"] == "case_session_unsupported_record_cli"
+    assert imported["imported_event_count"] == 4
+    assert imported["unsupported_record_type_counts"] == {"checkpoint": 1}
+
+
 def test_cli_imports_openclaw_view_image_as_file_read(capsys, db_path) -> None:
     fixture_path = (
         Path(__file__).parent / "fixtures" / "openclaw_sessions" / "view-image-session.jsonl"
@@ -461,7 +483,11 @@ def test_cli_evaluates_collected_openclaw_sessions(capsys, db_path, tmp_path: Pa
     fixture_dir = Path(__file__).parent / "fixtures" / "openclaw_sessions"
     sessions_dir = tmp_path / "sessions"
     sessions_dir.mkdir()
-    for name in ("sample-session.jsonl", "failing-command-session.jsonl"):
+    for name in (
+        "sample-session.jsonl",
+        "failing-command-session.jsonl",
+        "unsupported-record-session.jsonl",
+    ):
         (sessions_dir / name).write_text(
             (fixture_dir / name).read_text(encoding="utf-8"),
             encoding="utf-8",
@@ -481,6 +507,12 @@ def test_cli_evaluates_collected_openclaw_sessions(capsys, db_path, tmp_path: Pa
                     "updatedAt": 1741498000000,
                     "label": "User session: failing command",
                 },
+                {
+                    "sessionId": "unsupported-record-session",
+                    "sessionFile": str(sessions_dir / "unsupported-record-session.jsonl"),
+                    "updatedAt": 1741499000000,
+                    "label": "User session: unsupported record",
+                },
             ]
         ),
         encoding="utf-8",
@@ -492,6 +524,7 @@ def test_cli_evaluates_collected_openclaw_sessions(capsys, db_path, tmp_path: Pa
                 "imported_session_ids": [
                     "failing-command-session",
                     "sample-session",
+                    "unsupported-record-session",
                 ]
             }
         ),
@@ -514,7 +547,52 @@ def test_cli_evaluates_collected_openclaw_sessions(capsys, db_path, tmp_path: Pa
     )
     assert result == 0
     report = json.loads(capsys.readouterr().out)
-    assert report["total_sessions"] == 2
-    assert report["evaluated_cases"] == 2
+    assert report["total_sessions"] == 3
+    assert report["evaluated_cases"] == 3
     assert "retry_or_recover" in report["decision_type_counts"]
+    assert report["unsupported_record_type_counts"] == {"checkpoint": 1}
     assert report_path.exists()
+
+
+def test_cli_renders_unsupported_record_type_summary_for_collected_sessions(capsys, db_path, tmp_path: Path) -> None:
+    fixture_dir = Path(__file__).parent / "fixtures" / "openclaw_sessions"
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    name = "unsupported-record-session.jsonl"
+    (sessions_dir / name).write_text(
+        (fixture_dir / name).read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    (sessions_dir / "sessions.json").write_text(
+        json.dumps(
+            [
+                {
+                    "sessionId": "unsupported-record-session",
+                    "sessionFile": str(sessions_dir / name),
+                    "updatedAt": 1741499000000,
+                    "label": "User session: unsupported record",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    state_path = tmp_path / "collector-state.json"
+    state_path.write_text(
+        json.dumps({"imported_session_ids": ["unsupported-record-session"]}),
+        encoding="utf-8",
+    )
+
+    result = main(
+        [
+            "eval",
+            "collected-openclaw-sessions",
+            "--sessions-root",
+            str(sessions_dir),
+            "--state-file",
+            str(state_path),
+        ]
+    )
+    assert result == 0
+    rendered = capsys.readouterr().out
+    assert "Unsupported record types: checkpoint=1" in rendered
+    assert "unsupported record types: checkpoint=1" in rendered


### PR DESCRIPTION
Closes #24

This change makes unsupported OpenClaw session record types visible during session import and collected-session evaluation instead of silently discarding them with no operator feedback.

The service layer now tracks skipped record types while importing session transcripts and carries those counts through collection and evaluation responses. The CLI surfaces the counts in both JSON output and human-readable collected-session evaluation output so the next mapping work can be driven by observed frequency rather than code inspection.

The change also adds a focused unsupported-record fixture and regression coverage for service and CLI behavior, and updates the collector operations doc to note that skipped record types are included in evaluation output.

Validation:
- `.venv/bin/python -m pytest tests/test_api.py tests/test_cli.py`
