### PR TITLE
Map OpenClaw checkpoint session records

### DIFF
--- a/docs/architecture/mvp-design.md
+++ b/docs/architecture/mvp-design.md
@@ -33,6 +33,7 @@ A retrieval result linking current work to historically similar cases.
 ## MVP Event Types
 
 - `case.started`
+- `checkpoint.saved`
 - `message.user`
 - `message.agent`
 - `model.invoked`

--- a/docs/architecture/openclaw-silent-collection.md
+++ b/docs/architecture/openclaw-silent-collection.md
@@ -30,6 +30,7 @@ OpenPrecedent imports two artifacts from the OpenClaw session directory:
 The current importer maps transcript records into OpenPrecedent events as follows:
 
 - `type=session` -> `case.started`
+- `type=checkpoint` -> `checkpoint.saved`
 - `type=model_change` -> `model.completed`
 - `message.role=user` -> `message.user`
 - `message.role=assistant` text/summary -> `message.agent`

--- a/src/openprecedent/schemas/event.py
+++ b/src/openprecedent/schemas/event.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 class EventType(StrEnum):
     CASE_STARTED = "case.started"
+    CHECKPOINT_SAVED = "checkpoint.saved"
     MESSAGE_USER = "message.user"
     MESSAGE_AGENT = "message.agent"
     MODEL_INVOKED = "model.invoked"

--- a/src/openprecedent/services.py
+++ b/src/openprecedent/services.py
@@ -1144,6 +1144,22 @@ class OpenPrecedentService:
                 )
             ], None)
 
+        if record_type == "checkpoint":
+            return ([
+                AppendEventInput(
+                    event_id=f"evt_checkpoint_{record_id}",
+                    event_type=EventType.CHECKPOINT_SAVED,
+                    actor=EventActor.SYSTEM,
+                    timestamp=timestamp,
+                    parent_event_id=parent_id,
+                    payload={
+                        "checkpoint_id": _string_or_default(raw_item.get("id"), record_id),
+                        "status": _string_or_none(raw_item.get("status")),
+                        "source": "openclaw.session",
+                    },
+                )
+            ], None)
+
         if record_type == "model_change":
             return ([
                 AppendEventInput(

--- a/tests/fixtures/openclaw_sessions/checkpoint-session.jsonl
+++ b/tests/fixtures/openclaw_sessions/checkpoint-session.jsonl
@@ -1,0 +1,5 @@
+{"type":"session","version":3,"id":"checkpoint-session","timestamp":"2026-03-09T06:10:00.000Z","cwd":"/root/.openclaw/workspace"}
+{"type":"model_change","id":"checkpoint-model-1","parentId":null,"timestamp":"2026-03-09T06:10:00.001Z","provider":"openai-codex","modelId":"gpt-5.3-codex"}
+{"type":"checkpoint","id":"checkpoint-record-1","parentId":"checkpoint-model-1","timestamp":"2026-03-09T06:10:00.002Z","status":"saved"}
+{"type":"message","id":"checkpoint-msg-user","parentId":"checkpoint-model-1","timestamp":"2026-03-09T06:10:01.000Z","message":{"role":"user","content":[{"type":"text","text":"Summarize the roadmap."}]}}
+{"type":"message","id":"checkpoint-msg-assistant","parentId":"checkpoint-msg-user","timestamp":"2026-03-09T06:10:02.000Z","message":{"role":"assistant","content":[{"type":"text","text":"I will summarize the roadmap."}]}}

--- a/tests/fixtures/openclaw_sessions/unsupported-record-session.jsonl
+++ b/tests/fixtures/openclaw_sessions/unsupported-record-session.jsonl
@@ -1,5 +1,5 @@
 {"type":"session","version":3,"id":"unsupported-record-session","timestamp":"2026-03-09T06:00:00.000Z","cwd":"/root/.openclaw/workspace"}
 {"type":"model_change","id":"unsupported-model-1","parentId":null,"timestamp":"2026-03-09T06:00:00.001Z","provider":"openai-codex","modelId":"gpt-5.3-codex"}
-{"type":"checkpoint","id":"unsupported-checkpoint-1","parentId":"unsupported-model-1","timestamp":"2026-03-09T06:00:00.002Z","status":"saved"}
+{"type":"audit_marker","id":"unsupported-audit-marker-1","parentId":"unsupported-model-1","timestamp":"2026-03-09T06:00:00.002Z","status":"saved"}
 {"type":"message","id":"unsupported-msg-user","parentId":"unsupported-model-1","timestamp":"2026-03-09T06:00:01.000Z","message":{"role":"user","content":[{"type":"text","text":"Summarize the roadmap."}]}}
 {"type":"message","id":"unsupported-msg-assistant","parentId":"unsupported-msg-user","timestamp":"2026-03-09T06:00:02.000Z","message":{"role":"assistant","content":[{"type":"text","text":"I will summarize the roadmap."}]}}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -230,7 +230,31 @@ def test_service_reports_unsupported_openclaw_session_record_types(db_path) -> N
 
     assert result.case.case_id == "case_session_unsupported_record"
     assert len(result.imported_events) == 4
-    assert result.unsupported_record_type_counts == {"checkpoint": 1}
+    assert result.unsupported_record_type_counts == {"audit_marker": 1}
+
+
+def test_service_imports_openclaw_checkpoint_record_as_event(db_path) -> None:
+    service = OpenPrecedentService.from_path(get_db_path())
+    transcript_path = (
+        Path(__file__).parent / "fixtures" / "openclaw_sessions" / "checkpoint-session.jsonl"
+    )
+
+    result = service.import_openclaw_session(
+        transcript_path,
+        case_id="case_session_checkpoint",
+        title="Imported OpenClaw checkpoint session",
+        user_id="u1",
+    )
+
+    assert result.case.case_id == "case_session_checkpoint"
+    assert len(result.imported_events) == 5
+    assert result.unsupported_record_type_counts == {}
+
+    events = service.list_events("case_session_checkpoint")
+    checkpoint_events = [event for event in events if event.event_type.value == "checkpoint.saved"]
+    assert len(checkpoint_events) == 1
+    assert checkpoint_events[0].payload["checkpoint_id"] == "checkpoint-record-1"
+    assert checkpoint_events[0].payload["status"] == "saved"
 
 
 def test_service_imports_openclaw_file_operations(db_path) -> None:
@@ -424,7 +448,7 @@ def test_service_evaluates_collected_openclaw_sessions(db_path, tmp_path: Path) 
     assert report.failed_cases == 0
     assert report.cases_with_precedents >= 1
     assert "retry_or_recover" in report.decision_type_counts
-    assert report.unsupported_record_type_counts == {"checkpoint": 1}
+    assert report.unsupported_record_type_counts == {"audit_marker": 1}
     assert {item.session_id for item in report.results} == {
         "sample-session",
         "failing-command-session",
@@ -433,7 +457,7 @@ def test_service_evaluates_collected_openclaw_sessions(db_path, tmp_path: Path) 
     failing_result = next(item for item in report.results if item.session_id == "failing-command-session")
     assert failing_result.has_recovery is True
     unsupported_result = next(item for item in report.results if item.session_id == "unsupported-record-session")
-    assert unsupported_result.unsupported_record_type_counts == {"checkpoint": 1}
+    assert unsupported_result.unsupported_record_type_counts == {"audit_marker": 1}
 
 
 def test_service_precedent_prefers_semantically_related_case(db_path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -350,7 +350,37 @@ def test_cli_reports_unsupported_openclaw_session_record_types(capsys, db_path) 
     imported = json.loads(capsys.readouterr().out)
     assert imported["case"]["case_id"] == "case_session_unsupported_record_cli"
     assert imported["imported_event_count"] == 4
-    assert imported["unsupported_record_type_counts"] == {"checkpoint": 1}
+    assert imported["unsupported_record_type_counts"] == {"audit_marker": 1}
+
+
+def test_cli_imports_openclaw_checkpoint_record_as_event(capsys, db_path) -> None:
+    fixture_path = (
+        Path(__file__).parent / "fixtures" / "openclaw_sessions" / "checkpoint-session.jsonl"
+    )
+
+    result = main(
+        [
+            "runtime",
+            "import-openclaw-session",
+            "--session-file",
+            str(fixture_path),
+            "--case-id",
+            "case_session_checkpoint_cli",
+        ]
+    )
+    assert result == 0
+    imported = json.loads(capsys.readouterr().out)
+    assert imported["case"]["case_id"] == "case_session_checkpoint_cli"
+    assert imported["imported_event_count"] == 5
+    assert imported["unsupported_record_type_counts"] == {}
+
+    result = main(["replay", "case", "case_session_checkpoint_cli", "--json"])
+    assert result == 0
+    replay = json.loads(capsys.readouterr().out)
+    checkpoint_events = [event for event in replay["events"] if event["event_type"] == "checkpoint.saved"]
+    assert len(checkpoint_events) == 1
+    assert checkpoint_events[0]["payload"]["checkpoint_id"] == "checkpoint-record-1"
+    assert checkpoint_events[0]["payload"]["status"] == "saved"
 
 
 def test_cli_imports_openclaw_view_image_as_file_read(capsys, db_path) -> None:
@@ -550,7 +580,7 @@ def test_cli_evaluates_collected_openclaw_sessions(capsys, db_path, tmp_path: Pa
     assert report["total_sessions"] == 3
     assert report["evaluated_cases"] == 3
     assert "retry_or_recover" in report["decision_type_counts"]
-    assert report["unsupported_record_type_counts"] == {"checkpoint": 1}
+    assert report["unsupported_record_type_counts"] == {"audit_marker": 1}
     assert report_path.exists()
 
 
@@ -594,5 +624,5 @@ def test_cli_renders_unsupported_record_type_summary_for_collected_sessions(caps
     )
     assert result == 0
     rendered = capsys.readouterr().out
-    assert "Unsupported record types: checkpoint=1" in rendered
-    assert "unsupported record types: checkpoint=1" in rendered
+    assert "Unsupported record types: audit_marker=1" in rendered
+    assert "unsupported record types: audit_marker=1" in rendered


### PR DESCRIPTION
Closes #25

This change maps OpenClaw `type=checkpoint` session records into a stable raw event instead of leaving them in the unsupported-record bucket.

The importer now emits `checkpoint.saved` events with checkpoint id and status in the payload, so replay output keeps that trajectory detail instead of dropping it. The existing unsupported-record reporting from #24 is preserved by keeping a separate truly unknown record fixture in the regression suite.

The change updates the event schema and session-mapping docs, adds a dedicated checkpoint fixture, and extends the API and CLI regression coverage for both checkpoint mapping and unsupported-record reporting.

Validation:
- `.venv/bin/python -m pytest tests/test_api.py tests/test_cli.py`
