### PR TITLE
Add a Codex-native ccpm workflow

### DIFF
--- a/.codex/skills/ccpm-codex/SKILL.md
+++ b/.codex/skills/ccpm-codex/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: ccpm-codex
+description: Use when work should follow a spec-to-epic-to-issue GitHub workflow inside this repository using Codex instead of Claude Code. Provides a project-local equivalent of ccpm for PRDs, epics, task files, issue bodies, PR bodies, next-task selection, and issue-scoped execution.
+---
+
+# CCPM For Codex
+
+Use this skill for project-management work in this repository when the task involves PRDs, epics, task decomposition, GitHub issue creation, issue-driven execution, or PR body generation.
+
+## Workflow
+
+1. Initialize the local PM workspace if `.codex/pm/` is missing:
+   - `python3 -m openprecedent.codex_pm init`
+2. Create or update the planning documents:
+   - PRD: `python3 -m openprecedent.codex_pm prd-new <slug> --title "<title>"`
+   - Epic: `python3 -m openprecedent.codex_pm epic-new <slug> --title "<title>" --prd <prd-slug>`
+   - Task: `python3 -m openprecedent.codex_pm task-new <epic> <slug> --title "<title>" --issue <n> --labels feature,test`
+3. Treat each task file as the local twin of one GitHub issue.
+4. Keep task status in sync with the branch and PR state:
+   - start work: `set-status ... in_progress`
+   - blocked: `blocked ... --reason "..."`
+   - merged: `set-status ... done`
+5. Generate GitHub text from the task file instead of rewriting it each time:
+   - issue body: `python3 -m openprecedent.codex_pm issue-body <task-path>`
+   - PR body: `python3 -m openprecedent.codex_pm pr-body <task-path> --issue <n> --tests "..."`
+6. Pick the next local task with:
+   - `python3 -m openprecedent.codex_pm next`
+
+## Repository Rules
+
+- One issue per branch.
+- One issue per PR.
+- Always branch from the latest `upstream/main`.
+- Use `Closes #<issue>` in the PR body.
+- Do not append commits to a branch whose PR has already been merged.
+
+## Read Next
+
+- Command mapping and command equivalents: `references/command-map.md`
+- File model and local PM directory layout: `references/file-model.md`

--- a/.codex/skills/ccpm-codex/references/command-map.md
+++ b/.codex/skills/ccpm-codex/references/command-map.md
@@ -1,0 +1,50 @@
+# Command Map
+
+This skill ports the ccpm command model into Codex-friendly local commands.
+
+## Core Planning
+
+- `/pm:init`
+  - Codex equivalent: `python3 -m openprecedent.codex_pm init`
+- `/pm:prd-new`
+  - Codex equivalent: `python3 -m openprecedent.codex_pm prd-new <slug> --title "<title>"`
+- `/pm:epic-new`
+  - Codex equivalent: `python3 -m openprecedent.codex_pm epic-new <slug> --title "<title>" --prd <prd-slug>`
+- `/pm:task-new`
+  - Codex equivalent: `python3 -m openprecedent.codex_pm task-new <epic> <slug> --title "<title>" --issue <n> --labels feature,test`
+
+## Execution Flow
+
+- `/pm:next`
+  - Codex equivalent: `python3 -m openprecedent.codex_pm next`
+- `/pm:issue-start`
+  - Codex equivalent:
+    1. `python3 -m openprecedent.codex_pm set-status <task-path> in_progress`
+    2. create a new branch from `upstream/main`
+    3. start implementation for that issue only
+- `/pm:blocked`
+  - Codex equivalent: `python3 -m openprecedent.codex_pm blocked <task-path> --reason "<reason>"`
+- `/pm:done`
+  - Codex equivalent: `python3 -m openprecedent.codex_pm set-status <task-path> done`
+
+## Sync Helpers
+
+- `/pm:issue-sync`
+  - Codex equivalent: regenerate the issue body from the task file:
+    `python3 -m openprecedent.codex_pm issue-body <task-path>`
+- `/pm:pr-body`
+  - Codex equivalent:
+    `python3 -m openprecedent.codex_pm pr-body <task-path> --issue <n> --tests "<cmd>"`
+- `/pm:standup`
+  - Codex equivalent: `python3 -m openprecedent.codex_pm standup`
+
+## GitHub Usage
+
+Pair the local commands with `gh`:
+
+- create issue:
+  - `gh issue create --body-file <(python3 -m openprecedent.codex_pm issue-body <task-path>) ...`
+- create PR:
+  - `gh pr create --body-file <(python3 -m openprecedent.codex_pm pr-body <task-path> --issue <n> --tests "...") ...`
+
+If process substitution is inconvenient, redirect output to a temp file first.

--- a/.codex/skills/ccpm-codex/references/file-model.md
+++ b/.codex/skills/ccpm-codex/references/file-model.md
@@ -1,0 +1,68 @@
+# File Model
+
+The local Codex PM workspace lives under `.codex/pm/`.
+
+## Layout
+
+```text
+.codex/
+  skills/
+    ccpm-codex/
+      SKILL.md
+      references/
+  pm/
+    prds/
+    epics/
+    tasks/
+    context/
+    updates/
+```
+
+## Document Types
+
+### PRD
+
+- path: `.codex/pm/prds/<slug>.md`
+- frontmatter keys:
+  - `type: prd`
+  - `slug`
+  - `title`
+  - `status`
+
+### Epic
+
+- path: `.codex/pm/epics/<slug>.md`
+- frontmatter keys:
+  - `type: epic`
+  - `slug`
+  - `title`
+  - `status`
+  - `prd`
+
+### Task
+
+- path: `.codex/pm/tasks/<epic>/<slug>.md`
+- frontmatter keys:
+  - `type: task`
+  - `epic`
+  - `slug`
+  - `title`
+  - `status`
+  - `issue`
+  - `labels`
+  - `depends_on`
+  - `status_reason`
+
+## Status Values
+
+- `backlog`
+- `in_progress`
+- `blocked`
+- `done`
+
+## Conventions
+
+- Keep one task file aligned with one GitHub issue.
+- Keep one issue aligned with one branch and one PR.
+- Use the task file as the canonical source for issue and PR body text.
+- Use `context/` and `updates/` only for local supporting notes, not for replacing GitHub issue state.

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ coverage/
 
 # Local review notes
 .codex-review
+.codex/pm/context/
+.codex/pm/updates/
 
 # Build
 build/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,11 @@ The first implementation target is a local single-agent workflow. The current go
 - Link the PR to its issue in the PR body using a closing reference such as `Closes #24` so the issue is closed automatically when the PR is merged.
 - After a PR is merged, continue the next task on a new branch and a new PR linked to the next issue.
 
+## Project-Local Codex Skill
+
+- For project-management work in this repository, use the local skill at `.codex/skills/ccpm-codex/`.
+- Use it for PRD, epic, task, issue, and PR workflow management instead of inventing an ad hoc process each time.
+
 ## Documentation Rules
 
 - Update docs when schemas, APIs, or core object models change.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
 
 [project.scripts]
 openprecedent = "openprecedent.cli:run"
+openprecedent-pm = "openprecedent.codex_pm:run"
 
 [dependency-groups]
 dev = [

--- a/src/openprecedent/codex_pm.py
+++ b/src/openprecedent/codex_pm.py
@@ -1,0 +1,390 @@
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+
+PM_ROOT = Path(".codex/pm")
+VALID_STATUSES = ("backlog", "in_progress", "blocked", "done")
+
+
+@dataclass
+class PMDocument:
+    path: Path
+    metadata: dict[str, str]
+    sections: dict[str, str]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="openprecedent-pm")
+    subparsers = parser.add_subparsers(dest="action", required=True)
+
+    subparsers.add_parser("init")
+
+    prd_new = subparsers.add_parser("prd-new")
+    prd_new.add_argument("slug")
+    prd_new.add_argument("--title", required=True)
+
+    epic_new = subparsers.add_parser("epic-new")
+    epic_new.add_argument("slug")
+    epic_new.add_argument("--title", required=True)
+    epic_new.add_argument("--prd")
+
+    task_new = subparsers.add_parser("task-new")
+    task_new.add_argument("epic")
+    task_new.add_argument("slug")
+    task_new.add_argument("--title", required=True)
+    task_new.add_argument("--issue")
+    task_new.add_argument("--labels", default="")
+    task_new.add_argument("--status", default="backlog", choices=VALID_STATUSES)
+    task_new.add_argument("--depends-on", default="")
+
+    tasks = subparsers.add_parser("tasks")
+    tasks.add_argument("--status")
+    tasks.add_argument("--epic")
+    tasks.add_argument("--json", action="store_true", dest="as_json")
+
+    next_task = subparsers.add_parser("next")
+    next_task.add_argument("--epic")
+    next_task.add_argument("--json", action="store_true", dest="as_json")
+
+    set_status = subparsers.add_parser("set-status")
+    set_status.add_argument("path")
+    set_status.add_argument("status", choices=VALID_STATUSES)
+    set_status.add_argument("--reason", default="")
+
+    blocked = subparsers.add_parser("blocked")
+    blocked.add_argument("path")
+    blocked.add_argument("--reason", required=True)
+
+    subparsers.add_parser("standup").add_argument("--json", action="store_true", dest="as_json")
+
+    issue_body = subparsers.add_parser("issue-body")
+    issue_body.add_argument("path")
+
+    pr_body = subparsers.add_parser("pr-body")
+    pr_body.add_argument("path")
+    pr_body.add_argument("--issue", type=int)
+    pr_body.add_argument("--tests", action="append", default=[])
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.action == "init":
+        _init_pm()
+        return 0
+    if args.action == "prd-new":
+        _init_pm()
+        path = PM_ROOT / "prds" / f"{args.slug}.md"
+        _write_document(
+            path,
+            metadata={
+                "type": "prd",
+                "slug": args.slug,
+                "title": args.title,
+                "status": "draft",
+            },
+            sections={
+                "Summary": "",
+                "Problem": "",
+                "Goals": "- ",
+                "Non-Goals": "- ",
+                "Success Criteria": "- ",
+                "Dependencies": "- ",
+            },
+        )
+        print(path)
+        return 0
+    if args.action == "epic-new":
+        _init_pm()
+        path = PM_ROOT / "epics" / f"{args.slug}.md"
+        metadata = {
+            "type": "epic",
+            "slug": args.slug,
+            "title": args.title,
+            "status": "backlog",
+        }
+        if args.prd:
+            metadata["prd"] = args.prd
+        _write_document(
+            path,
+            metadata=metadata,
+            sections={
+                "Outcome": "",
+                "Scope": "- ",
+                "Acceptance Criteria": "- ",
+                "Child Issues": "- ",
+                "Notes": "",
+            },
+        )
+        print(path)
+        return 0
+    if args.action == "task-new":
+        _init_pm()
+        path = PM_ROOT / "tasks" / args.epic / f"{args.slug}.md"
+        metadata = {
+            "type": "task",
+            "epic": args.epic,
+            "slug": args.slug,
+            "title": args.title,
+            "status": args.status,
+            "labels": args.labels,
+            "depends_on": args.depends_on,
+        }
+        if args.issue:
+            metadata["issue"] = args.issue
+        _write_document(
+            path,
+            metadata=metadata,
+            sections={
+                "Context": "",
+                "Deliverable": "",
+                "Scope": "- ",
+                "Acceptance Criteria": "- ",
+                "Validation": "- ",
+                "Implementation Notes": "",
+            },
+        )
+        print(path)
+        return 0
+    if args.action == "tasks":
+        documents = _load_tasks(status=args.status, epic=args.epic)
+        return _print_tasks(documents, args.as_json)
+    if args.action == "next":
+        documents = _load_tasks(status=None, epic=args.epic)
+        candidates = [document for document in documents if document.metadata.get("status") == "backlog"]
+        if not candidates:
+            if args.as_json:
+                print("null")
+            else:
+                print("No backlog task found.")
+            return 0
+        next_document = _sort_tasks(candidates)[0]
+        if args.as_json:
+            print(json.dumps(_doc_to_dict(next_document), ensure_ascii=True, indent=2, sort_keys=True))
+        else:
+            print(next_document.path)
+        return 0
+    if args.action == "set-status":
+        document = _read_document(Path(args.path))
+        document.metadata["status"] = args.status
+        if args.reason:
+            document.metadata["status_reason"] = args.reason
+        _persist_document(document)
+        print(document.path)
+        return 0
+    if args.action == "blocked":
+        document = _read_document(Path(args.path))
+        document.metadata["status"] = "blocked"
+        document.metadata["status_reason"] = args.reason
+        _persist_document(document)
+        print(document.path)
+        return 0
+    if args.action == "standup":
+        documents = _load_tasks()
+        summary = {
+            "backlog": [],
+            "in_progress": [],
+            "blocked": [],
+            "done": [],
+        }
+        for document in _sort_tasks(documents):
+            summary[document.metadata.get("status", "backlog")].append(_doc_to_dict(document))
+        if args.as_json:
+            print(json.dumps(summary, ensure_ascii=True, indent=2, sort_keys=True))
+        else:
+            for status in VALID_STATUSES:
+                print(f"{status}: {len(summary[status])}")
+                for item in summary[status]:
+                    print(f"  - {item['title']} ({item['path']})")
+        return 0
+    if args.action == "issue-body":
+        document = _read_document(Path(args.path))
+        print(_render_issue_body(document))
+        return 0
+    if args.action == "pr-body":
+        document = _read_document(Path(args.path))
+        print(_render_pr_body(document, issue=args.issue, tests=args.tests))
+        return 0
+
+    parser.error("unknown action")
+    return 2
+
+
+def run() -> None:
+    raise SystemExit(main())
+
+
+def _init_pm() -> None:
+    for name in ("prds", "epics", "tasks", "context", "updates"):
+        (PM_ROOT / name).mkdir(parents=True, exist_ok=True)
+
+
+def _write_document(path: Path, *, metadata: dict[str, str], sections: dict[str, str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    document = PMDocument(path=path, metadata=metadata, sections=sections)
+    _persist_document(document)
+
+
+def _persist_document(document: PMDocument) -> None:
+    lines = ["---"]
+    for key, value in document.metadata.items():
+        if value:
+            lines.append(f"{key}: {value}")
+    lines.append("---")
+    lines.append("")
+    lines.append(f"# {document.metadata.get('title', document.path.stem)}")
+    lines.append("")
+    for heading, body in document.sections.items():
+        lines.append(f"## {heading}")
+        lines.append("")
+        if body:
+            lines.extend(body.rstrip().splitlines())
+        lines.append("")
+    document.path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def _read_document(path: Path) -> PMDocument:
+    text = path.read_text(encoding="utf-8")
+    metadata: dict[str, str] = {}
+    sections: dict[str, str] = {}
+
+    if not text.startswith("---\n"):
+        raise ValueError(f"document missing frontmatter: {path}")
+    _, remainder = text.split("---\n", 1)
+    frontmatter, body = remainder.split("---\n", 1)
+    for line in frontmatter.strip().splitlines():
+        if not line.strip():
+            continue
+        key, _, value = line.partition(":")
+        metadata[key.strip()] = value.strip()
+
+    current_heading: str | None = None
+    current_lines: list[str] = []
+    for line in body.splitlines():
+        if line.startswith("## "):
+            if current_heading is not None:
+                sections[current_heading] = "\n".join(current_lines).strip()
+            current_heading = line[3:].strip()
+            current_lines = []
+            continue
+        if line.startswith("# "):
+            continue
+        if current_heading is not None:
+            current_lines.append(line)
+    if current_heading is not None:
+        sections[current_heading] = "\n".join(current_lines).strip()
+
+    return PMDocument(path=path, metadata=metadata, sections=sections)
+
+
+def _load_tasks(*, status: str | None = None, epic: str | None = None) -> list[PMDocument]:
+    base = PM_ROOT / "tasks"
+    if not base.exists():
+        return []
+    documents: list[PMDocument] = []
+    for path in sorted(base.glob("*/*.md")):
+        document = _read_document(path)
+        if status and document.metadata.get("status") != status:
+            continue
+        if epic and document.metadata.get("epic") != epic:
+            continue
+        documents.append(document)
+    return _sort_tasks(documents)
+
+
+def _sort_tasks(documents: list[PMDocument]) -> list[PMDocument]:
+    return sorted(
+        documents,
+        key=lambda item: (
+            item.metadata.get("epic", ""),
+            _status_rank(item.metadata.get("status", "backlog")),
+            int(item.metadata.get("issue", "999999")) if item.metadata.get("issue", "").isdigit() else 999999,
+            item.metadata.get("title", ""),
+            str(item.path),
+        ),
+    )
+
+
+def _status_rank(status: str) -> int:
+    try:
+        return VALID_STATUSES.index(status)
+    except ValueError:
+        return len(VALID_STATUSES)
+
+
+def _doc_to_dict(document: PMDocument) -> dict[str, object]:
+    return {
+        "path": str(document.path),
+        "title": document.metadata.get("title", ""),
+        "status": document.metadata.get("status", ""),
+        "epic": document.metadata.get("epic", ""),
+        "issue": document.metadata.get("issue"),
+        "labels": [item for item in document.metadata.get("labels", "").split(",") if item],
+    }
+
+
+def _print_tasks(documents: list[PMDocument], as_json: bool) -> int:
+    if as_json:
+        print(json.dumps([_doc_to_dict(document) for document in documents], ensure_ascii=True, indent=2, sort_keys=True))
+        return 0
+    for document in documents:
+        issue = document.metadata.get("issue")
+        issue_suffix = f" issue=#{issue}" if issue else ""
+        print(f"{document.path} status={document.metadata.get('status', 'backlog')}{issue_suffix}")
+    return 0
+
+
+def _render_issue_body(document: PMDocument) -> str:
+    lines = []
+    context = document.sections.get("Context", "")
+    deliverable = document.sections.get("Deliverable", "")
+    scope = document.sections.get("Scope", "")
+    acceptance = document.sections.get("Acceptance Criteria", "")
+
+    if context:
+        lines.extend(["## Context", context, ""])
+    if deliverable:
+        lines.extend(["## Deliverable", deliverable, ""])
+    if scope:
+        lines.extend(["## Scope", scope, ""])
+    if acceptance:
+        lines.extend(["## Acceptance Criteria", acceptance, ""])
+    labels = document.metadata.get("labels", "")
+    if labels:
+        lines.extend(["## Labels", labels, ""])
+    return "\n".join(lines).rstrip()
+
+
+def _render_pr_body(document: PMDocument, *, issue: int | None, tests: list[str]) -> str:
+    lines: list[str] = []
+    closing_issue = issue or _parse_issue_number(document.metadata.get("issue", ""))
+    if closing_issue is not None:
+        lines.extend([f"Closes #{closing_issue}", ""])
+    deliverable = document.sections.get("Deliverable", "")
+    implementation_notes = document.sections.get("Implementation Notes", "")
+    validation = document.sections.get("Validation", "")
+    if deliverable:
+        lines.extend([deliverable, ""])
+    if implementation_notes:
+        lines.extend(["Implementation notes:", implementation_notes, ""])
+    if validation or tests:
+        lines.append("Validation:")
+        if validation:
+            lines.extend(validation.splitlines())
+        for test in tests:
+            lines.append(f"- `{test}`")
+    return "\n".join(lines).rstrip()
+
+
+def _parse_issue_number(value: str) -> int | None:
+    if value.isdigit():
+        return int(value)
+    return None
+

--- a/tests/test_codex_pm.py
+++ b/tests/test_codex_pm.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from openprecedent.codex_pm import main
+
+
+def test_codex_pm_init_creates_workspace(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    result = main(["init"])
+
+    assert result == 0
+    assert (tmp_path / ".codex" / "pm" / "prds").exists()
+    assert (tmp_path / ".codex" / "pm" / "epics").exists()
+    assert (tmp_path / ".codex" / "pm" / "tasks").exists()
+
+
+def test_codex_pm_scaffolds_and_selects_next_task(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    assert main(["init"]) == 0
+    capsys.readouterr()
+    assert main(["prd-new", "runtime-validation", "--title", "Runtime validation"]) == 0
+    capsys.readouterr()
+    assert (
+        main(
+            [
+                "epic-new",
+                "runtime-validation",
+                "--title",
+                "Runtime validation",
+                "--prd",
+                "runtime-validation",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+    assert (
+        main(
+            [
+                "task-new",
+                "runtime-validation",
+                "collector-rollout",
+                "--title",
+                "Roll out collector",
+                "--issue",
+                "23",
+                "--labels",
+                "feature,ops",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+    assert (
+        main(
+            [
+                "task-new",
+                "runtime-validation",
+                "quality-pass",
+                "--title",
+                "Inspect collected session quality",
+                "--issue",
+                "26",
+                "--status",
+                "done",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    assert main(["next", "--json"]) == 0
+    next_task = json.loads(capsys.readouterr().out)
+    assert next_task["title"] == "Roll out collector"
+    assert next_task["issue"] == "23"
+
+    assert main(["tasks", "--json"]) == 0
+    tasks = json.loads(capsys.readouterr().out)
+    assert len(tasks) == 2
+
+
+def test_codex_pm_updates_status_and_renders_issue_and_pr_body(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    task_path = tmp_path / ".codex" / "pm" / "tasks" / "runtime-validation" / "collector-rollout.md"
+    assert main(["init"]) == 0
+    capsys.readouterr()
+    assert (
+        main(
+            [
+                "task-new",
+                "runtime-validation",
+                "collector-rollout",
+                "--title",
+                "Roll out collector",
+                "--issue",
+                "23",
+                "--labels",
+                "feature,ops",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    task_text = task_path.read_text(encoding="utf-8")
+    task_text = task_text.replace("## Context\n\n", "## Context\n\nCollector rollout still needs a real target host.\n\n")
+    task_text = task_text.replace("## Deliverable\n\n", "## Deliverable\n\nRun the collector on a real schedule.\n\n")
+    task_text = task_text.replace("## Scope\n\n- \n\n", "## Scope\n\n- install the scheduled collector\n- validate cursor advance\n\n")
+    task_text = task_text.replace(
+        "## Acceptance Criteria\n\n- \n\n",
+        "## Acceptance Criteria\n\n- repeated runs do not duplicate sessions\n\n",
+    )
+    task_text = task_text.replace(
+        "## Validation\n\n- \n\n",
+        "## Validation\n\n- .venv/bin/python -m pytest tests/test_api.py tests/test_cli.py\n\n",
+    )
+    task_text = task_text.replace(
+        "## Implementation Notes\n\n",
+        "## Implementation Notes\n\nUse the systemd timer path for the first rollout.\n\n",
+    )
+    task_path.write_text(task_text, encoding="utf-8")
+
+    assert main(["blocked", str(task_path), "--reason", "waiting on host access"]) == 0
+    capsys.readouterr()
+    assert main(["set-status", str(task_path), "in_progress"]) == 0
+    capsys.readouterr()
+
+    assert main(["issue-body", str(task_path)]) == 0
+    issue_body = capsys.readouterr().out
+    assert "## Context" in issue_body
+    assert "Collector rollout still needs a real target host." in issue_body
+    assert "## Acceptance Criteria" in issue_body
+
+    assert (
+        main(
+            [
+                "pr-body",
+                str(task_path),
+                "--issue",
+                "23",
+                "--tests",
+                ".venv/bin/python -m pytest tests/test_api.py tests/test_cli.py",
+            ]
+        )
+        == 0
+    )
+    pr_body = capsys.readouterr().out
+    assert "Closes #23" in pr_body
+    assert "Run the collector on a real schedule." in pr_body
+    assert "Validation:" in pr_body


### PR DESCRIPTION
Closes #33

This change ports the ccpm workflow into OpenPrecedent as a project-local Codex capability instead of leaving it as an external reference or a loosely copied process.

The migration has three layers:
- a repository-local Codex skill under `.codex/skills/ccpm-codex/` that documents the workflow and maps ccpm concepts into Codex usage
- a new `openprecedent.codex_pm` CLI and `openprecedent-pm` entrypoint that scaffolds PRDs, epics, and tasks, tracks task status, selects the next backlog task, and renders issue and PR bodies from local task files
- repository rule updates so future agents know to use the local skill and the local PM workspace instead of inventing ad hoc issue and PR flows

This keeps the current GitHub issue-driven model but makes it much closer to ccpm: spec documents, epic and task decomposition, local task state, reusable issue and PR body generation, and deterministic next-task selection all live inside the repository.

Validation:
- `.venv/bin/python -m pytest tests/test_codex_pm.py tests/test_api.py tests/test_cli.py`
