### PR TITLE
Add a real-session evaluation fixture suite

### DIFF
--- a/.codex/pm/tasks/real-history-quality/anonymized-real-session-fixtures.md
+++ b/.codex/pm/tasks/real-history-quality/anonymized-real-session-fixtures.md
@@ -3,7 +3,7 @@ type: task
 epic: real-history-quality
 slug: anonymized-real-session-fixtures
 title: Add anonymized real-session fixtures to the evaluation suite
-status: backlog
+status: in_progress
 labels: feature,test
 issue: 26
 ---

--- a/src/openprecedent/services.py
+++ b/src/openprecedent/services.py
@@ -115,6 +115,7 @@ class EvaluationCaseSpec(BaseModel):
     case_id: str
     title: str
     trace_path: str
+    source_format: str = "openclaw_trace"
     expected_decision_types: list[DecisionType]
     expected_precedent_case_ids: list[str] = Field(default_factory=list)
 
@@ -440,11 +441,22 @@ class OpenPrecedentService:
         imported_case_ids: list[str] = []
         for case_spec in suite.cases:
             trace_path = (base_dir / case_spec.trace_path).resolve()
-            self.import_openclaw_jsonl(
-                trace_path,
-                case_id=case_spec.case_id,
-                title=case_spec.title,
-            )
+            if case_spec.source_format == "openclaw_trace":
+                self.import_openclaw_jsonl(
+                    trace_path,
+                    case_id=case_spec.case_id,
+                    title=case_spec.title,
+                )
+            elif case_spec.source_format == "openclaw_session":
+                self.import_openclaw_session(
+                    trace_path,
+                    case_id=case_spec.case_id,
+                    title=case_spec.title,
+                )
+            else:
+                raise ValueError(
+                    f"unsupported evaluation source_format '{case_spec.source_format}'"
+                )
             self.extract_decisions(case_spec.case_id)
             imported_case_ids.append(case_spec.case_id)
 

--- a/tests/fixtures/evaluation/real_session_suite.json
+++ b/tests/fixtures/evaluation/real_session_suite.json
@@ -1,0 +1,28 @@
+{
+  "cases": [
+    {
+      "case_id": "eval_real_file_ops",
+      "title": "Anonymized real session file ops",
+      "trace_path": "../openclaw_sessions/file-ops-session.jsonl",
+      "source_format": "openclaw_session",
+      "expected_decision_types": ["plan", "select_tool", "apply_change"],
+      "expected_precedent_case_ids": ["eval_real_search_read"]
+    },
+    {
+      "case_id": "eval_real_search_read",
+      "title": "Anonymized real session search read",
+      "trace_path": "../openclaw_sessions/search-read-session.jsonl",
+      "source_format": "openclaw_session",
+      "expected_decision_types": ["plan", "select_tool"],
+      "expected_precedent_case_ids": ["eval_real_file_ops"]
+    },
+    {
+      "case_id": "eval_real_clarify",
+      "title": "Anonymized real session clarify",
+      "trace_path": "../openclaw_sessions/clarify-session.jsonl",
+      "source_format": "openclaw_session",
+      "expected_decision_types": ["plan", "clarify", "select_tool"],
+      "expected_precedent_case_ids": ["eval_real_search_read"]
+    }
+  ]
+}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -408,6 +408,19 @@ def test_service_evaluates_fixture_suite(db_path) -> None:
     assert report.passed_cases == 3
 
 
+def test_service_evaluates_real_session_fixture_suite(db_path) -> None:
+    service = OpenPrecedentService.from_path(get_db_path())
+    suite_path = Path(__file__).parent / "fixtures" / "evaluation" / "real_session_suite.json"
+
+    report = service.evaluate_openclaw_fixture_suite(suite_path)
+
+    assert report.total_cases == 3
+    assert report.failed_cases == 0
+    assert report.passed_cases == 3
+    clarify_result = next(item for item in report.results if item.case_id == "eval_real_clarify")
+    assert "clarify" in [decision_type.value for decision_type in clarify_result.actual_decision_types]
+
+
 def test_service_evaluates_collected_openclaw_sessions(db_path, tmp_path: Path) -> None:
     service = OpenPrecedentService.from_path(get_db_path())
     fixture_dir = Path(__file__).parent / "fixtures" / "openclaw_sessions"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -538,6 +538,17 @@ def test_cli_evaluates_fixture_suite(capsys, db_path) -> None:
     assert report["passed_cases"] == 3
 
 
+def test_cli_evaluates_real_session_fixture_suite(capsys, db_path) -> None:
+    suite_path = Path(__file__).parent / "fixtures" / "evaluation" / "real_session_suite.json"
+
+    result = main(["eval", "fixtures", str(suite_path), "--json"])
+    assert result == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["total_cases"] == 3
+    assert report["failed_cases"] == 0
+    assert report["passed_cases"] == 3
+
+
 def test_cli_evaluates_collected_openclaw_sessions(capsys, db_path, tmp_path: Path) -> None:
     fixture_dir = Path(__file__).parent / "fixtures" / "openclaw_sessions"
     sessions_dir = tmp_path / "sessions"


### PR DESCRIPTION
Closes #26

This change adds an anonymized real-session fixture suite and wires it into the existing fixture-evaluation flow instead of creating a separate one-off evaluation path.

The evaluation suite now supports both existing OpenClaw runtime traces and OpenClaw session transcripts through a `source_format` field. Using that support, the repository now includes a dedicated `real_session_suite.json` built from anonymized OpenClaw session fixtures already in the repo, covering file operations, search-read behavior, and follow-up clarification behavior.

The API and CLI regression suites now execute the real-session fixture suite through the existing `eval fixtures` path, which means replay, extraction, and precedent behavior on anonymized real-session trajectories are covered by the same workflow already used for curated fixtures.

Validation:
- `.venv/bin/python -m pytest tests/test_api.py tests/test_cli.py`
