### PR TITLE
Improve precedent ranking for real session history

### DIFF
--- a/src/openprecedent/services.py
+++ b/src/openprecedent/services.py
@@ -870,6 +870,14 @@ class OpenPrecedentService:
                 if (path := _string_or_none(event.payload.get("path"))) is not None
             }
         )
+        file_read_paths = sorted(
+            {
+                Path(path).name
+                for event in events
+                if event.event_type == EventType.FILE_READ
+                and (path := _string_or_none(event.payload.get("path"))) is not None
+            }
+        )
         keywords = sorted(self._case_keywords(case, events, decisions))
         return {
             "status": case.status.value,
@@ -878,6 +886,7 @@ class OpenPrecedentService:
             "tool_count": event_types[EventType.TOOL_CALLED.value],
             "tool_names": tool_names,
             "file_paths": file_paths,
+            "file_read_paths": file_read_paths,
             "keywords": keywords,
             "decision_types": dict(decision_types),
         }
@@ -891,10 +900,17 @@ class OpenPrecedentService:
         similarities: list[str] = []
         differences: list[str] = []
 
-        for key in ("has_file_write", "has_recovery", "status"):
+        if current["status"] == other["status"]:
+            score += 2
+            similarities.append("same status")
+        else:
+            differences.append("different status")
+
+        for key in ("has_file_write", "has_recovery"):
             if current[key] == other[key]:
-                score += 2
-                similarities.append(f"same {key}")
+                if current[key]:
+                    score += 2
+                    similarities.append(f"same {key}")
             else:
                 differences.append(f"different {key}")
 
@@ -935,12 +951,24 @@ class OpenPrecedentService:
             score += min(len(shared_paths), 2)
             similarities.append("shared file targets: " + ",".join(shared_paths[:3]))
 
+        shared_read_paths = sorted(set(current["file_read_paths"]) & set(other["file_read_paths"]))
+        if shared_read_paths:
+            score += min(len(shared_read_paths) * 2, 4)
+            similarities.append("shared read targets: " + ",".join(shared_read_paths[:3]))
+
         shared_keywords = sorted(set(current["keywords"]) & set(other["keywords"]))
         if shared_keywords:
             score += min(len(shared_keywords), 4)
             similarities.append("shared keywords: " + ",".join(shared_keywords[:4]))
         else:
             differences.append("different task keywords")
+
+        current_decision_keys = set(current["decision_types"])
+        other_decision_keys = set(other["decision_types"])
+        clarify_mismatch = DecisionType.CLARIFY.value in (current_decision_keys ^ other_decision_keys)
+        if clarify_mismatch:
+            score -= 1
+            differences.append("different clarification pattern")
 
         return score, similarities or ["similar case structure"], differences
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -421,6 +421,19 @@ def test_service_evaluates_real_session_fixture_suite(db_path) -> None:
     assert "clarify" in [decision_type.value for decision_type in clarify_result.actual_decision_types]
 
 
+def test_service_precedent_prefers_shared_read_targets_for_real_session_search(db_path) -> None:
+    service = OpenPrecedentService.from_path(get_db_path())
+    suite_path = Path(__file__).parent / "fixtures" / "evaluation" / "real_session_suite.json"
+
+    service.evaluate_openclaw_fixture_suite(suite_path)
+
+    precedents = service.find_precedents("eval_real_search_read", limit=2)
+
+    assert len(precedents) == 2
+    assert precedents[0].case_id == "eval_real_file_ops"
+    assert precedents[0].similarity_score >= precedents[1].similarity_score
+
+
 def test_service_evaluates_collected_openclaw_sessions(db_path, tmp_path: Path) -> None:
     service = OpenPrecedentService.from_path(get_db_path())
     fixture_dir = Path(__file__).parent / "fixtures" / "openclaw_sessions"


### PR DESCRIPTION
Closes #28

This change improves precedent ranking against the anonymized real-session fixture suite by correcting a concrete ordering failure in the current fingerprint scoring.

The failure was that the search-oriented real session ranked the clarify-oriented session above the file-ops session, even though the file-ops case shared a stronger read-target structure with it. The current scoring overvalued shared keyword overlap and shared absence of file writes, while undervaluing shared file-read targets.

The fix refines the fingerprint comparison in two ways:
- it tracks `file.read` targets separately and rewards shared read targets more strongly
- it only gives the stronger boolean-match bonus when both cases positively share `has_file_write` or `has_recovery`, instead of rewarding shared absence equally
- it applies a small clarify-pattern mismatch penalty so a clarification-heavy case does not outrank a closer search/read case on weak overlap alone

A regression test now locks in the expected ordering for the real-session search case using the anonymized real-session suite introduced in `#26`.

Validation:
- `.venv/bin/python -m pytest tests/test_api.py tests/test_cli.py`
