### PR TITLE
[codex] Roll out OpenClaw collector in a real environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ coverage/
 
 # Logs
 *.log
+runtime/*.log
 
 # Local review notes
 .codex-review
@@ -34,3 +35,9 @@ coverage/
 build/
 tmp/
 .cache/
+
+# Local runtime data
+openprecedent.db
+runtime/*.db
+runtime/*.json
+runtime/*.cron

--- a/deploy/cron/openprecedent-collector.cron
+++ b/deploy/cron/openprecedent-collector.cron
@@ -3,7 +3,7 @@ PATH=/usr/local/bin:/usr/bin:/bin
 
 OPENPRECEDENT_DB=__OPENPRECEDENT_ROOT__/runtime/openprecedent.db
 OPENPRECEDENT_COLLECTOR_STATE=__OPENPRECEDENT_ROOT__/runtime/openprecedent-collector-state.json
-OPENCLAW_SESSIONS_ROOT=$HOME/.openclaw/agents/main/sessions
+OPENCLAW_SESSIONS_ROOT=__OPENCLAW_HOME__/.openclaw/agents/main/sessions
 OPENPRECEDENT_COLLECT_LIMIT=1
 
 */5 * * * * cd "__OPENPRECEDENT_ROOT__" && ./scripts/run-collector.sh >> "__OPENPRECEDENT_ROOT__/runtime/collector.log" 2>&1

--- a/docs/engineering/openclaw-collector-operations.md
+++ b/docs/engineering/openclaw-collector-operations.md
@@ -11,9 +11,14 @@ It covers:
 - the fallback `cron` setup
 - the evaluation/report command for real collected sessions
 
+For the first validated live rollout and its observed caveats, see
+[`docs/engineering/openclaw-collector-rollout-validation.md`](/workspace/02-projects/incubation/openprecedent/docs/engineering/openclaw-collector-rollout-validation.md).
+
 ## Wrapper Script
 
 Use [`scripts/run-collector.sh`](/workspace/02-projects/incubation/openprecedent/scripts/run-collector.sh) as the single entrypoint for scheduled collection.
+
+The wrapper prefers the repository-local `.venv/bin/openprecedent` binary when it exists, then falls back to `openprecedent` on `PATH`. This keeps scheduled runs aligned with the checked-out repository environment without requiring a separate global install.
 
 Default environment variables:
 
@@ -61,6 +66,8 @@ systemctl --user status openprecedent-collector.timer
 journalctl --user -u openprecedent-collector.service -n 50 --no-pager
 ```
 
+If `systemctl --user` cannot reach the user bus in the target environment, use the documented `cron` path instead of trying to force a partially working user-service setup.
+
 ## cron
 
 If `systemd --user` is unavailable, use the template at
@@ -73,6 +80,8 @@ Render a repo-path-aware crontab file with:
 crontab runtime/openprecedent-collector.cron
 crontab -l
 ```
+
+The rendered crontab writes the absolute home-directory session path directly into `OPENCLAW_SESSIONS_ROOT` because cron variable assignments do not expand `$HOME` reliably.
 
 ## Real Session Evaluation
 

--- a/docs/engineering/openclaw-collector-rollout-validation.md
+++ b/docs/engineering/openclaw-collector-rollout-validation.md
@@ -1,0 +1,92 @@
+# OpenClaw Collector Rollout Validation
+
+## Goal
+
+Record the first validated real-environment rollout of the OpenClaw collector for MVP issue `#23`.
+
+## Environment
+
+- repository: `openprecedent/openprecedent`
+- collector branch: `codex/roll-out-openclaw-collector`
+- sessions root: `~/.openclaw/agents/main/sessions`
+- validated scheduler: `cron`
+
+`systemctl --user` was present on the target machine, but the user bus was not reachable from this environment. The validated deployment path therefore uses the documented cron installer instead of the `systemd --user` timer path.
+
+Installed schedule:
+
+```cron
+*/5 * * * * cd "/workspace/02-projects/incubation/openprecedent" && ./scripts/run-collector.sh >> "/workspace/02-projects/incubation/openprecedent/runtime/collector.log" 2>&1
+```
+
+## Real Rollout Result
+
+The collector was installed into the real target environment and confirmed to run on a schedule.
+
+Validated behaviors:
+
+- the scheduled wrapper resolved the repository-local `.venv/bin/openprecedent` binary without requiring a separate global install
+- the collector discovered sessions from the real OpenClaw `sessions.json` index format
+- repeated collector runs advanced the state file and skipped already imported sessions instead of duplicating them
+- collected sessions were replayable and evaluable through the existing CLI
+
+## First Collected Session
+
+The first fully validated collected case was:
+
+- `case_id`: `openclaw_d51637888ee44ff29f2791fc`
+- `session_id`: `d5163788-8ee4-4ff2-9f27-91fce72599a4`
+- `event_count`: `42`
+- `decision_count`: `20`
+- `status`: `started`
+- `precedent_count`: `0`
+
+Observed unsupported OpenClaw session record types:
+
+- `custom`: `1`
+- `thinking_level_change`: `1`
+
+High-level replay summary:
+
+1. the user asked about Feishu-related skills
+2. the runtime inspected the skills guidance and ran `skillhub search feishu`
+3. the user declined installation until a more specific target existed
+4. the user asked for raw contents of two local Context Graph documents
+5. the runtime read both local markdown files and returned their contents
+6. the user asked whether the runtime could read the `openprecedent/openprecedent` GitHub repository page
+7. the runtime read the GitHub skill, fetched the repository page, and confirmed it was accessible
+8. the user asked how to subscribe to new GitHub PRs
+9. the user then shifted into agent-memory and adjacent-market questions
+10. the runtime used `skillhub search`, `gh search repos`, and one failed `web_search` attempt while answering those questions
+
+## Issues Found During Rollout
+
+The real rollout exposed three concrete issues that were fixed in this branch:
+
+1. the scheduled wrapper defaulted to `openprecedent` on `PATH`, which failed when only the repository virtualenv was installed
+2. the collector assumed `sessions.json` was a list of objects, but the real OpenClaw index is a dictionary keyed by channel/session scope
+3. the cron template used `OPENCLAW_SESSIONS_ROOT=$HOME/...`, but cron environment variable assignments do not reliably expand `$HOME`, so scheduled runs imported zero sessions until the template was rendered with an absolute home path
+
+## Acceptance Summary For Issue 23
+
+Issue `#23` required:
+
+- at least one real environment running scheduled collection
+- repeated runs that do not duplicate already imported sessions
+- validated setup steps documented in-repo
+- the first collected-session evaluation report attached or summarized
+
+This rollout satisfies those conditions:
+
+- the collector is installed in the real target environment via cron
+- repeated runs skip imported session ids through the collector state file
+- the validated setup path and caveats are documented here and in the collector operations guide
+- the first collected session and replay/evaluation summary are recorded above
+
+## Follow-Up Work
+
+The rollout proved the capture path works. The next work should focus on quality rather than more collector scaffolding:
+
+- reduce session-message noise from operator policy and transport metadata wrappers (`#47`)
+- tighten `clarify` decision extraction on real multi-turn OpenClaw sessions (`#45`)
+- extend OpenClaw session modeling for additional real-world record types only where the live collection stream exposes value (`#46`)

--- a/docs/product/mvp-roadmap.md
+++ b/docs/product/mvp-roadmap.md
@@ -2,7 +2,7 @@
 
 ## Current Status
 
-As of 2026-03-10, the MVP core loop is functionally implemented in-repo.
+As of 2026-03-10, the MVP core loop is implemented and validated in a real local target environment.
 
 Completed:
 
@@ -19,12 +19,14 @@ Completed:
 - follow-up user clarification extraction on multi-turn OpenClaw transcripts
 - anonymized real-session evaluation fixtures through the existing evaluation flow
 - precedent ranking improvements validated against anonymized real-session cases
+- real-environment scheduled collector rollout validated through cron
+- first collected OpenClaw session replayed and evaluated end-to-end in the target environment
 
 Still open:
 
-- connect the collector to a real scheduled/background job in the target environment
-- validate replay, extraction, and precedent quality against a growing set of real collected sessions
-- continue transcript mapping and ranking improvements only where real collected history reveals concrete gaps
+- reduce real-session noise in imported OpenClaw messages and derived decisions
+- improve transcript mapping coverage for real-world OpenClaw record types that still carry useful signal
+- strengthen precedent quality and evaluation depth on larger real-case histories
 
 ## Objective
 
@@ -213,7 +215,7 @@ Remaining gaps:
 
 Status:
 
-- partially completed
+- completed for MVP rollout
 
 Goal:
 
@@ -244,18 +246,21 @@ Completed work:
 - `checkpoint` session record mapping into replayable raw events
 - follow-up user clarification extraction on multi-turn session transcripts
 - precedent ranking tuned and regression-tested against anonymized real-session cases
+- validated cron-based rollout in the real target environment
+- first live collected session replayed and evaluated end-to-end
+- rollout findings and caveats documented in `docs/engineering/openclaw-collector-rollout-validation.md`
 
 Remaining gaps:
 
-- run the collector on a real schedule in the target machine environment
-- validate replay/extraction/precedent quality on a growing set of real collected sessions
-- extend transcript mapping or ranking only where real collected history exposes concrete shortcomings
+- reduce import-time noise and false-positive decision extraction on real collected sessions
+- validate replay/extraction/precedent quality on a broader set of real collected sessions
+- keep improving precedent ranking and record-type coverage as real history grows
 
 ## Next Tasks
 
-The next MVP work should focus on operationalizing and validating what already exists:
+The next MVP work should focus on improving quality on top of the validated live collection path:
 
-1. run `openprecedent runtime collect-openclaw-sessions --limit 1` on a schedule in the real environment
-2. collect a small set of real OpenClaw sessions and inspect replay / decision / precedent quality
-3. document the operational baseline for collector rollout, cursor behavior, failure recovery, and report review
-4. only extend transcript mapping or ranking when the newly collected session history exposes specific gaps
+1. strip operator policy and transport metadata noise from imported OpenClaw session messages
+2. tighten `clarify` decision extraction against real multi-turn sessions
+3. extend transcript mapping for additional OpenClaw record types only where live collection exposes useful signal
+4. grow the real-session evaluation set and re-tune precedent ranking against the larger history

--- a/scripts/install-collector-assets.sh
+++ b/scripts/install-collector-assets.sh
@@ -7,8 +7,13 @@ MODE="${1:-systemd}"
 render_template() {
   local source_path="$1"
   local escaped_root
+  local escaped_home
   escaped_root="$(printf '%s\n' "$ROOT_DIR" | sed 's/[&]/\\&/g')"
-  sed "s|__OPENPRECEDENT_ROOT__|$escaped_root|g" "$source_path"
+  escaped_home="$(printf '%s\n' "$HOME" | sed 's/[&]/\\&/g')"
+  sed \
+    -e "s|__OPENPRECEDENT_ROOT__|$escaped_root|g" \
+    -e "s|__OPENCLAW_HOME__|$escaped_home|g" \
+    "$source_path"
 }
 
 install_systemd() {

--- a/scripts/run-collector.sh
+++ b/scripts/run-collector.sh
@@ -3,7 +3,13 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-OPENPRECEDENT_BIN="${OPENPRECEDENT_BIN:-openprecedent}"
+if [[ -n "${OPENPRECEDENT_BIN:-}" ]]; then
+  OPENPRECEDENT_BIN="$OPENPRECEDENT_BIN"
+elif [[ -x "$ROOT_DIR/.venv/bin/openprecedent" ]]; then
+  OPENPRECEDENT_BIN="$ROOT_DIR/.venv/bin/openprecedent"
+else
+  OPENPRECEDENT_BIN="openprecedent"
+fi
 OPENPRECEDENT_DB="${OPENPRECEDENT_DB:-$ROOT_DIR/runtime/openprecedent.db}"
 OPENPRECEDENT_COLLECTOR_STATE="${OPENPRECEDENT_COLLECTOR_STATE:-$ROOT_DIR/runtime/openprecedent-collector-state.json}"
 OPENCLAW_SESSIONS_ROOT="${OPENCLAW_SESSIONS_ROOT:-$HOME/.openclaw/agents/main/sessions}"

--- a/src/openprecedent/services.py
+++ b/src/openprecedent/services.py
@@ -295,8 +295,16 @@ class OpenPrecedentService:
         references: list[OpenClawSessionReference] = []
         index_path = sessions_root / "sessions.json"
         if index_path.exists():
-            entries = json.loads(index_path.read_text(encoding="utf-8"))
+            raw_entries = json.loads(index_path.read_text(encoding="utf-8"))
+            if isinstance(raw_entries, dict):
+                entries = raw_entries.values()
+            elif isinstance(raw_entries, list):
+                entries = raw_entries
+            else:
+                entries = []
             for item in entries:
+                if not isinstance(item, dict):
+                    continue
                 session_id = _string_or_none(item.get("sessionId"))
                 transcript_path = _string_or_none(item.get("sessionFile")) or _string_or_none(
                     item.get("transcriptPath")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -185,6 +185,38 @@ def test_service_lists_and_imports_openclaw_session(db_path, tmp_path: Path) -> 
     assert replay.summary == "Imported OpenClaw session: 9 events, 2 decisions, status=started"
 
 
+def test_service_lists_openclaw_sessions_from_dict_index(db_path, tmp_path: Path) -> None:
+    service = OpenPrecedentService.from_path(get_db_path())
+    fixture_dir = Path(__file__).parent / "fixtures" / "openclaw_sessions"
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+
+    transcript_path = sessions_dir / "sample-session.jsonl"
+    transcript_path.write_text(
+        (fixture_dir / "sample-session.jsonl").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    (sessions_dir / "sessions.json").write_text(
+        json.dumps(
+            {
+                "agent:main:main": {
+                    "sessionId": "sample-session",
+                    "sessionFile": str(transcript_path),
+                    "updatedAt": 1730948045000,
+                    "model": "gpt-5.3-codex",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    sessions = service.list_openclaw_sessions(sessions_dir)
+
+    assert len(sessions) == 1
+    assert sessions[0].session_id == "sample-session"
+    assert sessions[0].transcript_path == str(transcript_path)
+
+
 def test_service_imports_failing_openclaw_command_without_output(db_path) -> None:
     service = OpenPrecedentService.from_path(get_db_path())
     transcript_path = (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
 from pathlib import Path
 
 from openprecedent.cli import main
@@ -525,6 +527,35 @@ def test_cli_collects_openclaw_sessions(capsys, db_path, tmp_path: Path) -> None
     collected_again = json.loads(capsys.readouterr().out)
     assert collected_again["imported"] == []
     assert "sample-session" in collected_again["skipped_session_ids"]
+
+
+def test_run_collector_script_prefers_repo_venv_binary(tmp_path: Path) -> None:
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    (sessions_dir / "sessions.json").write_text("[]", encoding="utf-8")
+
+    db_path = tmp_path / "openprecedent.db"
+    state_path = tmp_path / "collector-state.json"
+    env = os.environ.copy()
+    env.pop("OPENPRECEDENT_BIN", None)
+    env["OPENPRECEDENT_DB"] = str(db_path)
+    env["OPENPRECEDENT_COLLECTOR_STATE"] = str(state_path)
+    env["OPENCLAW_SESSIONS_ROOT"] = str(sessions_dir)
+    env["PATH"] = "/usr/bin:/bin"
+    env["PYTHONPATH"] = str(Path(__file__).parent.parent / "src")
+
+    result = subprocess.run(
+        ["./scripts/run-collector.sh"],
+        cwd=Path(__file__).parent.parent,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert db_path.exists()
+    assert state_path.exists()
 
 
 def test_cli_evaluates_fixture_suite(capsys, db_path) -> None:


### PR DESCRIPTION
Closes #23

## Summary
Validate the OpenClaw collector in the real target environment and document the resulting rollout baseline.

## What changed
- make the scheduled collector wrapper prefer the repository-local virtualenv binary
- support the real OpenClaw sessions.json dictionary index format during session discovery
- fix the cron template so the rendered OpenClaw sessions root uses an absolute home path instead of a non-expanded HOME reference
- document the validated live rollout, the first collected session, and the rollout caveats in a dedicated engineering note
- update the MVP roadmap to reflect that the live collector rollout is now complete and shift the next work toward quality improvements
- ignore local runtime collector artifacts generated by the validated deployment path

## Validation
- .venv/bin/python -m pytest tests/test_api.py tests/test_cli.py
- manual live rollout validation against the real OpenClaw sessions root
- cron installation confirmed with crontab -l
- first collected session replayed and evaluated from runtime/openprecedent.db

## Follow-up issues
- #45 Reduce false clarify decisions on wrapped OpenClaw multi-turn sessions
- #46 Model additional real-session OpenClaw record types from live collection
- #47 Strip operator policy and transport metadata from imported OpenClaw session messages
