### PR TITLE
Model additional real-session OpenClaw record types

### DIFF
--- a/.codex/pm/tasks/real-history-quality/model-additional-openclaw-record-types.md
+++ b/.codex/pm/tasks/real-history-quality/model-additional-openclaw-record-types.md
@@ -1,0 +1,39 @@
+---
+type: task
+epic: real-history-quality
+slug: model-additional-openclaw-record-types
+title: Model additional real-session OpenClaw record types from live collection
+status: in_progress
+labels: feature,test
+issue: 46
+---
+
+## Context
+
+The first validated live OpenClaw collector run surfaced two previously unsupported session record types: `custom` and `thinking_level_change`.
+Those records should not be treated as user-visible chat messages, but they can still carry replay or explanation signal that should be preserved when importing real sessions.
+
+## Deliverable
+
+Extend OpenClaw session import so useful `custom` and `thinking_level_change` records are normalized into the existing event model instead of being reported as unsupported.
+
+## Scope
+
+- map `thinking_level_change` into a non-chat event that preserves the new level and change source
+- map `custom` records only when they expose replayable signal such as a named action or text/details payload
+- keep unsupported-record reporting for session record types that still cannot be normalized safely
+- add targeted fixture, API coverage, and CLI coverage for the new record types
+
+## Acceptance Criteria
+
+- importing a session fixture with `custom` and `thinking_level_change` records yields replayable events for both record types
+- those records no longer appear in `unsupported_record_type_counts`
+- the new mapping does not create false user-message or clarify decisions
+
+## Validation
+
+- run targeted API and CLI tests covering OpenClaw session import and replay for the new record types
+
+## Implementation Notes
+
+Prefer a conservative mapping into existing event types over introducing new schema objects just for OpenClaw-specific transcript variants.

--- a/src/openprecedent/services.py
+++ b/src/openprecedent/services.py
@@ -1247,6 +1247,35 @@ class OpenPrecedentService:
                 )
             ], None)
 
+        if record_type == "thinking_level_change":
+            return ([
+                AppendEventInput(
+                    event_id=f"evt_thinking_level_{record_id}",
+                    event_type=EventType.MODEL_INVOKED,
+                    actor=EventActor.SYSTEM,
+                    timestamp=timestamp,
+                    parent_event_id=parent_id,
+                    payload={
+                        "thinking_level": _string_or_none(raw_item.get("thinkingLevel"))
+                        or _string_or_none(raw_item.get("level")),
+                        "changed_by": _string_or_none(raw_item.get("source")),
+                        "trigger": _string_or_none(raw_item.get("trigger")),
+                        "source": "openclaw.session",
+                    },
+                )
+            ], None)
+
+        if record_type == "custom":
+            normalized_custom_event = _normalize_openclaw_custom_record(
+                raw_item=raw_item,
+                record_id=record_id,
+                parent_id=parent_id,
+                timestamp=timestamp,
+            )
+            if normalized_custom_event is None:
+                return [], record_type
+            return [normalized_custom_event], None
+
         if record_type != "message":
             return [], record_type
 
@@ -1676,6 +1705,47 @@ def _normalize_openclaw_tool_result_events(
             },
         )
     ]
+
+
+def _normalize_openclaw_custom_record(
+    *,
+    raw_item: dict[str, object],
+    record_id: str,
+    parent_id: str | None,
+    timestamp: datetime | None,
+) -> AppendEventInput | None:
+    tool_name = (
+        _string_or_none(raw_item.get("name"))
+        or _string_or_none(raw_item.get("customType"))
+        or _string_or_none(raw_item.get("event"))
+    )
+    details = raw_item.get("data")
+    if not isinstance(details, dict):
+        details = raw_item.get("details")
+    normalized_details = details if isinstance(details, dict) else {}
+    content = (
+        _string_or_none(raw_item.get("text"))
+        or _string_or_none(raw_item.get("summary"))
+        or _string_or_none(raw_item.get("content"))
+    )
+
+    if tool_name is None and content is None and not normalized_details:
+        return None
+
+    return AppendEventInput(
+        event_id=f"evt_custom_{record_id}",
+        event_type=EventType.TOOL_COMPLETED,
+        actor=EventActor.TOOL,
+        timestamp=timestamp,
+        parent_event_id=parent_id,
+        payload={
+            "tool_name": tool_name or "custom",
+            "tool_call_id": _string_or_none(raw_item.get("toolCallId")),
+            "content": content,
+            "details": normalized_details,
+            "source": "openclaw.session.custom",
+        },
+    )
 
 
 _STOP_WORDS = {

--- a/tests/fixtures/openclaw_sessions/live-record-types-session.jsonl
+++ b/tests/fixtures/openclaw_sessions/live-record-types-session.jsonl
@@ -1,0 +1,5 @@
+{"type":"session","version":3,"id":"live-record-types-session","timestamp":"2026-03-09T02:00:00.000Z","cwd":"/root/.openclaw/workspace"}
+{"type":"thinking_level_change","id":"thinking-level-1","parentId":"live-record-types-session","timestamp":"2026-03-09T02:00:01.000Z","thinkingLevel":"high","source":"user","trigger":"slash_command"}
+{"type":"message","id":"msg-user-live-record-types","parentId":"thinking-level-1","timestamp":"2026-03-09T02:00:03.000Z","message":{"role":"user","content":[{"type":"text","text":"Find the latest repo governance notes."}]}}
+{"type":"custom","id":"custom-web-search-1","parentId":"msg-user-live-record-types","timestamp":"2026-03-09T02:00:05.000Z","name":"web_search","text":"web_search failed because the network was unavailable.","data":{"query":"repo governance openprecedent","status":"error","error":"network unavailable"}}
+{"type":"message","id":"msg-assistant-live-record-types","parentId":"custom-web-search-1","timestamp":"2026-03-09T02:00:07.000Z","message":{"role":"assistant","content":[{"type":"text","text":"The network is unavailable, so I will rely on local repository documentation."}]}}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -289,6 +289,43 @@ def test_service_imports_openclaw_checkpoint_record_as_event(db_path) -> None:
     assert checkpoint_events[0].payload["status"] == "saved"
 
 
+def test_service_imports_additional_live_openclaw_record_types(db_path) -> None:
+    service = OpenPrecedentService.from_path(get_db_path())
+    transcript_path = (
+        Path(__file__).parent / "fixtures" / "openclaw_sessions" / "live-record-types-session.jsonl"
+    )
+
+    result = service.import_openclaw_session(
+        transcript_path,
+        case_id="case_session_live_record_types",
+        title="Imported OpenClaw live record types session",
+        user_id="u1",
+    )
+
+    assert result.case.case_id == "case_session_live_record_types"
+    assert len(result.imported_events) == 5
+    assert result.unsupported_record_type_counts == {}
+
+    events = service.list_events("case_session_live_record_types")
+    thinking_events = [event for event in events if event.event_type.value == "model.invoked"]
+    custom_events = [event for event in events if event.event_type.value == "tool.completed"]
+    assert len(thinking_events) == 1
+    assert thinking_events[0].payload["thinking_level"] == "high"
+    assert thinking_events[0].payload["changed_by"] == "user"
+    assert thinking_events[0].payload["trigger"] == "slash_command"
+    assert len(custom_events) == 1
+    assert custom_events[0].payload["tool_name"] == "web_search"
+    assert custom_events[0].payload["content"] == "web_search failed because the network was unavailable."
+    assert custom_events[0].payload["details"] == {
+        "query": "repo governance openprecedent",
+        "status": "error",
+        "error": "network unavailable",
+    }
+
+    decisions = service.extract_decisions("case_session_live_record_types")
+    assert [item.decision_type.value for item in decisions] == ["plan"]
+
+
 def test_service_extracts_clarify_decision_from_follow_up_user_message(db_path) -> None:
     service = OpenPrecedentService.from_path(get_db_path())
     transcript_path = (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -385,6 +385,41 @@ def test_cli_imports_openclaw_checkpoint_record_as_event(capsys, db_path) -> Non
     assert checkpoint_events[0]["payload"]["status"] == "saved"
 
 
+def test_cli_imports_additional_live_openclaw_record_types(capsys, db_path) -> None:
+    fixture_path = (
+        Path(__file__).parent / "fixtures" / "openclaw_sessions" / "live-record-types-session.jsonl"
+    )
+
+    result = main(
+        [
+            "runtime",
+            "import-openclaw-session",
+            "--session-file",
+            str(fixture_path),
+            "--case-id",
+            "case_session_live_record_types_cli",
+        ]
+    )
+    assert result == 0
+    imported = json.loads(capsys.readouterr().out)
+    assert imported["case"]["case_id"] == "case_session_live_record_types_cli"
+    assert imported["imported_event_count"] == 5
+    assert imported["unsupported_record_type_counts"] == {}
+
+    result = main(["replay", "case", "case_session_live_record_types_cli", "--json"])
+    assert result == 0
+    replay = json.loads(capsys.readouterr().out)
+    thinking_events = [event for event in replay["events"] if event["event_type"] == "model.invoked"]
+    custom_events = [event for event in replay["events"] if event["event_type"] == "tool.completed"]
+    assert len(thinking_events) == 1
+    assert thinking_events[0]["payload"]["thinking_level"] == "high"
+    assert thinking_events[0]["payload"]["changed_by"] == "user"
+    assert thinking_events[0]["payload"]["trigger"] == "slash_command"
+    assert len(custom_events) == 1
+    assert custom_events[0]["payload"]["tool_name"] == "web_search"
+    assert custom_events[0]["payload"]["details"]["status"] == "error"
+
+
 def test_cli_extracts_clarify_decision_from_follow_up_user_message(capsys, db_path) -> None:
     fixture_path = (
         Path(__file__).parent / "fixtures" / "openclaw_sessions" / "clarify-session.jsonl"


### PR DESCRIPTION
Closes #46

Extend OpenClaw session import so useful `custom` and `thinking_level_change` records are normalized into the existing event model instead of being reported as unsupported.

Implementation notes:
Prefer a conservative mapping into existing event types over introducing new schema objects just for OpenClaw-specific transcript variants.

Validation:
- run targeted API and CLI tests covering OpenClaw session import and replay for the new record types
- `PYTHONPATH=src .venv/bin/pytest tests/test_api.py -k 'service_imports_openclaw or service_reports_unsupported_openclaw or service_extracts_clarify or service_skips_false_clarify or service_strips_openclaw'`
- `PYTHONPATH=src .venv/bin/pytest tests/test_cli.py -k 'cli_imports_openclaw or cli_reports_unsupported_openclaw or cli_extracts_clarify or cli_skips_false_clarify'`
