### PR TITLE
Unify OpenClaw transcript deduplication

### DIFF
--- a/.codex/pm/tasks/local-runtime-validation/unify-openclaw-transcript-deduplication.md
+++ b/.codex/pm/tasks/local-runtime-validation/unify-openclaw-transcript-deduplication.md
@@ -1,0 +1,41 @@
+---
+type: task
+epic: local-runtime-validation
+slug: unify-openclaw-transcript-deduplication
+title: Unify OpenClaw transcript deduplication across manual import and collector
+status: in_progress
+labels: bug,test
+issue: 64
+---
+
+## Context
+
+The OpenClaw full-user-journey validation found that manual transcript import and background collection do not share one deduplication contract.
+If a transcript is manually imported first and later discovered by the collector, the collector can attempt to import the same transcript again under a different derived case id, hit a global event-id conflict, and leave behind an empty case shell.
+
+## Deliverable
+
+Unify transcript identity and deduplication across manual import and collector flows so the same OpenClaw session cannot create conflicting duplicate cases or empty partial cases.
+
+## Scope
+
+- reproduce the duplicate transcript path across manual import and collector workflows
+- define one durable identity rule for an OpenClaw transcript or session
+- prevent duplicate imports from creating conflicting event ids or empty residual cases
+- add regression coverage for mixed manual-import and collector scenarios
+
+## Acceptance Criteria
+
+- the same transcript cannot be imported twice through different OpenClaw entry paths in a way that leaves conflicting duplicate state
+- collector and manual import share a consistent transcript identity rule
+- failed duplicate attempts do not leave behind empty cases
+- regression tests cover the mixed-flow scenario
+
+## Validation
+
+- reproduce the conflict and empty-case behavior from the full-user-journey validation
+- run targeted tests for manual import followed by collector import of the same transcript
+
+## Implementation Notes
+
+The fix should optimize for real user journey safety rather than only for collector-state bookkeeping.

--- a/src/openprecedent/services.py
+++ b/src/openprecedent/services.py
@@ -358,18 +358,7 @@ class OpenPrecedentService:
         user_id: str | None = None,
         agent_id: str = "openclaw",
     ) -> RuntimeTraceImportResult:
-        case = self.store.get_case(case_id)
-        if case is None:
-            case = self.create_case(
-                CreateCaseInput(
-                    case_id=case_id,
-                    title=title,
-                    user_id=user_id,
-                    agent_id=agent_id,
-                )
-            )
-
-        imported: list[Event] = []
+        normalized_imports: list[AppendEventInput] = []
         unsupported_record_type_counts: Counter[str] = Counter()
         with transcript_path.open("r", encoding="utf-8") as handle:
             for line_no, line in enumerate(handle, start=1):
@@ -384,8 +373,37 @@ class OpenPrecedentService:
                 )
                 if unsupported_record_type is not None:
                     unsupported_record_type_counts[unsupported_record_type] += 1
-                for normalized in normalized_events:
-                    imported.append(self.append_event(case_id, normalized))
+                normalized_imports.extend(normalized_events)
+
+        session_id = _openclaw_session_id_from_import(
+            normalized_imports,
+            default=transcript_path.stem,
+        )
+        existing_case_id = self.store.find_case_id_by_openclaw_session_id(session_id)
+        if existing_case_id is not None:
+            existing_case = self.store.get_case(existing_case_id)
+            if existing_case is None:
+                raise KeyError(existing_case_id)
+            return RuntimeTraceImportResult(
+                case=existing_case,
+                imported_events=[],
+                unsupported_record_type_counts=dict(sorted(unsupported_record_type_counts.items())),
+            )
+
+        case = self.store.get_case(case_id)
+        if case is None:
+            case = self.create_case(
+                CreateCaseInput(
+                    case_id=case_id,
+                    title=title,
+                    user_id=user_id,
+                    agent_id=agent_id,
+                )
+            )
+
+        imported: list[Event] = []
+        for normalized in normalized_imports:
+            imported.append(self.append_event(case_id, normalized))
 
         return RuntimeTraceImportResult(
             case=case,
@@ -1773,6 +1791,16 @@ _STOP_WORDS = {
 def _case_id_for_openclaw_session(session_id: str) -> str:
     normalized = "".join(ch for ch in session_id.lower() if ch.isalnum())
     return f"openclaw_{normalized[:24]}"
+
+
+def _openclaw_session_id_from_import(events: list[AppendEventInput], *, default: str) -> str:
+    for event in events:
+        if event.event_type != EventType.CASE_STARTED:
+            continue
+        session_id = _string_or_none(event.payload.get("session_id"))
+        if session_id is not None:
+            return session_id
+    return default
 
 
 def _extract_file_reads_from_command(command: str) -> list[str]:

--- a/src/openprecedent/storage.py
+++ b/src/openprecedent/storage.py
@@ -153,6 +153,23 @@ class SQLiteStore:
             return None
         return self._row_to_case(row)
 
+    def find_case_id_by_openclaw_session_id(self, session_id: str) -> str | None:
+        with self.connect() as connection:
+            row = connection.execute(
+                """
+                SELECT case_id
+                FROM events
+                WHERE event_type = ?
+                  AND json_extract(payload_json, '$.session_id') = ?
+                ORDER BY sequence_no ASC, event_id ASC
+                LIMIT 1
+                """,
+                (EventType.CASE_STARTED.value, session_id),
+            ).fetchone()
+        if row is None:
+            return None
+        return str(row["case_id"])
+
     def append_event(self, event: Event) -> Event:
         with self.connect() as connection:
             connection.execute(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -520,6 +520,54 @@ def test_service_collects_latest_unseen_openclaw_session(db_path, tmp_path: Path
     assert "sample-session" in second.skipped_session_ids
 
 
+def test_service_dedupes_openclaw_transcript_across_manual_import_and_collector(
+    db_path, tmp_path: Path
+) -> None:
+    service = OpenPrecedentService.from_path(get_db_path())
+    fixture_dir = Path(__file__).parent / "fixtures" / "openclaw_sessions"
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    transcript_name = "sample-session.jsonl"
+    transcript_path = sessions_dir / transcript_name
+    transcript_path.write_text(
+        (fixture_dir / transcript_name).read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    (sessions_dir / "sessions.json").write_text(
+        (fixture_dir / "sessions.json").read_text(encoding="utf-8").replace(
+            "__FIXTURE_DIR__",
+            str(sessions_dir),
+        ),
+        encoding="utf-8",
+    )
+    state_path = tmp_path / "collector-state.json"
+
+    manual = service.import_openclaw_session(
+        transcript_path,
+        case_id="case_manual_sample",
+        title="Manual sample import",
+        user_id="u1",
+    )
+    assert manual.case.case_id == "case_manual_sample"
+    assert len(manual.imported_events) == 9
+
+    collected = service.collect_openclaw_sessions(
+        sessions_dir,
+        state_path=state_path,
+        limit=1,
+        user_id="u1",
+    )
+    assert len(collected.imported) == 1
+    assert collected.imported[0].session_id == "sample-session"
+    assert collected.imported[0].case_id == "case_manual_sample"
+    assert collected.imported[0].imported_event_count == 0
+
+    cases = service.list_cases()
+    assert [case.case_id for case in cases] == ["case_manual_sample"]
+    replay = service.replay_case("case_manual_sample")
+    assert len(replay.events) == 9
+
+
 def test_service_evaluates_fixture_suite(db_path) -> None:
     service = OpenPrecedentService.from_path(get_db_path())
     suite_path = Path(__file__).parent / "fixtures" / "evaluation" / "suite.json"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -626,6 +626,66 @@ def test_cli_collects_openclaw_sessions(capsys, db_path, tmp_path: Path) -> None
     assert "sample-session" in collected_again["skipped_session_ids"]
 
 
+def test_cli_dedupes_openclaw_transcript_across_manual_import_and_collector(
+    capsys, db_path, tmp_path: Path
+) -> None:
+    fixture_dir = Path(__file__).parent / "fixtures" / "openclaw_sessions"
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    transcript_path = sessions_dir / "sample-session.jsonl"
+    transcript_path.write_text(
+        (fixture_dir / "sample-session.jsonl").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    (sessions_dir / "sessions.json").write_text(
+        (fixture_dir / "sessions.json").read_text(encoding="utf-8").replace(
+            "__FIXTURE_DIR__",
+            str(sessions_dir),
+        ),
+        encoding="utf-8",
+    )
+    state_path = tmp_path / "collector-state.json"
+
+    result = main(
+        [
+            "runtime",
+            "import-openclaw-session",
+            "--session-file",
+            str(transcript_path),
+            "--case-id",
+            "case_manual_sample_cli",
+        ]
+    )
+    assert result == 0
+    imported = json.loads(capsys.readouterr().out)
+    assert imported["case"]["case_id"] == "case_manual_sample_cli"
+    assert imported["imported_event_count"] == 9
+
+    result = main(
+        [
+            "runtime",
+            "collect-openclaw-sessions",
+            "--sessions-root",
+            str(sessions_dir),
+            "--state-file",
+            str(state_path),
+            "--limit",
+            "1",
+        ]
+    )
+    assert result == 0
+    collected = json.loads(capsys.readouterr().out)
+    assert len(collected["imported"]) == 1
+    assert collected["imported"][0]["session_id"] == "sample-session"
+    assert collected["imported"][0]["case_id"] == "case_manual_sample_cli"
+    assert collected["imported"][0]["imported_event_count"] == 0
+
+    result = main(["case", "list"])
+    assert result == 0
+    cases = json.loads(capsys.readouterr().out)
+    assert [case["case_id"] for case in cases] == ["case_manual_sample_cli"]
+
+
 def test_run_collector_script_prefers_repo_venv_binary(tmp_path: Path) -> None:
     sessions_dir = tmp_path / "sessions"
     sessions_dir.mkdir()


### PR DESCRIPTION
Closes #64

Unify transcript identity and deduplication across manual import and collector flows so the same OpenClaw session cannot create conflicting duplicate cases or empty partial cases.

Implementation notes:
The fix should optimize for real user journey safety rather than only for collector-state bookkeeping.

Validation:
- reproduce the conflict and empty-case behavior from the full-user-journey validation
- run targeted tests for manual import followed by collector import of the same transcript
- `PYTHONPATH=src .venv/bin/pytest tests/test_api.py -k 'dedupes_openclaw_transcript or collects_latest_unseen_openclaw_session'`
- `PYTHONPATH=src .venv/bin/pytest tests/test_cli.py -k 'dedupes_openclaw_transcript or collects_openclaw_sessions'`
- `PYTHONPATH=src .venv/bin/pytest tests/test_api.py -k 'imports_openclaw or collects_latest_unseen_openclaw_session or dedupes_openclaw_transcript'`
- `PYTHONPATH=src .venv/bin/pytest tests/test_cli.py -k 'imports_openclaw or collects_openclaw_sessions or dedupes_openclaw_transcript'`
