### PR TITLE
Fail fast on reused fixture evaluation DB

### DIFF
--- a/.codex/pm/tasks/local-runtime-validation/isolate-fixture-eval-from-used-db.md
+++ b/.codex/pm/tasks/local-runtime-validation/isolate-fixture-eval-from-used-db.md
@@ -1,0 +1,40 @@
+---
+type: task
+epic: local-runtime-validation
+slug: isolate-fixture-eval-from-used-db
+title: Isolate fixture evaluation from reused working databases
+status: in_progress
+labels: bug,test
+issue: 63
+---
+
+## Context
+
+The OpenClaw full-user-journey validation found that `openprecedent eval fixtures` is not safe to rerun against a database that already contains the evaluation case ids.
+Instead of behaving like an isolated evaluation pass, the command attempts to import the same fixture cases again and fails with event or sequence conflicts.
+
+## Deliverable
+
+Make fixture evaluation safe and predictable when run from a normal working environment, either by isolating evaluation imports from the active database or by failing early with a clear non-partial behavior.
+
+## Scope
+
+- reproduce the current conflict behavior on a reused database
+- decide whether fixture evaluation should use an isolated store, namespaced cases, or stricter preflight checks
+- prevent partial writes or confusing reuse behavior during evaluation
+- document the expected evaluation semantics if they change
+
+## Acceptance Criteria
+
+- rerunning `eval fixtures` against a previously used environment does not leave the user with partial or confusing state
+- the command either succeeds safely or fails early with a clear message before partial imports
+- the behavior is covered by regression tests
+
+## Validation
+
+- reproduce the current `event conflict` behavior from the full-user-journey validation
+- run targeted tests for the chosen isolated or fail-fast behavior
+
+## Implementation Notes
+
+This is a workflow and reliability issue, not just a test harness issue. Human operators and agent workflows should be able to reason about whether evaluation is safe to rerun.

--- a/src/openprecedent/services.py
+++ b/src/openprecedent/services.py
@@ -463,6 +463,15 @@ class OpenPrecedentService:
     def evaluate_openclaw_fixture_suite(self, suite_path: Path) -> EvaluationReport:
         suite = EvaluationSuiteSpec.model_validate_json(suite_path.read_text(encoding="utf-8"))
         base_dir = suite_path.parent
+        existing_case_ids = [
+            case_spec.case_id for case_spec in suite.cases if self.store.get_case(case_spec.case_id) is not None
+        ]
+        if existing_case_ids:
+            duplicated = ", ".join(sorted(existing_case_ids))
+            raise ValueError(
+                "fixture evaluation requires an isolated database; "
+                f"existing evaluation case ids found: {duplicated}"
+            )
 
         imported_case_ids: list[str] = []
         for case_spec in suite.cases:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -592,6 +592,24 @@ def test_service_evaluates_real_session_fixture_suite(db_path) -> None:
     assert "clarify" in [decision_type.value for decision_type in clarify_result.actual_decision_types]
 
 
+def test_service_fixture_evaluation_fails_fast_on_reused_database(db_path) -> None:
+    service = OpenPrecedentService.from_path(get_db_path())
+    suite_path = Path(__file__).parent / "fixtures" / "evaluation" / "real_session_suite.json"
+
+    first = service.evaluate_openclaw_fixture_suite(suite_path)
+    assert first.passed_cases == 3
+
+    with pytest.raises(ValueError, match="fixture evaluation requires an isolated database"):
+        service.evaluate_openclaw_fixture_suite(suite_path)
+
+    cases = service.list_cases()
+    assert sorted(case.case_id for case in cases) == [
+        "eval_real_clarify",
+        "eval_real_file_ops",
+        "eval_real_search_read",
+    ]
+
+
 def test_service_precedent_prefers_shared_read_targets_for_real_session_search(db_path) -> None:
     service = OpenPrecedentService.from_path(get_db_path())
     suite_path = Path(__file__).parent / "fixtures" / "evaluation" / "real_session_suite.json"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -737,6 +737,28 @@ def test_cli_evaluates_real_session_fixture_suite(capsys, db_path) -> None:
     assert report["passed_cases"] == 3
 
 
+def test_cli_fixture_evaluation_fails_fast_on_reused_database(capsys, db_path) -> None:
+    suite_path = Path(__file__).parent / "fixtures" / "evaluation" / "real_session_suite.json"
+
+    first = main(["eval", "fixtures", str(suite_path), "--json"])
+    assert first == 0
+    capsys.readouterr()
+
+    second = main(["eval", "fixtures", str(suite_path), "--json"])
+    assert second == 1
+    stderr = capsys.readouterr().err
+    assert "fixture evaluation requires an isolated database" in stderr
+
+    result = main(["case", "list"])
+    assert result == 0
+    cases = json.loads(capsys.readouterr().out)
+    assert sorted(case["case_id"] for case in cases) == [
+        "eval_real_clarify",
+        "eval_real_file_ops",
+        "eval_real_search_read",
+    ]
+
+
 def test_cli_evaluates_collected_openclaw_sessions(capsys, db_path, tmp_path: Path) -> None:
     fixture_dir = Path(__file__).parent / "fixtures" / "openclaw_sessions"
     sessions_dir = tmp_path / "sessions"


### PR DESCRIPTION
Closes #63

Make fixture evaluation safe and predictable when run from a normal working environment, either by isolating evaluation imports from the active database or by failing early with a clear non-partial behavior.

Implementation notes:
This is a workflow and reliability issue, not just a test harness issue. Human operators and agent workflows should be able to reason about whether evaluation is safe to rerun.

Validation:
- reproduce the current `event conflict` behavior from the full-user-journey validation
- run targeted tests for the chosen isolated or fail-fast behavior
- `PYTHONPATH=src .venv/bin/pytest tests/test_api.py -k 'fixture_evaluation_fails_fast_on_reused_database or evaluates_real_session_fixture_suite or evaluates_fixture_suite'`
- `PYTHONPATH=src .venv/bin/pytest tests/test_cli.py -k 'fixture_evaluation_fails_fast_on_reused_database or evaluates_real_session_fixture_suite or evaluates_fixture_suite'`
- `PYTHONPATH=src .venv/bin/pytest tests/test_api.py -k 'evaluates_fixture_suite or evaluates_real_session_fixture_suite or evaluates_collected_openclaw_sessions or fixture_evaluation_fails_fast_on_reused_database'`
- `PYTHONPATH=src .venv/bin/pytest tests/test_cli.py -k 'evaluates_fixture_suite or evaluates_real_session_fixture_suite or evaluates_collected_openclaw_sessions or fixture_evaluation_fails_fast_on_reused_database'`
