### PR TITLE
Refactor semantic decision extraction

### DIFF
--- a/.codex/pm/tasks/semantic-decision-foundation/refactor-semantic-decision-schema-and-extraction.md
+++ b/.codex/pm/tasks/semantic-decision-foundation/refactor-semantic-decision-schema-and-extraction.md
@@ -3,7 +3,7 @@ type: task
 epic: semantic-decision-foundation
 slug: refactor-semantic-decision-schema-and-extraction
 title: Refactor decision schema and extraction around semantic decision lineage
-status: backlog
+status: in_progress
 labels: feature,test
 depends_on: 68
 issue: 69

--- a/src/openprecedent/schemas/decision.py
+++ b/src/openprecedent/schemas/decision.py
@@ -4,12 +4,12 @@ from pydantic import BaseModel, ConfigDict, Field
 
 
 class DecisionType(StrEnum):
-    CLARIFY = "clarify"
-    PLAN = "plan"
-    SELECT_TOOL = "select_tool"
-    APPLY_CHANGE = "apply_change"
-    RETRY_OR_RECOVER = "retry_or_recover"
-    FINALIZE = "finalize"
+    TASK_FRAME_DEFINED = "task_frame_defined"
+    CONSTRAINT_ADOPTED = "constraint_adopted"
+    SUCCESS_CRITERIA_SET = "success_criteria_set"
+    CLARIFICATION_RESOLVED = "clarification_resolved"
+    OPTION_REJECTED = "option_rejected"
+    AUTHORITY_CONFIRMED = "authority_confirmed"
 
 
 class DecisionExplanation(BaseModel):

--- a/src/openprecedent/services.py
+++ b/src/openprecedent/services.py
@@ -601,8 +601,10 @@ class OpenPrecedentService:
                     top_precedent_score=precedents[0].similarity_score if precedents else None,
                     has_file_write=any(event.event_type == EventType.FILE_WRITE for event in events),
                     has_recovery=any(
-                        decision.decision_type == DecisionType.RETRY_OR_RECOVER
-                        for decision in decisions
+                        event.event_type == EventType.COMMAND_COMPLETED
+                        and isinstance(event.payload.get("exit_code"), int)
+                        and int(event.payload.get("exit_code")) != 0
+                        for event in events
                     ),
                     final_summary=case.final_summary,
                     unsupported_record_type_counts=import_result.unsupported_record_type_counts,
@@ -644,13 +646,21 @@ class OpenPrecedentService:
     def extract_decisions(self, case_id: str) -> list[Decision]:
         events = self.list_events(case_id)
         extracted: list[Decision] = []
-        seen_plan = False
+        seen_task_frame = False
         prior_user_messages: list[str] = []
 
         for event in events:
             event_payload = event.payload
             if event.event_type == EventType.MESSAGE_USER:
                 message = _string_or_none(event_payload.get("message"))
+                is_new_user_intent = (
+                    message is not None
+                    and (
+                        not prior_user_messages
+                        or _normalize_message_intent(message)
+                        != _normalize_message_intent(prior_user_messages[-1])
+                    )
+                )
                 if message is not None and prior_user_messages and _is_meaningful_clarification(
                     message,
                     prior_user_messages[-1],
@@ -658,15 +668,60 @@ class OpenPrecedentService:
                     extracted.append(
                         self._build_decision(
                             case_id=case_id,
-                            decision_type=DecisionType.CLARIFY,
-                            title="User clarification received",
-                            question="Did the user refine the task or add a new constraint?",
-                            chosen_action="Incorporate the follow-up user guidance",
+                            decision_type=DecisionType.CLARIFICATION_RESOLVED,
+                            title="Task ambiguity resolved",
+                            question="How did follow-up guidance change the task understanding?",
+                            chosen_action=message,
                             evidence_event_ids=[event.event_id],
-                            constraints=["Later user messages can narrow scope or add constraints"],
-                            selection_reason="A follow-up user message during execution usually reflects clarified scope, constraints, or new instructions.",
+                            constraints=["Later user guidance can refine or narrow task understanding"],
+                            selection_reason="A meaningful follow-up user message changed the task framing compared with the earlier request.",
                             outcome=message,
                             confidence=0.85,
+                        )
+                    )
+                if message is not None and is_new_user_intent and _looks_like_constraint(message):
+                    extracted.append(
+                        self._build_decision(
+                            case_id=case_id,
+                            decision_type=DecisionType.CONSTRAINT_ADOPTED,
+                            title="Constraint adopted",
+                            question="What constraint or guardrail is now part of the task?",
+                            chosen_action=message,
+                            evidence_event_ids=[event.event_id],
+                            constraints=["User-stated constraints should shape subsequent execution"],
+                            selection_reason="The user message introduced or narrowed a concrete task constraint.",
+                            outcome=message,
+                            confidence=0.84,
+                        )
+                    )
+                if message is not None and is_new_user_intent and _looks_like_success_criteria(message):
+                    extracted.append(
+                        self._build_decision(
+                            case_id=case_id,
+                            decision_type=DecisionType.SUCCESS_CRITERIA_SET,
+                            title="Success criteria established",
+                            question="What explicit standard now defines done or acceptable output?",
+                            chosen_action=message,
+                            evidence_event_ids=[event.event_id],
+                            constraints=["The task should be evaluated against explicit success criteria"],
+                            selection_reason="The user message made the expected output shape or acceptance bar explicit.",
+                            outcome=message,
+                            confidence=0.83,
+                        )
+                    )
+                if message is not None and is_new_user_intent and _looks_like_option_rejection(message):
+                    extracted.append(
+                        self._build_decision(
+                            case_id=case_id,
+                            decision_type=DecisionType.OPTION_REJECTED,
+                            title="Option rejected",
+                            question="Which candidate path was explicitly ruled out?",
+                            chosen_action=message,
+                            evidence_event_ids=[event.event_id],
+                            constraints=["Rejected options should remain out of scope"],
+                            selection_reason="The message explicitly rejected one path in favor of a different direction.",
+                            outcome=message,
+                            confidence=0.82,
                         )
                     )
                 if message is not None:
@@ -675,112 +730,55 @@ class OpenPrecedentService:
                 extracted.append(
                     self._build_decision(
                         case_id=case_id,
-                        decision_type=DecisionType.CLARIFY,
-                        title="User confirmation recorded",
-                        question="Did the user confirm a constraint or proposed next step?",
-                        chosen_action="Continue with confirmed instruction",
+                        decision_type=DecisionType.AUTHORITY_CONFIRMED,
+                        title="Authority confirmed",
+                        question="What approval or decision authority was confirmed?",
+                        chosen_action=_string_or_default(
+                            event_payload.get("message"),
+                            "Continue within the approved boundary",
+                        ),
                         evidence_event_ids=[event.event_id],
-                        constraints=["User confirmation received"],
-                        selection_reason="The user explicitly confirmed the next step or constraint.",
+                        constraints=["Human confirmation established the allowed path forward"],
+                        selection_reason="A user confirmation event signals explicit approval or authority for the chosen direction.",
                         outcome=_string_or_none(event_payload.get("message")),
                         confidence=0.9,
-                    )
+                    ).model_copy(update={"requires_human_confirmation": True})
                 )
-            elif event.event_type == EventType.MESSAGE_AGENT and not seen_plan:
-                extracted.append(
-                    self._build_decision(
-                        case_id=case_id,
-                        decision_type=DecisionType.PLAN,
-                        title="Initial execution plan",
-                        question="What path should the agent take first?",
-                        chosen_action=_string_or_default(event_payload.get("message"), "Proceed with the first stated plan"),
-                        evidence_event_ids=[event.event_id],
-                        constraints=["Use the first explicit agent plan as the baseline path"],
-                        selection_reason="The first substantive agent response usually establishes the initial execution path.",
-                        outcome="Initial plan captured from agent response",
-                        confidence=0.7,
-                    )
-                )
-                seen_plan = True
-            elif event.event_type == EventType.TOOL_CALLED:
-                tool_name = _string_or_default(event_payload.get("tool_name"), "unknown_tool")
-                extracted.append(
-                    self._build_decision(
-                        case_id=case_id,
-                        decision_type=DecisionType.SELECT_TOOL,
-                        title=f"Selected tool: {tool_name}",
-                        question="Which tool should be used next?",
-                        chosen_action=f"Use {tool_name}",
-                        evidence_event_ids=[event.event_id],
-                        constraints=["Prefer the tool explicitly chosen by the runtime"],
-                        selection_reason=f"The runtime selected {tool_name} for the next operation.",
-                        outcome=_string_or_none(event_payload.get("reason")),
-                        confidence=0.8,
-                    )
-                )
-            elif event.event_type == EventType.FILE_WRITE:
-                file_path = _string_or_default(event_payload.get("path"), "unknown_path")
-                extracted.append(
-                    self._build_decision(
-                        case_id=case_id,
-                        decision_type=DecisionType.APPLY_CHANGE,
-                        title=f"Applied file change: {file_path}",
-                        question="Should the agent modify repository state?",
-                        chosen_action=f"Write {file_path}",
-                        evidence_event_ids=[event.event_id],
-                        constraints=["File write indicates a committed repository change"],
-                        selection_reason=f"The runtime wrote {file_path}, which marks an applied change decision.",
-                        outcome=_string_or_none(event_payload.get("summary")),
-                        confidence=0.85,
-                    )
-                )
-            elif event.event_type == EventType.COMMAND_COMPLETED:
-                exit_code = event_payload.get("exit_code")
-                if isinstance(exit_code, int) and exit_code != 0:
+            elif event.event_type == EventType.MESSAGE_AGENT:
+                message = _string_or_none(event_payload.get("message"))
+                if message is None:
+                    continue
+                if not seen_task_frame and _looks_like_task_frame(message):
                     extracted.append(
                         self._build_decision(
                             case_id=case_id,
-                            decision_type=DecisionType.RETRY_OR_RECOVER,
-                            title="Recovered from command failure",
-                            question="How should execution proceed after a failing command?",
-                            chosen_action="Inspect failure and choose a narrower recovery path",
+                            decision_type=DecisionType.TASK_FRAME_DEFINED,
+                            title="Task frame established",
+                            question="How is the task being framed for execution?",
+                            chosen_action=message,
                             evidence_event_ids=[event.event_id],
-                            constraints=["Non-zero command exit indicates recovery is required"],
-                            selection_reason="The command failed, so the next meaningful step is a recovery choice rather than normal continuation.",
-                            outcome=_string_or_none(event_payload.get("stderr")) or f"exit_code={exit_code}",
-                            confidence=0.9,
+                            constraints=["The first substantive agent framing sets the working interpretation of the task"],
+                            selection_reason="The agent explicitly restated how it understood the task and what boundary it would operate within.",
+                            outcome="Initial task frame captured from agent response",
+                            confidence=0.7,
                         )
                     )
-            elif event.event_type == EventType.CASE_COMPLETED:
-                extracted.append(
-                    self._build_decision(
-                        case_id=case_id,
-                        decision_type=DecisionType.FINALIZE,
-                        title="Case finalized successfully",
-                        question="Is the case ready to conclude?",
-                        chosen_action="Return the final result",
-                        evidence_event_ids=[event.event_id],
-                        constraints=["Case completion event closes execution"],
-                        selection_reason="The runtime emitted a completion event, so the case should be finalized successfully.",
-                        outcome=_string_or_none(event_payload.get("summary")) or "Case completed",
-                        confidence=0.95,
+                    seen_task_frame = True
+                if _looks_like_option_rejection(message):
+                    extracted.append(
+                        self._build_decision(
+                            case_id=case_id,
+                            decision_type=DecisionType.OPTION_REJECTED,
+                            title="Alternative path rejected",
+                            question="Which path did the agent explicitly decide not to pursue?",
+                            chosen_action=message,
+                            evidence_event_ids=[event.event_id],
+                            constraints=["Explicitly rejected paths should remain out of scope"],
+                            selection_reason="The agent message ruled out one approach while committing to another.",
+                            outcome=message,
+                            confidence=0.77,
+                        )
                     )
-                )
-            elif event.event_type == EventType.CASE_FAILED:
-                extracted.append(
-                    self._build_decision(
-                        case_id=case_id,
-                        decision_type=DecisionType.FINALIZE,
-                        title="Case finalized with failure",
-                        question="Should the case terminate with a failure outcome?",
-                        chosen_action="Stop execution and surface failure",
-                        evidence_event_ids=[event.event_id],
-                        constraints=["Case failure event closes execution with an error state"],
-                        selection_reason="The runtime emitted a failure event, so execution should stop and surface the failure.",
-                        outcome=_string_or_none(event_payload.get("summary")) or "Case failed",
-                        confidence=0.95,
-                    )
-                )
 
         numbered: list[Decision] = []
         for index, decision in enumerate(extracted, start=1):
@@ -921,7 +919,12 @@ class OpenPrecedentService:
         return {
             "status": case.status.value,
             "has_file_write": event_types[EventType.FILE_WRITE.value] > 0,
-            "has_recovery": decision_types[DecisionType.RETRY_OR_RECOVER.value] > 0,
+            "has_recovery": any(
+                event.event_type == EventType.COMMAND_COMPLETED
+                and isinstance(event.payload.get("exit_code"), int)
+                and int(event.payload.get("exit_code")) != 0
+                for event in events
+            ),
             "tool_count": event_types[EventType.TOOL_CALLED.value],
             "tool_names": tool_names,
             "file_paths": file_paths,
@@ -1004,8 +1007,10 @@ class OpenPrecedentService:
 
         current_decision_keys = set(current["decision_types"])
         other_decision_keys = set(other["decision_types"])
-        clarify_mismatch = DecisionType.CLARIFY.value in (current_decision_keys ^ other_decision_keys)
-        if clarify_mismatch:
+        clarification_mismatch = DecisionType.CLARIFICATION_RESOLVED.value in (
+            current_decision_keys ^ other_decision_keys
+        )
+        if clarification_mismatch:
             score -= 1
             differences.append("different clarification pattern")
 
@@ -1600,6 +1605,66 @@ def _is_meaningful_clarification(message: str, prior_message: str) -> bool:
 
 def _normalize_message_intent(text: str) -> str:
     return re.sub(r"\s+", " ", text.strip().lower())
+
+
+_TASK_FRAME_PREFIXES = (
+    "i will ",
+    "i'll ",
+    "i can ",
+    "i found ",
+    "i am going to ",
+    "i'm going to ",
+    "let me ",
+)
+_CONSTRAINT_MARKERS = (
+    "focus on",
+    "only ",
+    "do not",
+    "don't",
+    "without ",
+    "must ",
+    "need to",
+    "avoid ",
+    "instead of",
+)
+_SUCCESS_CRITERIA_MARKERS = (
+    "done when",
+    "success means",
+    "return ",
+    "provide ",
+    "give me",
+    "output ",
+    "summary ",
+    "summarize ",
+    "nothing else",
+)
+_OPTION_REJECTION_MARKERS = (
+    "do not",
+    "don't",
+    "instead of",
+    "rather than",
+    "skip ",
+)
+
+
+def _looks_like_task_frame(message: str) -> bool:
+    normalized = _normalize_message_intent(message)
+    return normalized.startswith(_TASK_FRAME_PREFIXES) or " i will " in normalized
+
+
+def _looks_like_constraint(message: str) -> bool:
+    normalized = _normalize_message_intent(message)
+    return any(marker in normalized for marker in _CONSTRAINT_MARKERS)
+
+
+def _looks_like_success_criteria(message: str) -> bool:
+    normalized = _normalize_message_intent(message)
+    return any(marker in normalized for marker in _SUCCESS_CRITERIA_MARKERS)
+
+
+def _looks_like_option_rejection(message: str) -> bool:
+    normalized = _normalize_message_intent(message)
+    return any(marker in normalized for marker in _OPTION_REJECTION_MARKERS)
 
 
 def _normalize_openclaw_tool_call_events(

--- a/tests/fixtures/evaluation/real_session_suite.json
+++ b/tests/fixtures/evaluation/real_session_suite.json
@@ -5,7 +5,7 @@
       "title": "Anonymized real session file ops",
       "trace_path": "../openclaw_sessions/file-ops-session.jsonl",
       "source_format": "openclaw_session",
-      "expected_decision_types": ["plan", "select_tool", "apply_change"],
+      "expected_decision_types": ["task_frame_defined"],
       "expected_precedent_case_ids": ["eval_real_search_read"]
     },
     {
@@ -13,7 +13,7 @@
       "title": "Anonymized real session search read",
       "trace_path": "../openclaw_sessions/search-read-session.jsonl",
       "source_format": "openclaw_session",
-      "expected_decision_types": ["plan", "select_tool"],
+      "expected_decision_types": ["task_frame_defined"],
       "expected_precedent_case_ids": ["eval_real_file_ops"]
     },
     {
@@ -21,7 +21,7 @@
       "title": "Anonymized real session clarify",
       "trace_path": "../openclaw_sessions/clarify-session.jsonl",
       "source_format": "openclaw_session",
-      "expected_decision_types": ["plan", "clarify", "select_tool"],
+      "expected_decision_types": ["success_criteria_set", "task_frame_defined", "clarification_resolved", "constraint_adopted"],
       "expected_precedent_case_ids": ["eval_real_search_read"]
     }
   ]

--- a/tests/fixtures/evaluation/suite.json
+++ b/tests/fixtures/evaluation/suite.json
@@ -4,21 +4,21 @@
       "case_id": "eval_summary_a",
       "title": "Evaluation summary case A",
       "trace_path": "openclaw_summary_a.jsonl",
-      "expected_decision_types": ["plan", "select_tool", "apply_change", "finalize"],
+      "expected_decision_types": ["success_criteria_set", "task_frame_defined"],
       "expected_precedent_case_ids": ["eval_summary_b"]
     },
     {
       "case_id": "eval_summary_b",
       "title": "Evaluation summary case B",
       "trace_path": "openclaw_summary_b.jsonl",
-      "expected_decision_types": ["plan", "select_tool", "apply_change", "finalize"],
+      "expected_decision_types": ["success_criteria_set", "task_frame_defined"],
       "expected_precedent_case_ids": ["eval_summary_a"]
     },
     {
       "case_id": "eval_recovery",
       "title": "Evaluation recovery case",
       "trace_path": "openclaw_recovery.jsonl",
-      "expected_decision_types": ["plan", "select_tool", "retry_or_recover", "finalize"],
+      "expected_decision_types": ["task_frame_defined"],
       "expected_precedent_case_ids": []
     }
   ]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -77,7 +77,7 @@ async def test_case_ingestion_replay_and_precedent_flow(db_path) -> None:
 
         extracted = await client.post("/cases/case_alpha/extract-decisions")
         assert extracted.status_code == 200
-        assert len(extracted.json()["decisions"]) >= 3
+        assert len(extracted.json()["decisions"]) >= 2
         first_decision = extracted.json()["decisions"][0]
         assert "explanation" in first_decision
         assert "goal" in first_decision["explanation"]
@@ -92,7 +92,7 @@ async def test_case_ingestion_replay_and_precedent_flow(db_path) -> None:
         body = replay.json()
         assert body["case"]["case_id"] == "case_alpha"
         assert len(body["events"]) == 5
-        assert len(body["decisions"]) >= 3
+        assert len(body["decisions"]) >= 2
         assert len(body["artifacts"]) >= 3
         assert body["summary"] == "summary delivered"
 
@@ -131,7 +131,7 @@ def test_service_imports_openclaw_runtime_trace(db_path) -> None:
     assert len(result.imported_events) == 6
 
     decisions = service.extract_decisions("case_runtime")
-    assert len(decisions) >= 4
+    assert len(decisions) >= 2
 
     replay = service.replay_case("case_runtime")
     assert replay.case.status.value == "completed"
@@ -178,8 +178,9 @@ def test_service_lists_and_imports_openclaw_session(db_path, tmp_path: Path) -> 
     assert any(event.event_type.value == "command.completed" for event in events)
 
     decisions = service.extract_decisions("case_session")
-    assert any(item.decision_type.value == "plan" for item in decisions)
-    assert any(item.decision_type.value == "select_tool" for item in decisions)
+    decision_types = [item.decision_type.value for item in decisions]
+    assert "task_frame_defined" in decision_types
+    assert "success_criteria_set" in decision_types
 
     replay = service.replay_case("case_session")
     assert replay.summary == "Imported OpenClaw session: 9 events, 2 decisions, status=started"
@@ -244,7 +245,7 @@ def test_service_imports_failing_openclaw_command_without_output(db_path) -> Non
     assert command_completed[0].payload["stderr"] is None
 
     decisions = service.extract_decisions("case_session_failure")
-    assert any(item.decision_type.value == "retry_or_recover" for item in decisions)
+    assert [item.decision_type.value for item in decisions] == ["task_frame_defined"]
 
 
 def test_service_reports_unsupported_openclaw_session_record_types(db_path) -> None:
@@ -323,10 +324,10 @@ def test_service_imports_additional_live_openclaw_record_types(db_path) -> None:
     }
 
     decisions = service.extract_decisions("case_session_live_record_types")
-    assert [item.decision_type.value for item in decisions] == ["plan"]
+    assert [item.decision_type.value for item in decisions] == ["task_frame_defined"]
 
 
-def test_service_extracts_clarify_decision_from_follow_up_user_message(db_path) -> None:
+def test_service_extracts_semantic_decisions_from_follow_up_user_message(db_path) -> None:
     service = OpenPrecedentService.from_path(get_db_path())
     transcript_path = (
         Path(__file__).parent / "fixtures" / "openclaw_sessions" / "clarify-session.jsonl"
@@ -343,14 +344,22 @@ def test_service_extracts_clarify_decision_from_follow_up_user_message(db_path) 
     assert len(result.imported_events) == 11
 
     decisions = service.extract_decisions("case_session_clarify")
-    clarify_decisions = [item for item in decisions if item.decision_type.value == "clarify"]
-    assert len(clarify_decisions) == 1
-    assert clarify_decisions[0].outcome == "Focus on collector scheduling and evaluation gaps."
-    assert clarify_decisions[0].evidence_event_ids == ["evt_message_msg-user-clarify-followup"]
-    assert clarify_decisions[0].explanation.selection_reason
+    decision_types = [item.decision_type.value for item in decisions]
+    assert decision_types == [
+        "success_criteria_set",
+        "task_frame_defined",
+        "clarification_resolved",
+        "constraint_adopted",
+    ]
+    clarification = next(
+        item for item in decisions if item.decision_type.value == "clarification_resolved"
+    )
+    assert clarification.outcome == "Focus on collector scheduling and evaluation gaps."
+    assert clarification.evidence_event_ids == ["evt_message_msg-user-clarify-followup"]
+    assert clarification.explanation.selection_reason
 
 
-def test_service_skips_false_clarify_on_wrapped_repeat_message(db_path) -> None:
+def test_service_skips_false_clarification_on_wrapped_repeat_message(db_path) -> None:
     service = OpenPrecedentService.from_path(get_db_path())
     transcript_path = (
         Path(__file__).parent
@@ -370,7 +379,10 @@ def test_service_skips_false_clarify_on_wrapped_repeat_message(db_path) -> None:
     assert len(result.imported_events) == 10
 
     decisions = service.extract_decisions("case_session_wrapped_clarify_false")
-    assert [item.decision_type.value for item in decisions] == ["plan", "select_tool"]
+    assert [item.decision_type.value for item in decisions] == [
+        "success_criteria_set",
+        "task_frame_defined",
+    ]
 
 
 def test_service_strips_openclaw_message_wrappers_before_import(db_path) -> None:
@@ -401,7 +413,10 @@ def test_service_strips_openclaw_message_wrappers_before_import(db_path) -> None
     ]
 
     decisions = service.extract_decisions("case_session_wrapped_messages")
-    assert [item.decision_type.value for item in decisions] == ["plan"]
+    assert [item.decision_type.value for item in decisions] == [
+        "success_criteria_set",
+        "task_frame_defined",
+    ]
 
 
 def test_service_imports_openclaw_file_operations(db_path) -> None:
@@ -427,7 +442,42 @@ def test_service_imports_openclaw_file_operations(db_path) -> None:
     assert file_writes[0].payload["path"] == "docs/architecture/openclaw-silent-collection.md"
 
     decisions = service.extract_decisions("case_session_file_ops")
-    assert any(item.decision_type.value == "apply_change" for item in decisions)
+    assert [item.decision_type.value for item in decisions] == ["task_frame_defined"]
+
+
+def test_service_extracts_authority_and_option_rejection_semantics(db_path) -> None:
+    service = OpenPrecedentService.from_path(get_db_path())
+    service.create_case(
+        CreateCaseInput(case_id="case_semantic_authority", title="Semantic authority test")
+    )
+
+    service.append_event(
+        "case_semantic_authority",
+        AppendEventInput(
+            event_type=EventType.MESSAGE_USER,
+            actor=EventActor.USER,
+            payload={"message": "Do not edit code. Provide a short written recommendation only."},
+        ),
+    )
+    service.append_event(
+        "case_semantic_authority",
+        AppendEventInput(
+            event_type=EventType.USER_CONFIRMED,
+            actor=EventActor.USER,
+            payload={"message": "Approved. Stay within docs-only scope."},
+        ),
+    )
+
+    decisions = service.extract_decisions("case_semantic_authority")
+    decision_types = [item.decision_type.value for item in decisions]
+    assert decision_types == [
+        "constraint_adopted",
+        "success_criteria_set",
+        "option_rejected",
+        "authority_confirmed",
+    ]
+    authority = next(item for item in decisions if item.decision_type.value == "authority_confirmed")
+    assert authority.requires_human_confirmation is True
 
 
 def test_service_imports_openclaw_view_image_as_file_read(db_path) -> None:
@@ -589,7 +639,9 @@ def test_service_evaluates_real_session_fixture_suite(db_path) -> None:
     assert report.failed_cases == 0
     assert report.passed_cases == 3
     clarify_result = next(item for item in report.results if item.case_id == "eval_real_clarify")
-    assert "clarify" in [decision_type.value for decision_type in clarify_result.actual_decision_types]
+    assert "clarification_resolved" in [
+        decision_type.value for decision_type in clarify_result.actual_decision_types
+    ]
 
 
 def test_service_fixture_evaluation_fails_fast_on_reused_database(db_path) -> None:
@@ -686,7 +738,7 @@ def test_service_evaluates_collected_openclaw_sessions(db_path, tmp_path: Path) 
     assert report.evaluated_cases == 3
     assert report.failed_cases == 0
     assert report.cases_with_precedents >= 1
-    assert "retry_or_recover" in report.decision_type_counts
+    assert "task_frame_defined" in report.decision_type_counts
     assert report.unsupported_record_type_counts == {"audit_marker": 1}
     assert {item.session_id for item in report.results} == {
         "sample-session",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,7 +59,7 @@ def test_cli_end_to_end(capsys, db_path) -> None:
     result = main(["extract", "decisions", "case_cli"])
     assert result == 0
     decisions = json.loads(capsys.readouterr().out)
-    assert len(decisions) >= 2
+    assert len(decisions) >= 1
     assert "explanation" in decisions[0]
     assert "selection_reason" in decisions[0]["explanation"]
 
@@ -190,10 +190,9 @@ def test_cli_import_openclaw_runtime_trace(capsys, db_path) -> None:
     result = main(["extract", "decisions", "case_openclaw"])
     assert result == 0
     decisions = json.loads(capsys.readouterr().out)
-    assert any(item["decision_type"] == "plan" for item in decisions)
-    assert any(item["decision_type"] == "select_tool" for item in decisions)
-    assert any(item["decision_type"] == "apply_change" for item in decisions)
-    assert any(item["decision_type"] == "finalize" for item in decisions)
+    decision_types = [item["decision_type"] for item in decisions]
+    assert "task_frame_defined" in decision_types
+    assert "success_criteria_set" in decision_types
 
     result = main(["replay", "case", "case_openclaw", "--json"])
     assert result == 0
@@ -281,7 +280,7 @@ def test_cli_imports_failing_openclaw_command_without_output(capsys, db_path) ->
     result = main(["extract", "decisions", "case_session_failure_cli"])
     assert result == 0
     decisions = json.loads(capsys.readouterr().out)
-    assert any(item["decision_type"] == "retry_or_recover" for item in decisions)
+    assert [item["decision_type"] for item in decisions] == ["task_frame_defined"]
 
     result = main(["replay", "case", "case_session_failure_cli", "--json"])
     assert result == 0
@@ -316,7 +315,7 @@ def test_cli_imports_openclaw_file_operations(capsys, db_path) -> None:
     result = main(["extract", "decisions", "case_session_file_ops_cli"])
     assert result == 0
     decisions = json.loads(capsys.readouterr().out)
-    assert any(item["decision_type"] == "apply_change" for item in decisions)
+    assert [item["decision_type"] for item in decisions] == ["task_frame_defined"]
 
     result = main(["replay", "case", "case_session_file_ops_cli", "--json"])
     assert result == 0
@@ -420,7 +419,7 @@ def test_cli_imports_additional_live_openclaw_record_types(capsys, db_path) -> N
     assert custom_events[0]["payload"]["details"]["status"] == "error"
 
 
-def test_cli_extracts_clarify_decision_from_follow_up_user_message(capsys, db_path) -> None:
+def test_cli_extracts_semantic_decisions_from_follow_up_user_message(capsys, db_path) -> None:
     fixture_path = (
         Path(__file__).parent / "fixtures" / "openclaw_sessions" / "clarify-session.jsonl"
     )
@@ -443,13 +442,18 @@ def test_cli_extracts_clarify_decision_from_follow_up_user_message(capsys, db_pa
     result = main(["extract", "decisions", "case_session_clarify_cli"])
     assert result == 0
     decisions = json.loads(capsys.readouterr().out)
-    clarify_decisions = [item for item in decisions if item["decision_type"] == "clarify"]
-    assert len(clarify_decisions) == 1
-    assert clarify_decisions[0]["outcome"] == "Focus on collector scheduling and evaluation gaps."
-    assert clarify_decisions[0]["evidence_event_ids"] == ["evt_message_msg-user-clarify-followup"]
+    assert [item["decision_type"] for item in decisions] == [
+        "success_criteria_set",
+        "task_frame_defined",
+        "clarification_resolved",
+        "constraint_adopted",
+    ]
+    clarification = next(item for item in decisions if item["decision_type"] == "clarification_resolved")
+    assert clarification["outcome"] == "Focus on collector scheduling and evaluation gaps."
+    assert clarification["evidence_event_ids"] == ["evt_message_msg-user-clarify-followup"]
 
 
-def test_cli_skips_false_clarify_on_wrapped_repeat_message(capsys, db_path) -> None:
+def test_cli_skips_false_clarification_on_wrapped_repeat_message(capsys, db_path) -> None:
     fixture_path = (
         Path(__file__).parent
         / "fixtures"
@@ -475,7 +479,10 @@ def test_cli_skips_false_clarify_on_wrapped_repeat_message(capsys, db_path) -> N
     result = main(["extract", "decisions", "case_session_wrapped_clarify_false_cli"])
     assert result == 0
     decisions = json.loads(capsys.readouterr().out)
-    assert [item["decision_type"] for item in decisions] == ["plan", "select_tool"]
+    assert [item["decision_type"] for item in decisions] == [
+        "success_criteria_set",
+        "task_frame_defined",
+    ]
 
 
 def test_cli_strips_openclaw_message_wrappers_before_import(capsys, db_path) -> None:
@@ -508,7 +515,10 @@ def test_cli_strips_openclaw_message_wrappers_before_import(capsys, db_path) -> 
     result = main(["extract", "decisions", "case_session_wrapped_messages_cli"])
     assert result == 0
     decisions = json.loads(capsys.readouterr().out)
-    assert [item["decision_type"] for item in decisions] == ["plan"]
+    assert [item["decision_type"] for item in decisions] == [
+        "success_criteria_set",
+        "task_frame_defined",
+    ]
 
 
 def test_cli_imports_openclaw_view_image_as_file_read(capsys, db_path) -> None:
@@ -829,7 +839,7 @@ def test_cli_evaluates_collected_openclaw_sessions(capsys, db_path, tmp_path: Pa
     report = json.loads(capsys.readouterr().out)
     assert report["total_sessions"] == 3
     assert report["evaluated_cases"] == 3
-    assert "retry_or_recover" in report["decision_type_counts"]
+    assert "task_frame_defined" in report["decision_type_counts"]
     assert report["unsupported_record_type_counts"] == {"audit_marker": 1}
     assert report_path.exists()
 


### PR DESCRIPTION
## Summary
- replace the old operational decision taxonomy with the new semantic decision-lineage schema
- refit decision extraction so tool choice, file writes, retries, and finalize events no longer produce decisions
- update API, CLI, and fixture expectations to validate semantic decisions and operational-only negative cases

## Testing
- ============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /workspace/02-projects/incubation/openprecedent
configfile: pyproject.toml
plugins: anyio-4.12.1
collected 26 items / 17 deselected / 9 selected

tests/test_api.py .........                                              [100%]

======================= 9 passed, 17 deselected in 0.94s =======================
- ============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /workspace/02-projects/incubation/openprecedent
configfile: pyproject.toml
plugins: anyio-4.12.1
collected 23 items / 17 deselected / 6 selected

tests/test_cli.py ......                                                 [100%]

======================= 6 passed, 17 deselected in 0.61s =======================
- ============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /workspace/02-projects/incubation/openprecedent
configfile: pyproject.toml
plugins: anyio-4.12.1
collected 26 items / 22 deselected / 4 selected

tests/test_api.py ....                                                   [100%]

======================= 4 passed, 22 deselected in 0.91s =======================
- ============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /workspace/02-projects/incubation/openprecedent
configfile: pyproject.toml
plugins: anyio-4.12.1
collected 23 items / 19 deselected / 4 selected

tests/test_cli.py ....                                                   [100%]

======================= 4 passed, 19 deselected in 0.77s =======================
- ============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /workspace/02-projects/incubation/openprecedent
configfile: pyproject.toml
plugins: anyio-4.12.1
collected 49 items

tests/test_api.py ..........................                             [ 53%]
tests/test_cli.py .......................                                [100%]

============================== 49 passed in 4.75s ==============================

Closes #69