### PR TITLE
Rebuild semantic decision fixtures

### DIFF
--- a/.codex/pm/tasks/semantic-decision-foundation/rebuild-semantic-decision-fixtures-and-tests.md
+++ b/.codex/pm/tasks/semantic-decision-foundation/rebuild-semantic-decision-fixtures-and-tests.md
@@ -3,7 +3,7 @@ type: task
 epic: semantic-decision-foundation
 slug: rebuild-semantic-decision-fixtures-and-tests
 title: Rebuild evaluation fixtures and tests for semantic decision lineage
-status: backlog
+status: in_progress
 labels: test,docs
 depends_on: 69
 issue: 70

--- a/tests/fixtures/evaluation/openclaw_authority_scope.jsonl
+++ b/tests/fixtures/evaluation/openclaw_authority_scope.jsonl
@@ -1,0 +1,4 @@
+{"timestamp":"2026-03-10T10:00:00Z","kind":"user_message","content":"Do not edit code. Provide a short written recommendation only."}
+{"timestamp":"2026-03-10T10:00:02Z","kind":"agent_message","content":"I will stay within docs-only scope and provide a short recommendation."}
+{"timestamp":"2026-03-10T10:00:04Z","kind":"confirmation","content":"Approved. Stay within docs-only scope."}
+{"timestamp":"2026-03-10T10:00:06Z","kind":"completed","summary":"Provided a short recommendation without editing code."}

--- a/tests/fixtures/evaluation/openclaw_operational_only.jsonl
+++ b/tests/fixtures/evaluation/openclaw_operational_only.jsonl
@@ -1,0 +1,4 @@
+{"timestamp":"2026-03-10T11:00:00Z","kind":"tool_call","tool_name":"exec_command","reason":"inspect repository files","arguments":{"cmd":"rg --files docs"}}
+{"timestamp":"2026-03-10T11:00:02Z","kind":"command","command":"rg --files docs","exit_code":0,"stdout":"docs/architecture/mvp-design.md","stderr":""}
+{"timestamp":"2026-03-10T11:00:04Z","kind":"file_write","path":"notes/scratch.txt","summary":"captured temporary scratch note"}
+{"timestamp":"2026-03-10T11:00:06Z","kind":"completed","summary":"Finished the operational sequence."}

--- a/tests/fixtures/evaluation/suite.json
+++ b/tests/fixtures/evaluation/suite.json
@@ -20,6 +20,20 @@
       "trace_path": "openclaw_recovery.jsonl",
       "expected_decision_types": ["task_frame_defined"],
       "expected_precedent_case_ids": []
+    },
+    {
+      "case_id": "eval_authority_scope",
+      "title": "Evaluation authority and scope case",
+      "trace_path": "openclaw_authority_scope.jsonl",
+      "expected_decision_types": ["constraint_adopted", "success_criteria_set", "option_rejected", "task_frame_defined", "authority_confirmed"],
+      "expected_precedent_case_ids": []
+    },
+    {
+      "case_id": "eval_operational_only",
+      "title": "Evaluation operational-only case",
+      "trace_path": "openclaw_operational_only.jsonl",
+      "expected_decision_types": [],
+      "expected_precedent_case_ids": []
     }
   ]
 }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -624,9 +624,23 @@ def test_service_evaluates_fixture_suite(db_path) -> None:
 
     report = service.evaluate_openclaw_fixture_suite(suite_path)
 
-    assert report.total_cases == 3
+    assert report.total_cases == 5
     assert report.failed_cases == 0
-    assert report.passed_cases == 3
+    assert report.passed_cases == 5
+    assert all(not item.extra_decision_types for item in report.results)
+
+    authority_result = next(item for item in report.results if item.case_id == "eval_authority_scope")
+    assert [decision_type.value for decision_type in authority_result.actual_decision_types] == [
+        "constraint_adopted",
+        "success_criteria_set",
+        "option_rejected",
+        "task_frame_defined",
+        "authority_confirmed",
+    ]
+
+    operational_only = next(item for item in report.results if item.case_id == "eval_operational_only")
+    assert operational_only.actual_decision_types == []
+    assert operational_only.extra_decision_types == []
 
 
 def test_service_evaluates_real_session_fixture_suite(db_path) -> None:
@@ -638,6 +652,7 @@ def test_service_evaluates_real_session_fixture_suite(db_path) -> None:
     assert report.total_cases == 3
     assert report.failed_cases == 0
     assert report.passed_cases == 3
+    assert all(not item.extra_decision_types for item in report.results)
     clarify_result = next(item for item in report.results if item.case_id == "eval_real_clarify")
     assert "clarification_resolved" in [
         decision_type.value for decision_type in clarify_result.actual_decision_types
@@ -808,3 +823,16 @@ def test_service_precedent_prefers_semantically_related_case(db_path) -> None:
     assert len(precedents) == 2
     assert precedents[0].case_id == "case_semantic_related"
     assert precedents[0].similarity_score > precedents[1].similarity_score
+
+
+def test_service_fixture_suite_includes_operational_negative_case(db_path) -> None:
+    service = OpenPrecedentService.from_path(get_db_path())
+    suite_path = Path(__file__).parent / "fixtures" / "evaluation" / "suite.json"
+
+    report = service.evaluate_openclaw_fixture_suite(suite_path)
+
+    operational_only = next(item for item in report.results if item.case_id == "eval_operational_only")
+    assert operational_only.expected_decision_types == []
+    assert operational_only.actual_decision_types == []
+    assert operational_only.missing_decision_types == []
+    assert operational_only.extra_decision_types == []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -731,9 +731,23 @@ def test_cli_evaluates_fixture_suite(capsys, db_path) -> None:
     result = main(["eval", "fixtures", str(suite_path), "--json"])
     assert result == 0
     report = json.loads(capsys.readouterr().out)
-    assert report["total_cases"] == 3
+    assert report["total_cases"] == 5
     assert report["failed_cases"] == 0
-    assert report["passed_cases"] == 3
+    assert report["passed_cases"] == 5
+    assert all(not item["extra_decision_types"] for item in report["results"])
+
+    authority_result = next(item for item in report["results"] if item["case_id"] == "eval_authority_scope")
+    assert authority_result["actual_decision_types"] == [
+        "constraint_adopted",
+        "success_criteria_set",
+        "option_rejected",
+        "task_frame_defined",
+        "authority_confirmed",
+    ]
+
+    operational_only = next(item for item in report["results"] if item["case_id"] == "eval_operational_only")
+    assert operational_only["actual_decision_types"] == []
+    assert operational_only["extra_decision_types"] == []
 
 
 def test_cli_evaluates_real_session_fixture_suite(capsys, db_path) -> None:
@@ -745,6 +759,7 @@ def test_cli_evaluates_real_session_fixture_suite(capsys, db_path) -> None:
     assert report["total_cases"] == 3
     assert report["failed_cases"] == 0
     assert report["passed_cases"] == 3
+    assert all(not item["extra_decision_types"] for item in report["results"])
 
 
 def test_cli_fixture_evaluation_fails_fast_on_reused_database(capsys, db_path) -> None:


### PR DESCRIPTION
## Summary
- extend the semantic fixture suite with authority-confirmation and operational-only cases
- tighten API and CLI evaluation assertions so fixture reports must stay free of unexpected decision types
- keep the regression baseline focused on semantic-positive and operational-negative decision extraction behavior

## Testing
- ============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /workspace/02-projects/incubation/openprecedent
configfile: pyproject.toml
plugins: anyio-4.12.1
collected 27 items / 22 deselected / 5 selected

tests/test_api.py .....                                                  [100%]

======================= 5 passed, 22 deselected in 1.24s =======================
- ============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /workspace/02-projects/incubation/openprecedent
configfile: pyproject.toml
plugins: anyio-4.12.1
collected 23 items / 19 deselected / 4 selected

tests/test_cli.py ....                                                   [100%]

======================= 4 passed, 19 deselected in 0.83s =======================
- ============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /workspace/02-projects/incubation/openprecedent
configfile: pyproject.toml
plugins: anyio-4.12.1
collected 50 items

tests/test_api.py ...........................                            [ 54%]
tests/test_cli.py .......................                                [100%]

============================== 50 passed in 5.30s ==============================

Closes #70