### PR TITLE
Retune semantic precedent ranking

### DIFF
--- a/.codex/pm/tasks/semantic-decision-foundation/retune-semantic-precedent-ranking.md
+++ b/.codex/pm/tasks/semantic-decision-foundation/retune-semantic-precedent-ranking.md
@@ -3,7 +3,7 @@ type: task
 epic: semantic-decision-foundation
 slug: retune-semantic-precedent-ranking
 title: Retune precedent ranking toward semantic decision similarity
-status: backlog
+status: in_progress
 labels: feature,test
 depends_on: 69
 issue: 71

--- a/src/openprecedent/services.py
+++ b/src/openprecedent/services.py
@@ -916,6 +916,7 @@ class OpenPrecedentService:
             }
         )
         keywords = sorted(self._case_keywords(case, events, decisions))
+        decision_keywords = sorted(self._decision_keywords(decisions))
         return {
             "status": case.status.value,
             "has_file_write": event_types[EventType.FILE_WRITE.value] > 0,
@@ -930,6 +931,7 @@ class OpenPrecedentService:
             "file_paths": file_paths,
             "file_read_paths": file_read_paths,
             "keywords": keywords,
+            "decision_keywords": decision_keywords,
             "decision_types": dict(decision_types),
         }
 
@@ -943,7 +945,7 @@ class OpenPrecedentService:
         differences: list[str] = []
 
         if current["status"] == other["status"]:
-            score += 2
+            score += 1
             similarities.append("same status")
         else:
             differences.append("different status")
@@ -951,7 +953,7 @@ class OpenPrecedentService:
         for key in ("has_file_write", "has_recovery"):
             if current[key] == other[key]:
                 if current[key]:
-                    score += 2
+                    score += 1
                     similarities.append(f"same {key}")
             else:
                 differences.append(f"different {key}")
@@ -959,43 +961,53 @@ class OpenPrecedentService:
         current_decisions = current["decision_types"]
         other_decisions = other["decision_types"]
         if current_decisions == other_decisions:
-            score += 3
+            score += 6
             similarities.append("same decision shape")
         else:
             current_decision_keys = set(current_decisions)
             other_decision_keys = set(other_decisions)
             shared_decisions = sorted(current_decision_keys & other_decision_keys)
             if shared_decisions:
-                score += min(len(shared_decisions), 3)
+                score += min(len(shared_decisions) * 2, 6)
                 similarities.append("shared decision types: " + ",".join(shared_decisions))
             else:
                 differences.append("different decision shape")
 
+        shared_decision_keywords = sorted(
+            set(current["decision_keywords"]) & set(other["decision_keywords"])
+        )
+        if shared_decision_keywords:
+            score += min(len(shared_decision_keywords) * 2, 8)
+            similarities.append(
+                "shared decision language: " + ",".join(shared_decision_keywords[:4])
+            )
+        else:
+            differences.append("different decision language")
+
         tool_delta = abs(int(current["tool_count"]) - int(other["tool_count"]))
         if tool_delta == 0:
-            score += 2
+            score += 1
             similarities.append("same tool call count")
         elif tool_delta == 1:
-            score += 1
             similarities.append("nearby tool call count")
         else:
             differences.append("different tool call count")
 
         shared_tools = sorted(set(current["tool_names"]) & set(other["tool_names"]))
         if shared_tools:
-            score += min(len(shared_tools), 2)
+            score += 1
             similarities.append("shared tools: " + ",".join(shared_tools[:3]))
         else:
             differences.append("different tools")
 
         shared_paths = sorted(set(current["file_paths"]) & set(other["file_paths"]))
         if shared_paths:
-            score += min(len(shared_paths), 2)
+            score += 1
             similarities.append("shared file targets: " + ",".join(shared_paths[:3]))
 
         shared_read_paths = sorted(set(current["file_read_paths"]) & set(other["file_read_paths"]))
         if shared_read_paths:
-            score += min(len(shared_read_paths) * 2, 4)
+            score += min(len(shared_read_paths), 2)
             similarities.append("shared read targets: " + ",".join(shared_read_paths[:3]))
 
         shared_keywords = sorted(set(current["keywords"]) & set(other["keywords"]))
@@ -1036,6 +1048,15 @@ class OpenPrecedentService:
         keywords: set[str] = set()
         for text in texts:
             keywords.update(_tokenize_keywords(text))
+        return keywords
+
+    def _decision_keywords(self, decisions: list[Decision]) -> set[str]:
+        keywords: set[str] = set()
+        for decision in decisions:
+            keywords.update(_tokenize_keywords(decision.title))
+            keywords.update(_tokenize_keywords(decision.chosen_action))
+            if decision.outcome:
+                keywords.update(_tokenize_keywords(decision.outcome))
         return keywords
 
     def _build_reusable_takeaway(self, case: Case, decisions: list[Decision]) -> str | None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -825,6 +825,66 @@ def test_service_precedent_prefers_semantically_related_case(db_path) -> None:
     assert precedents[0].similarity_score > precedents[1].similarity_score
 
 
+def test_service_precedent_prefers_semantic_similarity_over_operational_overlap(db_path) -> None:
+    service = OpenPrecedentService.from_path(get_db_path())
+
+    cases = [
+        (
+            "case_precedent_current",
+            "Constrained recommendation",
+            [
+                ("message.user", "user", {"message": "Do not edit code. Provide a short written recommendation only."}),
+                ("message.agent", "agent", {"message": "I will stay within docs-only scope and provide a short recommendation."}),
+                ("tool.called", "agent", {"tool_name": "rg", "reason": "inspect docs"}),
+                ("file.write", "agent", {"path": "notes/recommendation.txt", "summary": "temporary scratch note"}),
+                ("case.completed", "system", {"summary": "recommendation delivered"}),
+            ],
+        ),
+        (
+            "case_precedent_semantic_match",
+            "Constrained guidance",
+            [
+                ("message.user", "user", {"message": "Do not edit code. Give me a brief guidance note only."}),
+                ("message.agent", "agent", {"message": "I will stay within docs-only scope and provide a brief guidance note."}),
+                ("tool.called", "agent", {"tool_name": "rg", "reason": "inspect docs"}),
+                ("file.write", "agent", {"path": "notes/guidance.txt", "summary": "temporary scratch note"}),
+                ("case.completed", "system", {"summary": "guidance delivered"}),
+            ],
+        ),
+        (
+            "case_precedent_operational_match",
+            "Same tools different goal",
+            [
+                ("message.user", "user", {"message": "Summarize the architecture document for me."}),
+                ("message.agent", "agent", {"message": "I will inspect the architecture docs and summarize them."}),
+                ("tool.called", "agent", {"tool_name": "rg", "reason": "inspect docs"}),
+                ("file.write", "agent", {"path": "notes/summary.txt", "summary": "temporary scratch note"}),
+                ("case.completed", "system", {"summary": "summary delivered"}),
+            ],
+        ),
+    ]
+
+    for case_id, title, events in cases:
+        service.create_case(CreateCaseInput(case_id=case_id, title=title))
+        for index, (event_type, actor, payload) in enumerate(events, start=1):
+            service.append_event(
+                case_id,
+                AppendEventInput(
+                    event_type=EventType(event_type),
+                    actor=EventActor(actor),
+                    payload=payload,
+                    sequence_no=index,
+                ),
+            )
+        service.extract_decisions(case_id)
+
+    precedents = service.find_precedents("case_precedent_current", limit=2)
+
+    assert len(precedents) == 2
+    assert precedents[0].case_id == "case_precedent_semantic_match"
+    assert precedents[0].similarity_score > precedents[1].similarity_score
+
+
 def test_service_fixture_suite_includes_operational_negative_case(db_path) -> None:
     service = OpenPrecedentService.from_path(get_db_path())
     suite_path = Path(__file__).parent / "fixtures" / "evaluation" / "suite.json"


### PR DESCRIPTION
## Summary
- reduce the influence of operational precedent signals such as tool count, shared tools, and file-target overlap
- increase the weight of semantic decision shape and decision-language overlap in precedent ranking
- add regression coverage proving semantic similarity outranks cases that only match on operational behavior

## Testing
- ============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /workspace/02-projects/incubation/openprecedent
configfile: pyproject.toml
plugins: anyio-4.12.1
collected 28 items / 24 deselected / 4 selected

tests/test_api.py ....                                                   [100%]

======================= 4 passed, 24 deselected in 0.83s =======================
- ============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /workspace/02-projects/incubation/openprecedent
configfile: pyproject.toml
plugins: anyio-4.12.1
collected 51 items

tests/test_api.py ............................                           [ 54%]
tests/test_cli.py .......................                                [100%]

============================== 51 passed in 5.16s ==============================

Closes #71