### PR TITLE
Validate runtime decision-lineage trigger baseline

### DIFF
--- a/.codex/pm/tasks/runtime-decision-lineage-integration/validate-runtime-decision-lineage-impact.md
+++ b/.codex/pm/tasks/runtime-decision-lineage-integration/validate-runtime-decision-lineage-impact.md
@@ -3,7 +3,7 @@ type: task
 epic: runtime-decision-lineage-integration
 slug: validate-runtime-decision-lineage-impact
 title: Validate OpenClaw runtime triggers and impact for decision-lineage retrieval
-status: backlog
+status: completed
 labels: feature,test,docs
 depends_on: 72
 issue: 73

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The repository now includes:
 ## How To Use It
 
 - usage guide for humans and agents: [docs/engineering/using-openprecedent.md](/workspace/02-projects/incubation/openprecedent/docs/engineering/using-openprecedent.md)
+- runtime decision-lineage validation baseline: [docs/engineering/openclaw-runtime-decision-lineage-validation.md](/workspace/02-projects/incubation/openprecedent/docs/engineering/openclaw-runtime-decision-lineage-validation.md)
 
 ## License
 

--- a/docs/engineering/openclaw-runtime-decision-lineage-validation.md
+++ b/docs/engineering/openclaw-runtime-decision-lineage-validation.md
@@ -1,0 +1,155 @@
+# OpenClaw Runtime Decision-Lineage Validation
+
+## Goal
+
+Record the first repository-local validation baseline for when OpenClaw should call the OpenPrecedent decision-lineage skill and what kind of benefit that brief can realistically provide.
+
+This document is intentionally narrow.
+It does not claim that OpenClaw is already runtime-integrated with OpenPrecedent inside a live execution loop.
+It defines the current best trigger policy and the expected effect of the brief when the skill is invoked at those moments.
+
+## Validation Baseline
+
+- validation date: `2026-03-10`
+- repository baseline: `upstream/main` at `8e62389`
+- runtime surface under test:
+  - `openprecedent runtime decision-lineage-brief`
+  - `skills/openprecedent-decision-lineage/SKILL.md`
+- validation mode: repository-local fixture-backed simulation
+
+## What Was Evaluated
+
+The validation focused on three candidate trigger points:
+
+1. `initial_planning`
+2. `before_file_write`
+3. `after_failure`
+
+The question was not whether the brief can tell OpenClaw which tool to use.
+The question was whether the brief can improve semantic task judgment:
+
+- task framing
+- accepted constraints
+- success criteria
+- rejected options
+- authority handling
+
+## Recommended Trigger Policy
+
+### Keep: `initial_planning`
+
+Use when:
+
+- the user request contains meaningful constraints
+- the task has likely been seen before
+- the agent needs to inherit task framing or success criteria before acting
+
+Why it is worth keeping:
+
+- this is the cleanest point to inherit prior judgment without already being committed to a local path
+- the brief is most useful here when prior cases encode docs-only scope, output shape, or approval boundaries
+
+Expected benefit:
+
+- better starting task frame
+- earlier visibility into accepted constraints
+- earlier visibility into rejected options
+
+### Keep: `before_file_write`
+
+Use when:
+
+- the agent is about to modify repository state
+- the current task has explicit scope or approval boundaries
+- a mistaken write would violate prior or current constraints
+
+Why it is worth keeping:
+
+- this is the highest-value safety checkpoint for semantic lineage reuse
+- it helps prevent drift from a recommendation or docs-only task into code modification
+
+Expected benefit:
+
+- stronger constraint adherence
+- better recognition of approval boundaries
+- fewer writes that violate the intended task frame
+
+### Keep Narrow: `after_failure`
+
+Use only when:
+
+- the failure reveals ambiguity in task direction
+- recovery requires re-evaluating constraints or rejected paths
+- the failure is semantic, not merely operational
+
+Why it should stay narrow:
+
+- many failures are local tool or command failures and do not justify precedent lookup
+- the brief is useful only when the failure changes how the task should be interpreted
+
+Expected benefit:
+
+- better recovery framing
+- better avoidance of previously rejected paths
+- more explicit re-alignment with success criteria
+
+## Trigger Points Not Recommended As Default
+
+Do not make these default automatic triggers:
+
+- every turn
+- every tool call
+- every search
+- every command failure
+
+Reason:
+
+- these moments add noise faster than they add semantic value
+- the current brief is optimized for judgment inheritance, not operational steering
+
+## Observed Value Of The Current Brief
+
+In the current implementation, the decision-lineage brief is best understood as:
+
+- a semantic memory lookup
+- a task-framing reminder
+- a constraint and authority checkpoint
+
+It is not yet:
+
+- a live planner replacement
+- a command recommender
+- a tool selector
+
+## Expected Positive Effects
+
+When used at the recommended trigger points, the brief can improve:
+
+- alignment with docs-only or no-code constraints
+- retention of explicit human approvals
+- awareness of previously rejected directions
+- consistency of task framing across similar tasks
+
+## Current Limits
+
+- this validation is fixture-backed and repository-local, not a live OpenClaw runtime A/B experiment
+- the brief depends on previously captured semantic decisions; sparse history limits usefulness
+- no automatic trigger policy is implemented yet inside OpenClaw
+- no quantitative quality delta is claimed yet
+
+## Practical Conclusion
+
+The current best policy is:
+
+1. call the skill at `initial_planning` when semantic ambiguity or strong constraints exist
+2. call the skill again at `before_file_write` for high-risk state changes
+3. use `after_failure` only for failures that require semantic re-interpretation, not routine operational retries
+
+This is enough to support the next stage of runtime experimentation without pretending that the product has already proven online accuracy gains.
+
+## Next Questions
+
+- which real OpenClaw tasks produce the clearest before/after difference from the brief
+- whether `before_file_write` should become mandatory for high-risk task classes
+- whether approval-sensitive tasks need a stronger authority-specific brief section
+- how to measure semantic-quality improvement beyond anecdotal observation

--- a/docs/engineering/using-openprecedent.md
+++ b/docs/engineering/using-openprecedent.md
@@ -267,6 +267,18 @@ An installable OpenClaw skill is also included in this repository:
 That skill is designed for progressive disclosure.
 It teaches OpenClaw when to call `openprecedent runtime decision-lineage-brief`, how to choose `query_reason`, and how to use the returned brief as judgment context rather than operational instructions.
 
+### Runtime decision-lineage validation baseline
+
+The current trigger-policy baseline for the OpenClaw-facing decision-lineage skill is documented here:
+
+- [openclaw-runtime-decision-lineage-validation.md](/workspace/02-projects/incubation/openprecedent/docs/engineering/openclaw-runtime-decision-lineage-validation.md)
+
+That document defines which trigger points are currently recommended:
+
+- `initial_planning`
+- `before_file_write`
+- `after_failure` only when the failure is semantic rather than merely operational
+
 ## What Humans Usually Need
 
 Human users usually care about:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -941,6 +941,82 @@ def test_service_builds_decision_lineage_brief(db_path) -> None:
     assert "tool" not in json.dumps(brief.model_dump(mode="json"))
 
 
+def test_service_runtime_decision_lineage_trigger_baseline(db_path) -> None:
+    service = OpenPrecedentService.from_path(get_db_path())
+
+    service.create_case(CreateCaseInput(case_id="case_runtime_scope", title="Runtime scope case"))
+    for index, (event_type, actor, payload) in enumerate(
+        [
+            ("message.user", "user", {"message": "Do not edit code. Provide a short written recommendation only."}),
+            ("message.agent", "agent", {"message": "I will stay within docs-only scope and provide a short recommendation."}),
+            ("user.confirmed", "user", {"message": "Approved. Stay within docs-only scope."}),
+        ],
+        start=1,
+    ):
+        service.append_event(
+            "case_runtime_scope",
+            AppendEventInput(
+                event_type=EventType(event_type),
+                actor=EventActor(actor),
+                payload=payload,
+                sequence_no=index,
+            ),
+        )
+    service.extract_decisions("case_runtime_scope")
+
+    planning_brief = service.build_decision_lineage_brief(
+        DecisionLineageBriefInput(
+            query_reason=DecisionLineageQueryReason.INITIAL_PLANNING,
+            task_summary="Do not edit code. Provide a short written recommendation only.",
+        )
+    )
+    write_brief = service.build_decision_lineage_brief(
+        DecisionLineageBriefInput(
+            query_reason=DecisionLineageQueryReason.BEFORE_FILE_WRITE,
+            task_summary="Do not edit code. Provide a short written recommendation only.",
+            candidate_action="Edit src/openprecedent/services.py",
+            known_files=["src/openprecedent/services.py"],
+        )
+    )
+
+    assert planning_brief.accepted_constraints
+    assert planning_brief.authority_signals
+    assert write_brief.cautions
+    assert write_brief.accepted_constraints
+
+    service.create_case(CreateCaseInput(case_id="case_runtime_failure", title="Runtime failure case"))
+    for index, (event_type, actor, payload) in enumerate(
+        [
+            ("message.user", "user", {"message": "Run the tests."}),
+            ("message.agent", "agent", {"message": "I will run the test suite."}),
+            ("command.completed", "system", {"command": "pytest", "exit_code": 1, "stderr": "AssertionError"}),
+        ],
+        start=1,
+    ):
+        service.append_event(
+            "case_runtime_failure",
+            AppendEventInput(
+                event_type=EventType(event_type),
+                actor=EventActor(actor),
+                payload=payload,
+                sequence_no=index,
+            ),
+        )
+    service.extract_decisions("case_runtime_failure")
+
+    failure_brief = service.build_decision_lineage_brief(
+        DecisionLineageBriefInput(
+            query_reason=DecisionLineageQueryReason.AFTER_FAILURE,
+            task_summary="Run the tests.",
+            current_plan="Run the test suite.",
+            candidate_action="Retry the same command",
+        )
+    )
+
+    assert failure_brief.query_reason.value == "after_failure"
+    assert failure_brief.matched_cases
+
+
 def test_service_fixture_suite_includes_operational_negative_case(db_path) -> None:
     service = OpenPrecedentService.from_path(get_db_path())
     suite_path = Path(__file__).parent / "fixtures" / "evaluation" / "suite.json"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -790,6 +790,21 @@ def test_cli_builds_decision_lineage_brief(capsys, db_path) -> None:
     assert brief["authority_signals"]
 
 
+def test_cli_runtime_decision_lineage_validation_baseline_exists() -> None:
+    path = (
+        Path(__file__).parent.parent
+        / "docs"
+        / "engineering"
+        / "openclaw-runtime-decision-lineage-validation.md"
+    )
+
+    content = path.read_text(encoding="utf-8")
+
+    assert "initial_planning" in content
+    assert "before_file_write" in content
+    assert "after_failure" in content
+
+
 def test_openclaw_skill_bundle_exists() -> None:
     skill_path = (
         Path(__file__).parent.parent


### PR DESCRIPTION
## Summary
- add a durable OpenClaw runtime decision-lineage validation baseline document
- link the validation baseline from the README and usage guide
- add API and CLI regression coverage for the recommended trigger points

Closes #73