### PR TITLE
Record runtime decision-lineage invocations

### DIFF
--- a/.codex/pm/tasks/runtime-decision-lineage-integration/record-runtime-decision-lineage-invocations.md
+++ b/.codex/pm/tasks/runtime-decision-lineage-integration/record-runtime-decision-lineage-invocations.md
@@ -1,0 +1,40 @@
+---
+type: task
+epic: runtime-decision-lineage-integration
+slug: record-runtime-decision-lineage-invocations
+title: Record runtime decision-lineage skill invocations
+status: completed
+labels: feature,observability
+depends_on: 72
+issue: 81
+---
+
+## Context
+
+OpenPrecedent can build a decision-lineage brief, but it does not yet record that a runtime skill invocation happened as a structured, inspectable event.
+Without that record, later validation cannot reliably answer when OpenClaw called the skill or what task context triggered the lookup.
+
+## Deliverable
+
+Add a minimal runtime observability mechanism that records each decision-lineage skill invocation as structured evidence.
+
+## Scope
+
+- record when the runtime decision-lineage skill is invoked
+- record the semantic query context, including `query_reason`, task summary, current plan, candidate action, and known files when available
+- make the invocation record visible through stored events, replay, or another inspectable repository-local surface
+- keep the scope focused on observability, not evaluation logic
+
+## Acceptance Criteria
+
+- a runtime invocation can be inspected after the fact without relying on terminal scrollback
+- the stored record includes enough context to explain why the lookup happened
+- the record can be associated with the surrounding case or session history
+
+## Validation
+
+- trigger at least one runtime decision-lineage lookup and verify that the invocation record is visible through a stable local interface
+
+## Implementation Notes
+
+This task is a prerequisite for meaningful real-task runtime validation.

--- a/docs/engineering/using-openprecedent.md
+++ b/docs/engineering/using-openprecedent.md
@@ -259,6 +259,13 @@ openprecedent runtime decision-lineage-brief \
 This command is intentionally narrow.
 It returns a semantic brief built from prior cases, including task framing, accepted constraints, success criteria, rejected options, and authority signals.
 It does not prescribe tools, commands, or file writes directly.
+Each successful call also appends a runtime invocation record to the local decision-lineage invocation log so later validation can inspect when the brief was requested and with what semantic context.
+
+If you want to inspect those records directly:
+
+```bash
+openprecedent runtime list-decision-lineage-invocations
+```
 
 An installable OpenClaw skill is also included in this repository:
 

--- a/src/openprecedent/cli.py
+++ b/src/openprecedent/cli.py
@@ -5,7 +5,11 @@ import json
 import sys
 from pathlib import Path
 
-from openprecedent.config import get_collector_state_path, get_db_path
+from openprecedent.config import (
+    get_collector_state_path,
+    get_db_path,
+    get_runtime_invocation_log_path,
+)
 from openprecedent.schemas import EventActor, EventType
 from openprecedent.services import (
     AppendEventInput,
@@ -98,7 +102,12 @@ def build_parser() -> argparse.ArgumentParser:
     runtime_brief.add_argument("--current-plan")
     runtime_brief.add_argument("--candidate-action")
     runtime_brief.add_argument("--known-file", action="append", dest="known_files", default=[])
+    runtime_brief.add_argument("--case-id")
+    runtime_brief.add_argument("--session-id")
+    runtime_brief.add_argument("--log-file")
     runtime_brief.add_argument("--limit", type=int, default=3)
+    runtime_list_invocations = runtime_subparsers.add_parser("list-decision-lineage-invocations")
+    runtime_list_invocations.add_argument("--log-file")
 
     eval_parser = subparsers.add_parser("eval")
     eval_subparsers = eval_parser.add_subparsers(dest="action", required=True)
@@ -315,17 +324,28 @@ def _handle_runtime(args: argparse.Namespace, service: OpenPrecedentService) -> 
         _print_json(result.model_dump(mode="json"))
         return 0
     if args.action == "decision-lineage-brief":
-        brief = service.build_decision_lineage_brief(
-            DecisionLineageBriefInput(
-                query_reason=DecisionLineageQueryReason(args.query_reason),
-                task_summary=args.task_summary,
-                current_plan=args.current_plan,
-                candidate_action=args.candidate_action,
-                known_files=args.known_files,
-                limit=args.limit,
-            )
+        input_data = DecisionLineageBriefInput(
+            query_reason=DecisionLineageQueryReason(args.query_reason),
+            task_summary=args.task_summary,
+            current_plan=args.current_plan,
+            candidate_action=args.candidate_action,
+            known_files=args.known_files,
+            limit=args.limit,
+        )
+        brief = service.build_decision_lineage_brief(input_data)
+        service.record_runtime_decision_lineage_invocation(
+            input_data,
+            log_path=_resolve_runtime_invocation_log_path(args.log_file),
+            case_id=args.case_id,
+            session_id=args.session_id,
         )
         _print_json(brief.model_dump(mode="json"))
+        return 0
+    if args.action == "list-decision-lineage-invocations":
+        invocations = service.list_runtime_decision_lineage_invocations(
+            _resolve_runtime_invocation_log_path(args.log_file)
+        )
+        _print_json([item.model_dump(mode="json") for item in invocations])
         return 0
     return 2
 
@@ -448,6 +468,12 @@ def _resolve_collector_state_path(value: str | None) -> Path:
     if value:
         return Path(value)
     return get_collector_state_path()
+
+
+def _resolve_runtime_invocation_log_path(value: str | None) -> Path:
+    if value:
+        return Path(value)
+    return get_runtime_invocation_log_path()
 
 
 def _resolve_openclaw_session_target(

--- a/src/openprecedent/config.py
+++ b/src/openprecedent/config.py
@@ -8,6 +8,8 @@ DEFAULT_DB_NAME = "openprecedent.db"
 DB_ENV_VAR = "OPENPRECEDENT_DB"
 DEFAULT_COLLECTOR_STATE_NAME = "openprecedent-collector-state.json"
 COLLECTOR_STATE_ENV_VAR = "OPENPRECEDENT_COLLECTOR_STATE"
+DEFAULT_RUNTIME_INVOCATION_LOG_NAME = "openprecedent-runtime-invocations.jsonl"
+RUNTIME_INVOCATION_LOG_ENV_VAR = "OPENPRECEDENT_RUNTIME_INVOCATION_LOG"
 
 
 def get_db_path() -> Path:
@@ -24,3 +26,11 @@ def get_collector_state_path() -> Path:
         return Path(configured).expanduser().resolve()
 
     return get_db_path().with_name(DEFAULT_COLLECTOR_STATE_NAME)
+
+
+def get_runtime_invocation_log_path() -> Path:
+    configured = os.environ.get(RUNTIME_INVOCATION_LOG_ENV_VAR)
+    if configured:
+        return Path(configured).expanduser().resolve()
+
+    return get_db_path().with_name(DEFAULT_RUNTIME_INVOCATION_LOG_NAME)

--- a/src/openprecedent/services.py
+++ b/src/openprecedent/services.py
@@ -242,6 +242,20 @@ class DecisionLineageBrief(BaseModel):
     cautions: list[str] = Field(default_factory=list)
 
 
+class RuntimeDecisionLineageInvocation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    invocation_id: str
+    recorded_at: datetime
+    query_reason: DecisionLineageQueryReason
+    task_summary: str
+    current_plan: str | None = None
+    candidate_action: str | None = None
+    known_files: list[str] = Field(default_factory=list)
+    case_id: str | None = None
+    session_id: str | None = None
+
+
 @dataclass
 class OpenPrecedentService:
     store: SQLiteStore
@@ -975,6 +989,52 @@ class OpenPrecedentService:
             authority_signals=authority_signals[:5],
             cautions=cautions,
         )
+
+    def record_runtime_decision_lineage_invocation(
+        self,
+        input_data: DecisionLineageBriefInput,
+        *,
+        log_path: Path,
+        case_id: str | None = None,
+        session_id: str | None = None,
+    ) -> RuntimeDecisionLineageInvocation:
+        invocation = RuntimeDecisionLineageInvocation(
+            invocation_id=f"rtinv_{uuid4().hex[:12]}",
+            recorded_at=datetime.now(UTC),
+            query_reason=input_data.query_reason,
+            task_summary=input_data.task_summary,
+            current_plan=input_data.current_plan,
+            candidate_action=input_data.candidate_action,
+            known_files=input_data.known_files,
+            case_id=case_id,
+            session_id=session_id,
+        )
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with log_path.open("a", encoding="utf-8") as handle:
+            handle.write(invocation.model_dump_json())
+            handle.write("\n")
+        return invocation
+
+    def list_runtime_decision_lineage_invocations(
+        self,
+        log_path: Path,
+    ) -> list[RuntimeDecisionLineageInvocation]:
+        if not log_path.exists():
+            return []
+
+        invocations: list[RuntimeDecisionLineageInvocation] = []
+        with log_path.open("r", encoding="utf-8") as handle:
+            for line_no, line in enumerate(handle, start=1):
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                try:
+                    invocations.append(RuntimeDecisionLineageInvocation.model_validate_json(stripped))
+                except ValueError as error:
+                    raise ValueError(
+                        f"invalid runtime decision-lineage invocation log at line {line_no}"
+                    ) from error
+        return invocations
 
     def _build_decision(
         self,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1017,6 +1017,33 @@ def test_service_runtime_decision_lineage_trigger_baseline(db_path) -> None:
     assert failure_brief.matched_cases
 
 
+def test_service_records_runtime_decision_lineage_invocation(db_path, tmp_path: Path) -> None:
+    service = OpenPrecedentService.from_path(get_db_path())
+    log_path = tmp_path / "runtime-invocations.jsonl"
+
+    invocation = service.record_runtime_decision_lineage_invocation(
+        DecisionLineageBriefInput(
+            query_reason=DecisionLineageQueryReason.BEFORE_FILE_WRITE,
+            task_summary="Do not edit code. Provide a short written recommendation only.",
+            current_plan="Prepare a short recommendation.",
+            candidate_action="Edit src/openprecedent/services.py",
+            known_files=["src/openprecedent/services.py"],
+        ),
+        log_path=log_path,
+        case_id="case_runtime_scope",
+        session_id="session_runtime_scope",
+    )
+
+    assert invocation.query_reason.value == "before_file_write"
+    assert log_path.exists()
+
+    stored = service.list_runtime_decision_lineage_invocations(log_path)
+    assert len(stored) == 1
+    assert stored[0].case_id == "case_runtime_scope"
+    assert stored[0].session_id == "session_runtime_scope"
+    assert stored[0].known_files == ["src/openprecedent/services.py"]
+
+
 def test_service_fixture_suite_includes_operational_negative_case(db_path) -> None:
     service = OpenPrecedentService.from_path(get_db_path())
     suite_path = Path(__file__).parent / "fixtures" / "evaluation" / "suite.json"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -790,6 +790,37 @@ def test_cli_builds_decision_lineage_brief(capsys, db_path) -> None:
     assert brief["authority_signals"]
 
 
+def test_cli_records_runtime_decision_lineage_invocation(capsys, db_path, tmp_path: Path) -> None:
+    log_path = tmp_path / "runtime-invocations.jsonl"
+
+    result = main(
+        [
+            "runtime",
+            "decision-lineage-brief",
+            "--query-reason",
+            "initial_planning",
+            "--task-summary",
+            "Do not edit code. Provide a short written recommendation only.",
+            "--case-id",
+            "case_runtime_scope",
+            "--session-id",
+            "session_runtime_scope",
+            "--log-file",
+            str(log_path),
+        ]
+    )
+    assert result == 0
+    capsys.readouterr()
+
+    result = main(["runtime", "list-decision-lineage-invocations", "--log-file", str(log_path)])
+    assert result == 0
+    invocations = json.loads(capsys.readouterr().out)
+    assert len(invocations) == 1
+    assert invocations[0]["query_reason"] == "initial_planning"
+    assert invocations[0]["case_id"] == "case_runtime_scope"
+    assert invocations[0]["session_id"] == "session_runtime_scope"
+
+
 def test_cli_runtime_decision_lineage_validation_baseline_exists() -> None:
     path = (
         Path(__file__).parent.parent


### PR DESCRIPTION
## Summary
- automatically record each successful runtime decision-lineage brief invocation to a local invocation log
- add a CLI surface to inspect recorded runtime decision-lineage invocations
- cover the new observability flow in API/service and CLI tests

## Testing
- PYTHONPATH=src .venv/bin/pytest tests/test_api.py tests/test_cli.py

Closes #81