### PR TITLE
Record decision-lineage brief outputs and effects

### DIFF
--- a/.codex/pm/tasks/runtime-decision-lineage-integration/record-runtime-decision-lineage-brief-effects.md
+++ b/.codex/pm/tasks/runtime-decision-lineage-integration/record-runtime-decision-lineage-brief-effects.md
@@ -1,0 +1,40 @@
+---
+type: task
+epic: runtime-decision-lineage-integration
+slug: record-runtime-decision-lineage-brief-effects
+title: Record decision-lineage brief outputs and downstream effects
+status: completed
+labels: feature,observability,docs
+depends_on: 72
+issue: 82
+---
+
+## Context
+
+Even if OpenPrecedent records that a skill lookup happened, real validation still needs visibility into what semantic brief was returned and how that brief related to later task judgment.
+At the moment, this relationship is not captured as structured evidence.
+
+## Deliverable
+
+Add a minimal mechanism for inspecting the semantic content returned by the runtime decision-lineage brief and relating it to subsequent agent decisions or messages.
+
+## Scope
+
+- record the returned semantic brief in an inspectable way, at least as a structured summary
+- preserve the key runtime brief fields needed for later validation, such as matched cases, task frame, constraints, success criteria, rejected options, and authority signals
+- expose enough linkage in replay or documentation-oriented output to compare the returned brief with subsequent semantic decisions
+- avoid turning this into a full causal inference system
+
+## Acceptance Criteria
+
+- a reviewer can inspect what semantic brief was returned during runtime use
+- the repository provides enough evidence to compare the brief with later task framing or constraint handling
+- the output is stable enough to support later validation documentation
+
+## Validation
+
+- execute at least one runtime lookup and verify that both the returned brief summary and the subsequent relevant task signals can be inspected together
+
+## Implementation Notes
+
+This task should stay focused on observability of returned semantic context and its nearby downstream effects.

--- a/docs/engineering/using-openprecedent.md
+++ b/docs/engineering/using-openprecedent.md
@@ -267,6 +267,13 @@ If you want to inspect those records directly:
 openprecedent runtime list-decision-lineage-invocations
 ```
 
+If you want to inspect one invocation together with its recorded brief summary and the nearby downstream case signals:
+
+```bash
+openprecedent runtime inspect-decision-lineage-invocation \
+  --invocation-id <invocation_id>
+```
+
 An installable OpenClaw skill is also included in this repository:
 
 - [SKILL.md](/workspace/02-projects/incubation/openprecedent/skills/openprecedent-decision-lineage/SKILL.md)

--- a/src/openprecedent/cli.py
+++ b/src/openprecedent/cli.py
@@ -108,6 +108,9 @@ def build_parser() -> argparse.ArgumentParser:
     runtime_brief.add_argument("--limit", type=int, default=3)
     runtime_list_invocations = runtime_subparsers.add_parser("list-decision-lineage-invocations")
     runtime_list_invocations.add_argument("--log-file")
+    runtime_inspect_invocation = runtime_subparsers.add_parser("inspect-decision-lineage-invocation")
+    runtime_inspect_invocation.add_argument("--invocation-id", required=True)
+    runtime_inspect_invocation.add_argument("--log-file")
 
     eval_parser = subparsers.add_parser("eval")
     eval_subparsers = eval_parser.add_subparsers(dest="action", required=True)
@@ -335,6 +338,7 @@ def _handle_runtime(args: argparse.Namespace, service: OpenPrecedentService) -> 
         brief = service.build_decision_lineage_brief(input_data)
         service.record_runtime_decision_lineage_invocation(
             input_data,
+            brief,
             log_path=_resolve_runtime_invocation_log_path(args.log_file),
             case_id=args.case_id,
             session_id=args.session_id,
@@ -346,6 +350,13 @@ def _handle_runtime(args: argparse.Namespace, service: OpenPrecedentService) -> 
             _resolve_runtime_invocation_log_path(args.log_file)
         )
         _print_json([item.model_dump(mode="json") for item in invocations])
+        return 0
+    if args.action == "inspect-decision-lineage-invocation":
+        inspection = service.inspect_runtime_decision_lineage_invocation(
+            args.invocation_id,
+            _resolve_runtime_invocation_log_path(args.log_file),
+        )
+        _print_json(inspection.model_dump(mode="json"))
         return 0
     return 2
 

--- a/src/openprecedent/services.py
+++ b/src/openprecedent/services.py
@@ -254,6 +254,22 @@ class RuntimeDecisionLineageInvocation(BaseModel):
     known_files: list[str] = Field(default_factory=list)
     case_id: str | None = None
     session_id: str | None = None
+    matched_case_ids: list[str] = Field(default_factory=list)
+    task_frame: str | None = None
+    accepted_constraints: list[str] = Field(default_factory=list)
+    success_criteria: list[str] = Field(default_factory=list)
+    rejected_options: list[str] = Field(default_factory=list)
+    authority_signals: list[str] = Field(default_factory=list)
+    cautions: list[str] = Field(default_factory=list)
+    suggested_focus: str | None = None
+
+
+class RuntimeDecisionLineageInspection(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    invocation: RuntimeDecisionLineageInvocation
+    downstream_events: list[Event] = Field(default_factory=list)
+    downstream_decisions: list[Decision] = Field(default_factory=list)
 
 
 @dataclass
@@ -993,6 +1009,7 @@ class OpenPrecedentService:
     def record_runtime_decision_lineage_invocation(
         self,
         input_data: DecisionLineageBriefInput,
+        brief: DecisionLineageBrief,
         *,
         log_path: Path,
         case_id: str | None = None,
@@ -1008,6 +1025,14 @@ class OpenPrecedentService:
             known_files=input_data.known_files,
             case_id=case_id,
             session_id=session_id,
+            matched_case_ids=[item.case_id for item in brief.matched_cases],
+            task_frame=brief.task_frame,
+            accepted_constraints=brief.accepted_constraints,
+            success_criteria=brief.success_criteria,
+            rejected_options=brief.rejected_options,
+            authority_signals=brief.authority_signals,
+            cautions=brief.cautions,
+            suggested_focus=brief.suggested_focus,
         )
         log_path.parent.mkdir(parents=True, exist_ok=True)
         with log_path.open("a", encoding="utf-8") as handle:
@@ -1035,6 +1060,43 @@ class OpenPrecedentService:
                         f"invalid runtime decision-lineage invocation log at line {line_no}"
                     ) from error
         return invocations
+
+    def inspect_runtime_decision_lineage_invocation(
+        self,
+        invocation_id: str,
+        log_path: Path,
+    ) -> RuntimeDecisionLineageInspection:
+        invocation = next(
+            (
+                item
+                for item in self.list_runtime_decision_lineage_invocations(log_path)
+                if item.invocation_id == invocation_id
+            ),
+            None,
+        )
+        if invocation is None:
+            raise KeyError(invocation_id)
+
+        if not invocation.case_id:
+            return RuntimeDecisionLineageInspection(invocation=invocation)
+
+        case = self.store.get_case(invocation.case_id)
+        if case is None:
+            return RuntimeDecisionLineageInspection(invocation=invocation)
+
+        events = self.store.list_events(invocation.case_id)
+        downstream_events = [event for event in events if event.timestamp > invocation.recorded_at]
+        downstream_event_ids = {event.event_id for event in downstream_events}
+        downstream_decisions = [
+            decision
+            for decision in self.store.list_decisions(invocation.case_id)
+            if downstream_event_ids.intersection(decision.evidence_event_ids)
+        ]
+        return RuntimeDecisionLineageInspection(
+            invocation=invocation,
+            downstream_events=downstream_events,
+            downstream_decisions=downstream_decisions,
+        )
 
     def _build_decision(
         self,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1021,6 +1021,37 @@ def test_service_records_runtime_decision_lineage_invocation(db_path, tmp_path: 
     service = OpenPrecedentService.from_path(get_db_path())
     log_path = tmp_path / "runtime-invocations.jsonl"
 
+    service.create_case(CreateCaseInput(case_id="case_runtime_scope", title="Runtime scope case"))
+    service.create_case(CreateCaseInput(case_id="case_brief_guidance", title="Docs-only recommendation"))
+    for index, (event_type, actor, payload) in enumerate(
+        [
+            ("message.user", "user", {"message": "Do not edit code. Provide a short written recommendation only."}),
+            ("message.agent", "agent", {"message": "I will stay within docs-only scope and provide a short recommendation."}),
+            ("user.confirmed", "user", {"message": "Approved. Stay within docs-only scope."}),
+        ],
+        start=1,
+    ):
+        service.append_event(
+            "case_brief_guidance",
+            AppendEventInput(
+                event_type=EventType(event_type),
+                actor=EventActor(actor),
+                payload=payload,
+                sequence_no=index,
+            ),
+        )
+    service.extract_decisions("case_brief_guidance")
+
+    brief = service.build_decision_lineage_brief(
+        DecisionLineageBriefInput(
+            query_reason=DecisionLineageQueryReason.BEFORE_FILE_WRITE,
+            task_summary="Do not edit code. Provide a short written recommendation only.",
+            current_plan="Prepare a short recommendation.",
+            candidate_action="Edit src/openprecedent/services.py",
+            known_files=["src/openprecedent/services.py"],
+        )
+    )
+
     invocation = service.record_runtime_decision_lineage_invocation(
         DecisionLineageBriefInput(
             query_reason=DecisionLineageQueryReason.BEFORE_FILE_WRITE,
@@ -1029,6 +1060,7 @@ def test_service_records_runtime_decision_lineage_invocation(db_path, tmp_path: 
             candidate_action="Edit src/openprecedent/services.py",
             known_files=["src/openprecedent/services.py"],
         ),
+        brief,
         log_path=log_path,
         case_id="case_runtime_scope",
         session_id="session_runtime_scope",
@@ -1042,6 +1074,24 @@ def test_service_records_runtime_decision_lineage_invocation(db_path, tmp_path: 
     assert stored[0].case_id == "case_runtime_scope"
     assert stored[0].session_id == "session_runtime_scope"
     assert stored[0].known_files == ["src/openprecedent/services.py"]
+    assert stored[0].matched_case_ids == ["case_brief_guidance"]
+    assert stored[0].accepted_constraints
+
+    service.append_event(
+        "case_runtime_scope",
+        AppendEventInput(
+            event_type=EventType.MESSAGE_AGENT,
+            actor=EventActor.AGENT,
+            payload={"message": "I will keep this docs-only and avoid code edits."},
+        ),
+    )
+    service.extract_decisions("case_runtime_scope")
+
+    inspection = service.inspect_runtime_decision_lineage_invocation(invocation.invocation_id, log_path)
+    assert inspection.invocation.invocation_id == invocation.invocation_id
+    assert inspection.downstream_events
+    assert inspection.downstream_decisions
+    assert inspection.downstream_decisions[0].decision_type.value == "task_frame_defined"
 
 
 def test_service_fixture_suite_includes_operational_negative_case(db_path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -793,6 +793,49 @@ def test_cli_builds_decision_lineage_brief(capsys, db_path) -> None:
 def test_cli_records_runtime_decision_lineage_invocation(capsys, db_path, tmp_path: Path) -> None:
     log_path = tmp_path / "runtime-invocations.jsonl"
 
+    result = main(["case", "create", "--case-id", "case_cli_brief_guidance", "--title", "Docs-only recommendation"])
+    assert result == 0
+    capsys.readouterr()
+    for command in (
+        [
+            "event",
+            "append",
+            "case_cli_brief_guidance",
+            "message.user",
+            "user",
+            "--payload",
+            '{"message":"Do not edit code. Provide a short written recommendation only."}',
+        ],
+        [
+            "event",
+            "append",
+            "case_cli_brief_guidance",
+            "message.agent",
+            "agent",
+            "--payload",
+            '{"message":"I will stay within docs-only scope and provide a short recommendation."}',
+        ],
+        [
+            "event",
+            "append",
+            "case_cli_brief_guidance",
+            "user.confirmed",
+            "user",
+            "--payload",
+            '{"message":"Approved. Stay within docs-only scope."}',
+        ],
+    ):
+        result = main(command)
+        assert result == 0
+        capsys.readouterr()
+    result = main(["extract", "decisions", "case_cli_brief_guidance"])
+    assert result == 0
+    capsys.readouterr()
+
+    result = main(["case", "create", "--case-id", "case_runtime_scope", "--title", "Runtime scope case"])
+    assert result == 0
+    capsys.readouterr()
+
     result = main(
         [
             "runtime",
@@ -819,6 +862,40 @@ def test_cli_records_runtime_decision_lineage_invocation(capsys, db_path, tmp_pa
     assert invocations[0]["query_reason"] == "initial_planning"
     assert invocations[0]["case_id"] == "case_runtime_scope"
     assert invocations[0]["session_id"] == "session_runtime_scope"
+    assert invocations[0]["matched_case_ids"] == ["case_cli_brief_guidance"]
+
+    result = main(
+        [
+            "event",
+            "append",
+            "case_runtime_scope",
+            "message.agent",
+            "agent",
+            "--payload",
+            '{"message":"I will keep this docs-only and avoid code edits."}',
+        ]
+    )
+    assert result == 0
+    capsys.readouterr()
+    result = main(["extract", "decisions", "case_runtime_scope"])
+    assert result == 0
+    capsys.readouterr()
+
+    result = main(
+        [
+            "runtime",
+            "inspect-decision-lineage-invocation",
+            "--invocation-id",
+            invocations[0]["invocation_id"],
+            "--log-file",
+            str(log_path),
+        ]
+    )
+    assert result == 0
+    inspection = json.loads(capsys.readouterr().out)
+    assert inspection["invocation"]["matched_case_ids"] == ["case_cli_brief_guidance"]
+    assert inspection["downstream_events"]
+    assert inspection["downstream_decisions"]
 
 
 def test_cli_runtime_decision_lineage_validation_baseline_exists() -> None:


### PR DESCRIPTION
## Summary
- extend runtime invocation records with the returned decision-lineage brief summary
- add an inspection command that shows one invocation together with nearby downstream events and decisions
- cover the inspection flow in service and CLI tests

## Testing
- PYTHONPATH=src .venv/bin/pytest tests/test_api.py tests/test_cli.py

Closes #82