### PR TITLE
[codex] Add standard end-to-end validation script

### DIFF
--- a/.codex/pm/tasks/local-runtime-validation/standard-e2e-validation.md
+++ b/.codex/pm/tasks/local-runtime-validation/standard-e2e-validation.md
@@ -1,0 +1,38 @@
+---
+type: task
+epic: local-runtime-validation
+slug: standard-e2e-validation
+title: Add a standard end-to-end validation script and merge checklist
+status: done
+labels: feature,docs,test
+issue: 88
+---
+
+## Context
+
+The repository already documents the OpenClaw full user journey validation flow, but today it is spread across manual commands in docs.
+That makes merge-time validation inconsistent for changes that touch the runtime path, collector, replay, extraction, or precedent behavior.
+
+## Deliverable
+
+Add a repository-local script that runs the standard E2E validation flow and document a short merge checklist describing when contributors should use it.
+
+## Scope
+
+- add a script that prepares a clean fixture-backed runtime workspace and runs the standard local E2E CLI flow
+- save the step outputs in a predictable location for later inspection
+- document when the script should be part of pre-merge validation
+- keep the scope focused on local validation rather than CI orchestration or live OpenClaw setup
+
+## Acceptance Criteria
+
+- a contributor can run one script to execute the standard local E2E validation path
+- the script uses the existing full-user-journey baseline rather than inventing a different path
+- docs explain when to run the script before merge and what outputs it produces
+
+## Validation
+
+- run the new E2E script against a temporary local workspace
+- run automated tests covering the script entrypoint and expected outputs
+
+## Implementation Notes

--- a/docs/engineering/merge-validation.md
+++ b/docs/engineering/merge-validation.md
@@ -1,0 +1,57 @@
+# Merge Validation
+
+## Goal
+
+Define the repository-local validation baseline contributors should use before merging changes that affect the shipped OpenPrecedent runtime path.
+
+## Standard E2E Script
+
+Run the standard local end-to-end validation flow with:
+
+```bash
+./scripts/run-e2e.sh
+```
+
+By default this script uses:
+
+- E2E root: `/tmp/openprecedent-openclaw-journey`
+- fixture sessions: `tests/fixtures/openclaw_sessions/`
+- runtime binary: `.venv/bin/openprecedent` when available, otherwise `openprecedent` on `PATH`
+
+You can override those defaults with:
+
+- `OPENPRECEDENT_E2E_ROOT`
+- `OPENPRECEDENT_E2E_FIXTURE_ROOT`
+- `OPENPRECEDENT_BIN`
+
+The script writes step-by-step JSON outputs under:
+
+- `$OPENPRECEDENT_E2E_ROOT/output/`
+
+This path is intentionally inspectable so a reviewer can spot which stage failed without re-running commands by hand.
+
+## When To Run It
+
+Run `./scripts/run-e2e.sh` before merge when a PR changes any of these areas:
+
+- `src/openprecedent/`
+- runtime CLI behavior
+- collector behavior or state handling
+- replay, decision extraction, or precedent retrieval behavior
+- evaluation flows or fixture-backed local runtime paths
+
+For docs-only or narrow PM-governance changes, the smaller relevant checks are enough.
+
+## Merge Checklist
+
+- run `./scripts/run-e2e.sh` for runtime-affecting PRs
+- confirm the script exits successfully
+- inspect `10-eval-fixtures.json` and verify `failed_cases` is `0`
+- inspect `11-eval-collected-openclaw-sessions.json` and verify collected-session evaluation completed
+- include the exact validation commands in the PR body when the E2E script was part of merge validation
+
+## Baseline Source
+
+The script mirrors the documented baseline in
+[`openclaw-full-user-journey-validation.md`](/workspace/02-projects/incubation/openprecedent/docs/engineering/openclaw-full-user-journey-validation.md)
+rather than introducing a separate E2E path.

--- a/docs/engineering/tooling-setup.md
+++ b/docs/engineering/tooling-setup.md
@@ -8,6 +8,7 @@ The repository already includes:
 - `python-ci` GitHub Actions workflow for dependency install and tests
 - `feishu-pr-notify` GitHub Actions workflow for pull request review notifications
 - a local Git pre-push hook that requires a Codex review note
+- `scripts/run-e2e.sh` for the standard local fixture-backed end-to-end runtime validation path
 
 To enable the local hook:
 
@@ -30,6 +31,17 @@ remaining risks: dependencies not installed locally, tests not executed
 ```
 
 This hook does not replace human judgment. It creates a minimal review checkpoint before code leaves the local branch.
+
+## Merge Validation
+
+For runtime-affecting pull requests, run:
+
+```bash
+./scripts/run-e2e.sh
+```
+
+The detailed merge checklist lives in
+[`docs/engineering/merge-validation.md`](/workspace/02-projects/incubation/openprecedent/docs/engineering/merge-validation.md).
 
 ## GitHub App Recommendations
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,4 +5,5 @@ Utility scripts for local development, setup, migration, and tooling live here.
 Notable operational entrypoints:
 
 - `run-collector.sh` runs one collector pass with local-first defaults
+- `run-e2e.sh` runs the standard local fixture-backed end-to-end validation flow
 - `install-collector-assets.sh` renders `systemd` / `cron` assets against the current repo path

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [[ -n "${OPENPRECEDENT_BIN:-}" ]]; then
+  OPENPRECEDENT_BIN="$OPENPRECEDENT_BIN"
+elif [[ -x "$ROOT_DIR/.venv/bin/openprecedent" ]]; then
+  OPENPRECEDENT_BIN="$ROOT_DIR/.venv/bin/openprecedent"
+else
+  OPENPRECEDENT_BIN="openprecedent"
+fi
+
+E2E_ROOT="${OPENPRECEDENT_E2E_ROOT:-/tmp/openprecedent-openclaw-journey}"
+FIXTURE_ROOT="${OPENPRECEDENT_E2E_FIXTURE_ROOT:-$ROOT_DIR/tests/fixtures/openclaw_sessions}"
+SESSIONS_ROOT="$E2E_ROOT/sessions"
+OUTPUT_ROOT="$E2E_ROOT/output"
+DB_PATH="$E2E_ROOT/openprecedent.db"
+STATE_PATH="$E2E_ROOT/collector-state.json"
+EVAL_DB_PATH="$E2E_ROOT/eval-fixtures.db"
+
+mkdir -p "$SESSIONS_ROOT" "$OUTPUT_ROOT"
+rm -f "$DB_PATH" "$STATE_PATH" "$EVAL_DB_PATH"
+rm -f "$OUTPUT_ROOT"/*.json
+
+cp "$FIXTURE_ROOT/file-ops-session.jsonl" "$SESSIONS_ROOT/"
+cp "$FIXTURE_ROOT/search-read-session.jsonl" "$SESSIONS_ROOT/"
+cp "$FIXTURE_ROOT/sample-session.jsonl" "$SESSIONS_ROOT/"
+
+cat > "$SESSIONS_ROOT/sessions.json" <<EOF
+[
+  {
+    "key": "agent:main:user:file-ops",
+    "label": "User session: file ops fixture",
+    "displayName": "User session: file ops fixture",
+    "updatedAt": 1773018022842,
+    "sessionId": "file-ops-session",
+    "model": "gpt-5.3-codex",
+    "sessionFile": "$SESSIONS_ROOT/file-ops-session.jsonl",
+    "isActive": false
+  },
+  {
+    "key": "agent:main:user:search-read",
+    "label": "User session: search roadmap docs",
+    "displayName": "User session: search roadmap docs",
+    "updatedAt": 1773018022841,
+    "sessionId": "search-read-session",
+    "model": "gpt-5.3-codex",
+    "sessionFile": "$SESSIONS_ROOT/search-read-session.jsonl",
+    "isActive": false
+  },
+  {
+    "key": "agent:main:user:sample",
+    "label": "User session: summarize context graph",
+    "displayName": "User session: summarize context graph",
+    "updatedAt": 1773018022840,
+    "sessionId": "sample-session",
+    "model": "gpt-5.3-codex",
+    "sessionFile": "$SESSIONS_ROOT/sample-session.jsonl",
+    "isActive": true
+  }
+]
+EOF
+
+run_openprecedent() {
+  OPENPRECEDENT_DB="$DB_PATH" \
+  OPENPRECEDENT_COLLECTOR_STATE="$STATE_PATH" \
+  "$OPENPRECEDENT_BIN" "$@"
+}
+
+echo "Running OpenPrecedent E2E validation in $E2E_ROOT"
+
+run_openprecedent runtime list-openclaw-sessions \
+  --sessions-root "$SESSIONS_ROOT" \
+  > "$OUTPUT_ROOT/01-list-openclaw-sessions.json"
+
+run_openprecedent runtime collect-openclaw-sessions \
+  --sessions-root "$SESSIONS_ROOT" \
+  --limit 1 \
+  > "$OUTPUT_ROOT/02-collect-openclaw-sessions.json"
+
+run_openprecedent runtime import-openclaw-session \
+  --session-id search-read-session \
+  --sessions-root "$SESSIONS_ROOT" \
+  --case-id case_openclaw_search_read \
+  > "$OUTPUT_ROOT/03-import-search-read-session.json"
+
+run_openprecedent runtime import-openclaw-session \
+  --session-id sample-session \
+  --sessions-root "$SESSIONS_ROOT" \
+  --case-id case_openclaw_sample \
+  > "$OUTPUT_ROOT/04-import-sample-session.json"
+
+run_openprecedent extract decisions openclaw_fileopssession \
+  > "$OUTPUT_ROOT/05-extract-decisions-file-ops.json"
+
+run_openprecedent extract decisions case_openclaw_search_read \
+  > "$OUTPUT_ROOT/06-extract-decisions-search-read.json"
+
+run_openprecedent extract decisions case_openclaw_sample \
+  > "$OUTPUT_ROOT/07-extract-decisions-sample.json"
+
+run_openprecedent replay case case_openclaw_search_read --json \
+  > "$OUTPUT_ROOT/08-replay-search-read.json"
+
+run_openprecedent precedent find case_openclaw_search_read --limit 3 \
+  > "$OUTPUT_ROOT/09-precedent-search-read.json"
+
+OPENPRECEDENT_DB="$EVAL_DB_PATH" \
+"$OPENPRECEDENT_BIN" eval fixtures "$ROOT_DIR/tests/fixtures/evaluation/real_session_suite.json" --json \
+  > "$OUTPUT_ROOT/10-eval-fixtures.json"
+
+run_openprecedent eval collected-openclaw-sessions \
+  --sessions-root "$SESSIONS_ROOT" \
+  --json \
+  > "$OUTPUT_ROOT/11-eval-collected-openclaw-sessions.json"
+
+echo "E2E validation completed."
+echo "Workspace: $E2E_ROOT"
+echo "Outputs:"
+echo "  $OUTPUT_ROOT/01-list-openclaw-sessions.json"
+echo "  $OUTPUT_ROOT/02-collect-openclaw-sessions.json"
+echo "  $OUTPUT_ROOT/03-import-search-read-session.json"
+echo "  $OUTPUT_ROOT/04-import-sample-session.json"
+echo "  $OUTPUT_ROOT/05-extract-decisions-file-ops.json"
+echo "  $OUTPUT_ROOT/06-extract-decisions-search-read.json"
+echo "  $OUTPUT_ROOT/07-extract-decisions-sample.json"
+echo "  $OUTPUT_ROOT/08-replay-search-read.json"
+echo "  $OUTPUT_ROOT/09-precedent-search-read.json"
+echo "  $OUTPUT_ROOT/10-eval-fixtures.json"
+echo "  $OUTPUT_ROOT/11-eval-collected-openclaw-sessions.json"

--- a/tests/test_e2e_script.py
+++ b/tests/test_e2e_script.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+def test_run_e2e_script_completes_and_writes_expected_outputs(tmp_path: Path) -> None:
+    repo_root = Path(__file__).parent.parent
+    env = os.environ.copy()
+    env["OPENPRECEDENT_E2E_ROOT"] = str(tmp_path / "journey")
+    env["PYTHONPATH"] = str(repo_root / "src")
+
+    result = subprocess.run(
+        ["./scripts/run-e2e.sh"],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    output_root = Path(env["OPENPRECEDENT_E2E_ROOT"]) / "output"
+    assert (output_root / "01-list-openclaw-sessions.json").exists()
+    assert (output_root / "10-eval-fixtures.json").exists()
+    assert (output_root / "11-eval-collected-openclaw-sessions.json").exists()
+
+    listed_sessions = json.loads((output_root / "01-list-openclaw-sessions.json").read_text(encoding="utf-8"))
+    assert [item["session_id"] for item in listed_sessions] == [
+        "file-ops-session",
+        "search-read-session",
+        "sample-session",
+    ]
+
+    fixture_report = json.loads((output_root / "10-eval-fixtures.json").read_text(encoding="utf-8"))
+    assert fixture_report["failed_cases"] == 0
+
+    collected_report = json.loads(
+        (output_root / "11-eval-collected-openclaw-sessions.json").read_text(encoding="utf-8")
+    )
+    assert collected_report["evaluated_cases"] == 1
+
+
+def test_merge_validation_doc_references_standard_e2e_script() -> None:
+    path = Path(__file__).parent.parent / "docs" / "engineering" / "merge-validation.md"
+
+    content = path.read_text(encoding="utf-8")
+
+    assert "./scripts/run-e2e.sh" in content
+    assert "When To Run It" in content


### PR DESCRIPTION
Closes #88

Add a repository-local script that runs the standard E2E validation flow and document a short merge checklist describing when contributors should use it.

Validation:
- run the new E2E script against a temporary local workspace
- run automated tests covering the script entrypoint and expected outputs
- `./scripts/run-e2e.sh`
- `.venv/bin/pytest tests/test_e2e_script.py tests/test_codex_pm.py`
- `.venv/bin/pytest`
