### PR TITLE
Refresh MVP status documentation

### DIFF
--- a/.codex/pm/tasks/real-history-quality/refresh-mvp-status-docs.md
+++ b/.codex/pm/tasks/real-history-quality/refresh-mvp-status-docs.md
@@ -1,0 +1,44 @@
+---
+type: task
+epic: real-history-quality
+slug: refresh-mvp-status-docs
+title: Refresh MVP status and architecture docs after core loop completion
+status: done
+labels: docs
+issue: 96
+---
+
+## Context
+
+The roadmap already states that MVP v1 is complete, but the surrounding product and architecture docs still present a partially in-flight picture.
+Some current docs describe the shipped system accurately, while older Chinese MVP drafts still read like the active plan and the English PRD does not explicitly mark the core loop as complete.
+
+## Deliverable
+
+A documentation-only refresh that makes the repository's MVP status consistent across roadmap, PRD, architecture, and a new summary note.
+
+## Scope
+
+- refresh the English MVP PRD so it reflects the shipped MVP v1 state instead of only the original target state
+- add a concise MVP status note that summarizes the completed core loop and separates post-MVP work from MVP-blocking scope
+- update the English and Chinese MVP architecture docs where the shipped runtime integration picture has changed
+- mark stale Chinese Context Graph MVP drafts as historical/superseded so they are not mistaken for the current shipped plan
+
+## Acceptance Criteria
+
+- a reader can tell from the repo docs that the MVP core loop is fully implemented and validated
+- architecture and product docs consistently frame remaining work as post-MVP validation and quality iteration
+- older draft docs are clearly labeled so they do not conflict with the current OpenPrecedent MVP narrative
+
+## Validation
+
+- read the refreshed docs together and confirm they present one consistent MVP-complete story
+- confirm that no updated doc implies that core-loop engineering is still blocked or incomplete
+
+## Implementation Notes
+
+- Keep the change documentation-only.
+- Prefer explicit status language over broad rewrites.
+- Added `docs/product/mvp-status.md` as the repository-level summary of MVP completion and post-MVP boundaries.
+- Refreshed the English PRD, roadmap, and English/Chinese MVP architecture docs to reflect the shipped MVP v1 state.
+- Marked the older Chinese Context Graph MVP PRD and design docs as historical drafts so they do not compete with the current OpenPrecedent MVP narrative.

--- a/docs/architecture/mvp-design.md
+++ b/docs/architecture/mvp-design.md
@@ -1,6 +1,7 @@
 # OpenPrecedent MVP v1 Architecture
 
 Chinese version: [中文版本 / MVP v1 架构文档](/workspace/02-projects/incubation/openprecedent/docs/zh/architecture/mvp-design.md)
+Status summary: [MVP status note](/workspace/02-projects/incubation/openprecedent/docs/product/mvp-status.md)
 
 ## Purpose
 
@@ -64,6 +65,7 @@ OpenPrecedent MVP v1 can:
 5. replay a case with raw events, decisions, artifacts, and summary
 6. retrieve similar prior cases as precedent
 7. evaluate curated fixtures and collected OpenClaw sessions
+8. surface runtime decision-lineage briefs for OpenClaw task planning against shared prior history
 
 ## What MVP v1 Is Not
 
@@ -389,12 +391,16 @@ For OpenClaw this means:
 - a collector command imports the latest unseen session
 - a local state file prevents duplicate collection
 - cron and systemd assets exist for unattended local scheduling
+- runtime lineage retrieval should use a stable shared OpenPrecedent home rather than workspace-local accidental persistence
+- the shipped OpenClaw skill guidance allows prior-decision consistency prompts to trigger lineage retrieval during initial planning
 
 Related operational docs:
 
 - [openclaw-silent-collection.md](/workspace/02-projects/incubation/openprecedent/docs/architecture/openclaw-silent-collection.md)
 - [openclaw-collector-operations.md](/workspace/02-projects/incubation/openprecedent/docs/engineering/openclaw-collector-operations.md)
 - [openclaw-collector-rollout-validation.md](/workspace/02-projects/incubation/openprecedent/docs/engineering/openclaw-collector-rollout-validation.md)
+- [openclaw-real-runtime-decision-lineage-validation.md](/workspace/02-projects/incubation/openprecedent/docs/engineering/openclaw-real-runtime-decision-lineage-validation.md)
+- [openclaw-runtime-decision-lineage-trigger-rerun.md](/workspace/02-projects/incubation/openprecedent/docs/engineering/openclaw-runtime-decision-lineage-trigger-rerun.md)
 
 ## Accurate MVP v1 Capability Summary
 

--- a/docs/product/mvp-prd.md
+++ b/docs/product/mvp-prd.md
@@ -1,5 +1,26 @@
 # OpenPrecedent MVP PRD
 
+## Status
+
+- status: shipped MVP v1
+- core-loop status date: `2026-03-10`
+- repository summary: [mvp-status.md](/workspace/02-projects/incubation/openprecedent/docs/product/mvp-status.md)
+- implementation boundary: [mvp-design.md](/workspace/02-projects/incubation/openprecedent/docs/architecture/mvp-design.md)
+- completion roadmap: [mvp-roadmap.md](/workspace/02-projects/incubation/openprecedent/docs/product/mvp-roadmap.md)
+
+## Current Outcome
+
+The MVP described in this PRD is no longer a planned target only.
+As of `2026-03-10`, the core loop is implemented and validated in the repository's OpenClaw-first local environment:
+
+1. capture a case
+2. store the ordered event timeline
+3. extract decision records
+4. replay and explain decisions
+5. retrieve similar precedent
+
+What remains after this point is post-MVP validation and quality work rather than unfinished core-loop engineering.
+
 ## MVP Anchor
 
 The first MVP is anchored on a local single-agent runtime such as OpenClaw.
@@ -60,3 +81,13 @@ Out of scope:
 - decision explanations are evidence-backed
 - replay is useful for real post-hoc review
 - precedent retrieval returns helpful historical cases
+
+## Post-MVP Boundary
+
+The next stage should focus on:
+
+- measuring whether runtime precedent usage improves downstream task quality
+- improving extraction and retrieval quality on a broader real-history corpus
+- deciding whether to deepen OpenClaw-specific quality work or validate a second runtime
+
+Those are important, but they are no longer prerequisites for calling the MVP core loop complete.

--- a/docs/product/mvp-roadmap.md
+++ b/docs/product/mvp-roadmap.md
@@ -4,6 +4,10 @@
 
 As of 2026-03-10, MVP v1 is complete: the core loop is implemented, validated in a real local target environment, and brought through the first round of real-session quality fixes.
 
+Primary summary:
+
+- [MVP status note](/workspace/02-projects/incubation/openprecedent/docs/product/mvp-status.md)
+
 Completed:
 
 - repository foundation, governance, CI, and review workflow
@@ -254,6 +258,9 @@ Completed work:
 - precedent ranking tuned and regression-tested against anonymized real-session cases
 - validated cron-based rollout in the real target environment
 - first live collected session replayed and evaluated end-to-end
+- stable shared runtime home for OpenClaw-facing decision-lineage retrieval and invocation logging
+- live runtime decision-lineage retrieval validated against shared prior history
+- OpenClaw skill trigger guidance updated so prior-decision consistency prompts can trigger lineage retrieval during initial planning
 - rollout findings and caveats documented in `docs/engineering/openclaw-collector-rollout-validation.md`
 
 Remaining gaps:

--- a/docs/product/mvp-status.md
+++ b/docs/product/mvp-status.md
@@ -1,0 +1,56 @@
+# OpenPrecedent MVP Status Note
+
+## Status
+
+As of `2026-03-10`, OpenPrecedent `MVP v1` is complete.
+
+The core loop is no longer just specified in design docs. It is implemented and validated in the repository's local OpenClaw-first runtime path.
+
+## Completed Core Loop
+
+The shipped MVP now covers:
+
+1. capture a case
+2. store the ordered event timeline
+3. extract decision records
+4. replay and explain decisions
+5. retrieve similar precedent
+
+In practical repository terms, that means:
+
+- local SQLite-backed case, event, decision, and artifact persistence
+- CLI flows for ingestion, replay, extraction, and precedent retrieval
+- OpenClaw session import and silent local collection
+- fixture-based and real-session evaluation flows
+- real local runtime validation for decision-lineage retrieval through the OpenClaw path
+
+## What Counts As Done
+
+The MVP should now be considered engineering-complete because:
+
+- the end-to-end loop works on real local runtime history, not only synthetic fixtures
+- the repository has a standard E2E validation path and merge validation guidance
+- OpenClaw-facing runtime lineage retrieval has a stable shared persistence path and a documented trigger policy
+- no current repository doc needs to treat the core loop as still blocked on foundational implementation work
+
+## What Is Not Done
+
+Completion of the MVP core loop does not mean the product is finished.
+
+The next stage is post-MVP validation and quality work, including:
+
+- measuring whether lineage retrieval improves downstream task behavior
+- expanding real-history evaluation coverage
+- improving decision extraction quality where real history shows repeated gaps
+- improving precedent ranking quality as the corpus grows
+
+These are product-effectiveness and research-quality questions, not missing core-loop plumbing.
+
+## Reference Docs
+
+- [MVP roadmap](/workspace/02-projects/incubation/openprecedent/docs/product/mvp-roadmap.md)
+- [MVP PRD](/workspace/02-projects/incubation/openprecedent/docs/product/mvp-prd.md)
+- [MVP architecture](/workspace/02-projects/incubation/openprecedent/docs/architecture/mvp-design.md)
+- [OpenClaw full user journey validation](/workspace/02-projects/incubation/openprecedent/docs/engineering/openclaw-full-user-journey-validation.md)
+- [OpenClaw real runtime decision-lineage validation](/workspace/02-projects/incubation/openprecedent/docs/engineering/openclaw-real-runtime-decision-lineage-validation.md)
+- [Merge validation guidance](/workspace/02-projects/incubation/openprecedent/docs/engineering/merge-validation.md)

--- a/docs/zh/architecture/context-graph-mvp-design.md
+++ b/docs/zh/architecture/context-graph-mvp-design.md
@@ -6,9 +6,19 @@
 - 主题：以本机 OpenClaw 为锚点的 case 轨迹、决策与回放设计
 - 版本：v1
 - 日期：2026-03-09
-- 状态：Draft
+- 状态：Historical draft（已被当前 OpenPrecedent MVP 架构文档取代）
 - 关联需求：[2026-03-context-graph-mvp-prd-v1.md](/workspace/01-product/04-requirements/2026-03-context-graph-mvp-prd-v1.md)
 - 关联战略：[2026-03-context-graph-product-strategy.md](/workspace/01-product/01-strategy/2026-03-context-graph-product-strategy.md)
+
+## 当前状态说明
+
+这份文档保留的是 `2026-03-09` 的早期中文设计草案，记录的是从 Context Graph 概念向当前 OpenPrecedent MVP 收敛前的方案。
+
+当前已交付系统边界请改看：
+
+- [MVP 状态说明](/workspace/02-projects/incubation/openprecedent/docs/product/mvp-status.md)
+- [MVP 路线图](/workspace/02-projects/incubation/openprecedent/docs/product/mvp-roadmap.md)
+- [当前 MVP 架构文档](/workspace/02-projects/incubation/openprecedent/docs/zh/architecture/mvp-design.md)
 
 ## 1. 设计目标
 

--- a/docs/zh/architecture/mvp-design.md
+++ b/docs/zh/architecture/mvp-design.md
@@ -1,5 +1,7 @@
 # OpenPrecedent MVP v1 架构文档
 
+状态摘要：[MVP 状态说明](/workspace/02-projects/incubation/openprecedent/docs/product/mvp-status.md)
+
 ## 文档目的
 
 本文描述的是截至 2026-03-10 实际已经交付的 OpenPrecedent MVP v1 架构。
@@ -63,6 +65,7 @@ OpenPrecedent MVP v1 目前可以：
 5. 回放一个 case，并展示原始事件、决策、artifact 与 summary
 6. 检索相似历史 case 作为 precedent
 7. 评估 curated fixtures 与 collected OpenClaw sessions
+8. 基于共享历史为 OpenClaw 任务规划返回 runtime decision-lineage brief
 
 ## MVP v1 目前不包含什么
 
@@ -277,6 +280,7 @@ Precedent ..> Case : 引用历史 case
 - `openprecedent runtime import-openclaw`
 - `openprecedent runtime import-openclaw-session`
 - `openprecedent runtime collect-openclaw-sessions`
+- `openprecedent runtime decision-lineage-brief`
 
 ### Evaluation 操作
 
@@ -387,12 +391,16 @@ MVP 的运行时验证路径是本地、导入式的。
 - collector 命令导入最新未见过的 session
 - 本地 state file 用来避免重复收集
 - 已提供 cron 与 systemd 资产用于无人值守本地调度
+- runtime lineage 检索应使用稳定共享的 OpenPrecedent home，而不是意外落到 workspace-local 路径
+- 当前已交付的 OpenClaw skill 指导允许“与先前决策保持一致”这类提示在 initial planning 阶段触发 lineage retrieval
 
 相关运行文档：
 
 - [openclaw-silent-collection.md](/workspace/02-projects/incubation/openprecedent/docs/architecture/openclaw-silent-collection.md)
 - [openclaw-collector-operations.md](/workspace/02-projects/incubation/openprecedent/docs/engineering/openclaw-collector-operations.md)
 - [openclaw-collector-rollout-validation.md](/workspace/02-projects/incubation/openprecedent/docs/engineering/openclaw-collector-rollout-validation.md)
+- [openclaw-real-runtime-decision-lineage-validation.md](/workspace/02-projects/incubation/openprecedent/docs/engineering/openclaw-real-runtime-decision-lineage-validation.md)
+- [openclaw-runtime-decision-lineage-trigger-rerun.md](/workspace/02-projects/incubation/openprecedent/docs/engineering/openclaw-runtime-decision-lineage-trigger-rerun.md)
 
 ## 对 MVP v1 最准确的能力总结
 

--- a/docs/zh/product/context-graph-mvp-prd.md
+++ b/docs/zh/product/context-graph-mvp-prd.md
@@ -6,8 +6,18 @@
 - 主题：以本机 OpenClaw 为锚点的最小决策轨迹闭环验证
 - 版本：v1
 - 日期：2026-03-09
-- 状态：Draft
+- 状态：Historical draft（已被当前 OpenPrecedent MVP 文档取代）
 - 关联战略：[2026-03-context-graph-product-strategy.md](/workspace/01-product/01-strategy/2026-03-context-graph-product-strategy.md)
+
+## 当前状态说明
+
+这份文档保留的是 `2026-03-09` 的早期中文草案，主要用于记录当时从 `Context Graph` 命名和方向向当前 OpenPrecedent MVP 收敛时的思路。
+
+如果要看当前已交付状态，请以这些文档为准：
+
+- [MVP 状态说明](/workspace/02-projects/incubation/openprecedent/docs/product/mvp-status.md)
+- [MVP 路线图](/workspace/02-projects/incubation/openprecedent/docs/product/mvp-roadmap.md)
+- [MVP 架构文档](/workspace/02-projects/incubation/openprecedent/docs/zh/architecture/mvp-design.md)
 
 ## 一句话定义
 


### PR DESCRIPTION
Closes #96

A documentation-only refresh that makes the repository's MVP status consistent across roadmap, PRD, architecture, and a new summary note.

Implementation notes:
- Keep the change documentation-only.
- Prefer explicit status language over broad rewrites.
- Added  as the repository-level summary of MVP completion and post-MVP boundaries.
- Refreshed the English PRD, roadmap, and English/Chinese MVP architecture docs to reflect the shipped MVP v1 state.
- Marked the older Chinese Context Graph MVP PRD and design docs as historical drafts so they do not compete with the current OpenPrecedent MVP narrative.

Validation:
- read the refreshed docs together and confirm they present one consistent MVP-complete story
- confirm that no updated doc implies that core-loop engineering is still blocked or incomplete
- ============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /workspace/02-projects/incubation/openprecedent
configfile: pyproject.toml
plugins: anyio-4.12.1
collected 30 items

tests/test_cli.py ..............................                         [100%]

============================== 30 passed in 2.76s ==============================
