### PR TITLE
Document post-MVP research validation phase

### DIFF
--- a/.codex/pm/tasks/real-history-quality/document-research-validation-phase.md
+++ b/.codex/pm/tasks/real-history-quality/document-research-validation-phase.md
@@ -1,0 +1,40 @@
+---
+type: task
+epic: real-history-quality
+slug: document-research-validation-phase
+title: Document post-MVP research validation platform positioning
+status: done
+labels: docs
+issue: 98
+---
+
+## Context
+
+The repository now has a completed MVP core loop, but the current phase is still easy to misread as ongoing MVP buildout.
+What remains is primarily hypothesis validation and quality iteration around decision-lineage usefulness, retrieval quality, and task impact.
+
+## Deliverable
+
+A documentation-only update that explicitly describes OpenPrecedent's current phase as post-MVP research validation and frames the repository as the local-first validation platform for that work.
+
+## Scope
+
+- update the MVP status note with the current phase and repository role
+- add a concise roadmap-level reference so the positioning is visible outside the status note
+- keep the change documentation-only and avoid reopening MVP scope debates
+
+## Acceptance Criteria
+
+- readers can distinguish shipped MVP engineering from the current research-validation phase
+- the repository docs describe the current platform role without implying unfinished core-loop plumbing
+- the positioning stays concrete and tied to the current OpenClaw-first implementation
+
+## Validation
+
+- read the updated status and roadmap docs together and confirm they tell a consistent story
+
+## Implementation Notes
+
+- Prefer small, explicit wording updates over broad rewrites.
+- Updated the MVP status note to describe the current repository phase as post-MVP research validation.
+- Added a roadmap-level sentence that frames the repository as a local-first validation platform for decision-lineage and precedent reuse hypotheses.

--- a/docs/product/mvp-roadmap.md
+++ b/docs/product/mvp-roadmap.md
@@ -34,6 +34,7 @@ Current MVP v1 status:
 - no open implementation issues remain in the current MVP v1 scope
 - the shipped loop now covers collection, replay, explanation, precedent retrieval, and the first real-session quality pass
 - follow-up work should be treated as post-MVP expansion rather than MVP-blocking scope
+- the repository is now best understood as a local-first research validation platform for decision-lineage and precedent reuse hypotheses
 
 ## Objective
 

--- a/docs/product/mvp-status.md
+++ b/docs/product/mvp-status.md
@@ -6,6 +6,20 @@ As of `2026-03-10`, OpenPrecedent `MVP v1` is complete.
 
 The core loop is no longer just specified in design docs. It is implemented and validated in the repository's local OpenClaw-first runtime path.
 
+## Current Phase
+
+OpenPrecedent is now in a post-MVP research validation phase.
+
+At this stage, the repository should be read as a local-first validation platform for the product's core hypotheses around:
+
+- decision-lineage usefulness
+- precedent reuse in real agent workflows
+- retrieval and extraction quality on growing real history
+- downstream task impact when lineage is actually surfaced at runtime
+
+This is no longer primarily a core-loop plumbing effort.
+The current platform role is to make those hypotheses fast to test against a real OpenClaw-first environment without reopening MVP foundation work each time.
+
 ## Completed Core Loop
 
 The shipped MVP now covers:


### PR DESCRIPTION
Closes #98

## Summary

- update the MVP status note to describe the repository's current phase as post-MVP research validation
- frame the current stack as a local-first validation platform for decision-lineage and precedent reuse hypotheses
- add the same positioning to the MVP roadmap so the repository phase is visible outside the status note

## Testing

- .venv/bin/pytest tests/test_cli.py
