### PR TITLE
Document post-MVP research framework governance

### DIFF
--- a/.codex/pm/tasks/real-history-quality/define-post-mvp-research-evolution-framework.md
+++ b/.codex/pm/tasks/real-history-quality/define-post-mvp-research-evolution-framework.md
@@ -1,0 +1,41 @@
+---
+type: task
+epic: real-history-quality
+slug: define-post-mvp-research-evolution-framework
+title: Define the post-MVP research evolution framework for OpenPrecedent
+status: backlog
+labels: docs
+issue: 100
+---
+
+## Context
+
+OpenPrecedent has already completed MVP v1 engineering, but the repository now needs one explicit umbrella issue that explains how post-MVP work should evolve.
+Several narrower runtime-impact, retrieval-quality, and extractor-quality tasks already exist, but they need a parent research frame so future work is organized as hypothesis-driven validation instead of drifting back into generic plumbing.
+
+## Deliverable
+
+A top-level GitHub issue that defines the post-MVP research evolution framework for OpenPrecedent and serves as the parent framing artifact for later child research issues.
+
+## Scope
+
+- create one umbrella GitHub issue for the post-MVP research phase
+- define the main research lens and primary tracks at a product level
+- explain how later child issues should be framed and what artifacts they should produce
+- keep the work focused on planning/governance rather than implementation
+
+## Acceptance Criteria
+
+- the umbrella issue clearly distinguishes completed MVP engineering from post-MVP research work
+- later child issues can be derived from the umbrella without ambiguity
+- the framing does not duplicate narrower implementation or validation issues already tracked elsewhere
+
+## Validation
+
+- review the umbrella issue against `docs/product/mvp-status.md` and `docs/product/mvp-roadmap.md`
+- confirm it sits above existing runtime-impact and observability tasks rather than repeating them
+
+## Implementation Notes
+
+- Created GitHub issue `#100` as the umbrella research-governance issue for post-MVP evolution.
+- The issue is intentionally long-lived and should remain open as a parent framing artifact rather than being closed by a documentation PR.

--- a/.codex/pm/tasks/real-history-quality/document-post-mvp-research-evolution-framework.md
+++ b/.codex/pm/tasks/real-history-quality/document-post-mvp-research-evolution-framework.md
@@ -1,0 +1,39 @@
+---
+type: task
+epic: real-history-quality
+slug: document-post-mvp-research-evolution-framework
+title: Document the post-MVP research evolution framework in repository docs
+status: done
+labels: docs
+issue: 101
+---
+
+## Context
+
+The repository now says it is in a post-MVP research validation phase, but contributors still need one explicit in-repo pointer to the long-lived umbrella issue that governs that research evolution.
+Issue `#100` should remain open, while the documentation update that points to it should be a normal closable docs task.
+
+## Deliverable
+
+A concise documentation update that points readers to issue `#100` as the parent framing artifact for post-MVP research evolution.
+
+## Scope
+
+- add a concise reference in the product/status docs to the post-MVP research evolution framework
+- explain that issue `#100` is the umbrella for later hypothesis-driven research work
+- keep the change documentation-only and concise
+
+## Acceptance Criteria
+
+- the repository docs mention the research evolution framework clearly
+- the documentation points contributors to issue `#100` as the parent framing artifact
+- this issue can be closed once the doc update lands, while issue `#100` stays open
+
+## Validation
+
+- read the updated status note and confirm it explains both the current phase and the role of issue `#100`
+
+## Implementation Notes
+
+- This issue is the closable documentation companion to umbrella issue `#100`.
+- The doc update should make the parent-child relationship explicit without copying the whole umbrella issue into repository docs.

--- a/docs/product/mvp-status.md
+++ b/docs/product/mvp-status.md
@@ -20,6 +20,13 @@ At this stage, the repository should be read as a local-first validation platfor
 This is no longer primarily a core-loop plumbing effort.
 The current platform role is to make those hypotheses fast to test against a real OpenClaw-first environment without reopening MVP foundation work each time.
 
+## Research Governance
+
+The long-lived umbrella for this phase is GitHub issue `#100`, `Define the post-MVP research evolution framework for OpenPrecedent`.
+
+That issue should remain open as the parent framing artifact for later hypothesis-driven child issues.
+Repository docs should point to it, but should not duplicate the full research program each time.
+
 ## Completed Core Loop
 
 The shipped MVP now covers:


### PR DESCRIPTION
Closes #101

## Summary

- add a concise repository-doc pointer to issue #100 as the long-lived umbrella for post-MVP research evolution
- land the local open task twin for issue #100 so the umbrella research frame is tracked in-repo without closing the issue
- add and complete the closable documentation task twin for issue #101

## Testing

- .venv/bin/pytest tests/test_cli.py
