### PR TITLE
Add issue and task types to Codex PM

### DIFF
--- a/.codex/pm/tasks/real-history-quality/add-issue-and-task-types.md
+++ b/.codex/pm/tasks/real-history-quality/add-issue-and-task-types.md
@@ -1,0 +1,42 @@
+---
+type: task
+epic: real-history-quality
+slug: add-issue-and-task-types
+title: Add issue and task types to the Codex PM workflow
+status: done
+labels: feature,test,ops
+issue: 103
+---
+
+## Context
+
+The current Codex PM workflow tracks status and issue linkage, but it does not explicitly represent what kind of issue a task actually is.
+That gap caused confusion during harness work around whether a PR should close an issue, whether a task should remain open long-term, and how umbrella research issues should be handled differently from normal delivery work.
+
+## Deliverable
+
+A first-pass issue/task type model in Codex PM that can distinguish normal delivery work from long-lived umbrella issues and enforce the most important closure behavior difference.
+
+## Scope
+
+- add explicit task type metadata to Codex PM task creation and task serialization
+- support task types for at least `implementation`, `docs`, `research`, and `umbrella`
+- make PR-body rendering and PR closure validation respect `umbrella` semantics
+- update the existing `#100` task twin to use the new `umbrella` type
+
+## Acceptance Criteria
+
+- Codex PM task documents can represent task type directly in frontmatter and JSON output
+- issue body rendering exposes the task type in an inspectable way
+- PR body generation does not emit `Closes #...` for `umbrella` tasks
+- PR closure sync fails if a PR attempts to close an `umbrella` task issue
+
+## Validation
+
+- `.venv/bin/pytest tests/test_codex_pm.py`
+
+## Implementation Notes
+
+- Added `--task-type` to `task-new` with `implementation`, `docs`, `research`, and `umbrella`.
+- Updated PR closure validation so `task_type=umbrella` must remain open.
+- Marked the existing `#100` local task twin as `task_type: umbrella`.

--- a/.codex/pm/tasks/real-history-quality/define-post-mvp-research-evolution-framework.md
+++ b/.codex/pm/tasks/real-history-quality/define-post-mvp-research-evolution-framework.md
@@ -4,6 +4,7 @@ epic: real-history-quality
 slug: define-post-mvp-research-evolution-framework
 title: Define the post-MVP research evolution framework for OpenPrecedent
 status: backlog
+task_type: umbrella
 labels: docs
 issue: 100
 ---

--- a/src/openprecedent/codex_pm.py
+++ b/src/openprecedent/codex_pm.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 PM_ROOT = Path(".codex/pm")
 VALID_STATUSES = ("backlog", "in_progress", "blocked", "done")
+VALID_TASK_TYPES = ("implementation", "docs", "research", "umbrella")
 CLOSING_ISSUE_PATTERN = re.compile(
     r"\b(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s+#(\d+)\b",
     re.IGNORECASE,
@@ -46,6 +47,7 @@ def build_parser() -> argparse.ArgumentParser:
     task_new.add_argument("--issue")
     task_new.add_argument("--labels", default="")
     task_new.add_argument("--status", default="backlog", choices=VALID_STATUSES)
+    task_new.add_argument("--task-type", default="implementation", choices=VALID_TASK_TYPES)
     task_new.add_argument("--depends-on", default="")
 
     tasks = subparsers.add_parser("tasks")
@@ -148,6 +150,7 @@ def main(argv: list[str] | None = None) -> int:
             "slug": args.slug,
             "title": args.title,
             "status": args.status,
+            "task_type": args.task_type,
             "labels": args.labels,
             "depends_on": args.depends_on,
         }
@@ -352,6 +355,7 @@ def _doc_to_dict(document: PMDocument) -> dict[str, object]:
         "status": document.metadata.get("status", ""),
         "epic": document.metadata.get("epic", ""),
         "issue": document.metadata.get("issue"),
+        "task_type": document.metadata.get("task_type", "implementation"),
         "labels": [item for item in document.metadata.get("labels", "").split(",") if item],
     }
 
@@ -373,6 +377,7 @@ def _render_issue_body(document: PMDocument) -> str:
     deliverable = document.sections.get("Deliverable", "")
     scope = document.sections.get("Scope", "")
     acceptance = document.sections.get("Acceptance Criteria", "")
+    task_type = document.metadata.get("task_type", "")
 
     if context:
         lines.extend(["## Context", context, ""])
@@ -382,6 +387,8 @@ def _render_issue_body(document: PMDocument) -> str:
         lines.extend(["## Scope", scope, ""])
     if acceptance:
         lines.extend(["## Acceptance Criteria", acceptance, ""])
+    if task_type:
+        lines.extend(["## Task Type", task_type, ""])
     labels = document.metadata.get("labels", "")
     if labels:
         lines.extend(["## Labels", labels, ""])
@@ -391,7 +398,8 @@ def _render_issue_body(document: PMDocument) -> str:
 def _render_pr_body(document: PMDocument, *, issue: int | None, tests: list[str]) -> str:
     lines: list[str] = []
     closing_issue = issue or _parse_issue_number(document.metadata.get("issue", ""))
-    if closing_issue is not None:
+    task_type = document.metadata.get("task_type", "implementation")
+    if closing_issue is not None and task_type != "umbrella":
         lines.extend([f"Closes #{closing_issue}", ""])
     deliverable = document.sections.get("Deliverable", "")
     implementation_notes = document.sections.get("Implementation Notes", "")
@@ -465,6 +473,16 @@ def _verify_pr_closure_sync(pr_body: str, changed_files: list[str]) -> list[str]
         if not matching_documents:
             errors.append(
                 f"PR closes #{issue} but does not update the matching local task file under .codex/pm/tasks/."
+            )
+            continue
+        umbrella_paths = ", ".join(
+            str(document.path)
+            for document in matching_documents
+            if document.metadata.get("task_type", "implementation") == "umbrella"
+        )
+        if umbrella_paths:
+            errors.append(
+                f"PR closes #{issue} but matching task file is task_type=umbrella and must remain open: {umbrella_paths}"
             )
             continue
         if not any(document.metadata.get("status") == "done" for document in matching_documents):

--- a/tests/test_codex_pm.py
+++ b/tests/test_codex_pm.py
@@ -94,6 +94,7 @@ def test_codex_pm_scaffolds_and_selects_next_task(tmp_path: Path, monkeypatch, c
     next_task = json.loads(capsys.readouterr().out)
     assert next_task["title"] == "Roll out collector"
     assert next_task["issue"] == "23"
+    assert next_task["task_type"] == "implementation"
 
     assert main(["tasks", "--json"]) == 0
     tasks = json.loads(capsys.readouterr().out)
@@ -152,6 +153,8 @@ def test_codex_pm_updates_status_and_renders_issue_and_pr_body(tmp_path: Path, m
     assert "## Context" in issue_body
     assert "Collector rollout still needs a real target host." in issue_body
     assert "## Acceptance Criteria" in issue_body
+    assert "## Task Type" in issue_body
+    assert "implementation" in issue_body
 
     assert (
         main(
@@ -170,6 +173,33 @@ def test_codex_pm_updates_status_and_renders_issue_and_pr_body(tmp_path: Path, m
     assert "Closes #23" in pr_body
     assert "Run the collector on a real schedule." in pr_body
     assert "Validation:" in pr_body
+
+
+def test_codex_pm_task_new_supports_explicit_task_type(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    assert main(["init"]) == 0
+    capsys.readouterr()
+    assert (
+        main(
+            [
+                "task-new",
+                "real-history-quality",
+                "research-framework",
+                "--title",
+                "Define research framework",
+                "--issue",
+                "100",
+                "--task-type",
+                "umbrella",
+            ]
+        )
+        == 0
+    )
+    task_path = tmp_path / ".codex" / "pm" / "tasks" / "real-history-quality" / "research-framework.md"
+    document = task_path.read_text(encoding="utf-8")
+
+    assert "task_type: umbrella" in document
 
 
 def test_codex_pm_lists_backfilled_tasks(tmp_path: Path, monkeypatch, capsys) -> None:
@@ -381,3 +411,76 @@ def test_codex_pm_verify_pr_closure_sync_fails_when_matching_task_is_not_done(
         == 1
     )
     assert "matching task file is not marked done" in capsys.readouterr().err
+
+
+def test_codex_pm_verify_pr_closure_sync_fails_for_umbrella_task_type(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    assert main(["init"]) == 0
+    capsys.readouterr()
+    assert (
+        main(
+            [
+                "task-new",
+                "real-history-quality",
+                "research-framework",
+                "--title",
+                "Define research framework",
+                "--issue",
+                "100",
+                "--task-type",
+                "umbrella",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    task_path = tmp_path / ".codex" / "pm" / "tasks" / "real-history-quality" / "research-framework.md"
+    assert (
+        main(
+            [
+                "verify-pr-closure-sync",
+                "--pr-body",
+                "Closes #100",
+                "--changed-file",
+                str(task_path.relative_to(tmp_path)),
+            ]
+        )
+        == 1
+    )
+    assert "task_type=umbrella and must remain open" in capsys.readouterr().err
+
+
+def test_codex_pm_pr_body_omits_closing_clause_for_umbrella_task(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    assert main(["init"]) == 0
+    capsys.readouterr()
+    assert (
+        main(
+            [
+                "task-new",
+                "real-history-quality",
+                "research-framework",
+                "--title",
+                "Define research framework",
+                "--issue",
+                "100",
+                "--task-type",
+                "umbrella",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    task_path = tmp_path / ".codex" / "pm" / "tasks" / "real-history-quality" / "research-framework.md"
+    assert main(["pr-body", str(task_path)]) == 0
+    pr_body = capsys.readouterr().out
+
+    assert "Closes #100" not in pr_body


### PR DESCRIPTION
Closes #103

## Summary

- add explicit task types to Codex PM task creation and serialized task metadata
- expose task type in issue-body rendering and task JSON output
- make umbrella tasks non-closable by default in PR body generation and PR closure sync validation
- mark the existing #100 research framework twin as task_type=umbrella

## Testing

- .venv/bin/pytest tests/test_codex_pm.py
