### PR TITLE
Add CI failure triage tooling

### DIFF
--- a/.codex/pm/tasks/real-history-quality/ci-failure-triage.md
+++ b/.codex/pm/tasks/real-history-quality/ci-failure-triage.md
@@ -1,0 +1,41 @@
+---
+type: task
+epic: real-history-quality
+slug: ci-failure-triage
+title: Add CI failure triage tooling for the agent development harness
+status: done
+task_type: implementation
+labels: feature,ops,test
+issue: 107
+---
+
+## Context
+
+The repository already has useful checks, but agents still spend too much time re-reading routine CI failures by hand.
+During MVP work, many failures fell into a small number of predictable categories such as markdownlint, python-ci regressions, and PR gate / PM drift checks. The harness should classify those failures quickly and point to the right next step.
+
+## Deliverable
+
+A repository-local CI triage entrypoint that summarizes current PR checks, classifies known failures, and surfaces the most likely next action for an agent developer.
+
+## Scope
+
+- add a local script that inspects GitHub PR check status through `gh`
+- classify the repository's current known checks into higher-level categories
+- render actionable summaries for failing checks without trying to auto-fix them
+- document the triage entrypoint in the local tooling docs
+
+## Acceptance Criteria
+
+- one command can summarize the current PR checks for this repository
+- known failures such as `python-ci`, `markdownlint`, and `pr-review-gate` are classified into useful categories
+- the output gives an agent enough context to choose the next repair step faster than raw log hunting
+
+## Validation
+
+- `.venv/bin/pytest tests/test_ci_triage_script.py`
+
+## Implementation Notes
+
+- The first version uses `gh pr view --json statusCheckRollup` because the installed `gh pr checks` command does not support JSON output in this environment.
+- Focus on classification and concise guidance, not automatic remediation.

--- a/docs/engineering/tooling-setup.md
+++ b/docs/engineering/tooling-setup.md
@@ -9,6 +9,7 @@ The repository already includes:
 - `feishu-pr-notify` GitHub Actions workflow for pull request review notifications
 - a local Git pre-push hook that requires a Codex review note
 - `scripts/run-agent-preflight.sh` for the standard local pre-push confidence checks
+- `scripts/triage_pr_checks.py` for local CI failure classification against current PR checks
 - `scripts/run-e2e.sh` for the standard local fixture-backed end-to-end runtime validation path
 
 To enable the local hook:
@@ -59,6 +60,25 @@ or run the E2E script directly:
 
 The detailed merge checklist lives in
 [`docs/engineering/merge-validation.md`](/workspace/02-projects/incubation/openprecedent/docs/engineering/merge-validation.md).
+
+## CI Failure Triage
+
+When a PR check fails and you want a faster local summary than manually opening each run, use:
+
+```bash
+python3 ./scripts/triage_pr_checks.py --pr <number>
+```
+
+If you are already on the PR branch, you can usually omit `--pr` and let `gh` resolve the current PR.
+
+The script classifies the repository's current checks into a few higher-level categories such as:
+
+- test regression
+- docs lint
+- workflow policy
+- notification-only
+
+It is intended as a diagnosis helper, not an auto-fix tool.
 
 ## GitHub App Recommendations
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,4 +7,5 @@ Notable operational entrypoints:
 - `run-collector.sh` runs one collector pass with local-first defaults
 - `run-e2e.sh` runs the standard local fixture-backed end-to-end validation flow
 - `run-agent-preflight.sh` runs the standard local pre-push confidence checks for agent-driven work
+- `triage_pr_checks.py` summarizes and classifies current PR check results for faster CI diagnosis
 - `install-collector-assets.sh` renders `systemd` / `cron` assets against the current repo path

--- a/scripts/triage_pr_checks.py
+++ b/scripts/triage_pr_checks.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+
+
+KNOWN_CHECKS: dict[str, tuple[str, str]] = {
+    "python-ci": ("test_regression", "Inspect failing pytest output and rerun the relevant local test subset."),
+    "markdownlint": ("docs_lint", "Inspect Markdown formatting and rerun the relevant local doc or lint checks."),
+    "pr-review-gate": ("workflow_policy", "Check PR approvals and issue/task closure-sync state."),
+    "feishu-pr-notify": ("notification", "Notification-only check; inspect only if delivery signaling matters."),
+}
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="triage-pr-checks")
+    parser.add_argument("--pr", help="PR number, URL, or branch. Defaults to current branch PR.")
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    return parser
+
+
+def _load_rollup(pr: str | None) -> list[dict[str, object]]:
+    command = ["gh", "pr", "view", "--json", "statusCheckRollup"]
+    if pr:
+        command[3:3] = [pr]
+    result = subprocess.run(command, check=True, capture_output=True, text=True)
+    payload = json.loads(result.stdout)
+    return payload.get("statusCheckRollup", [])
+
+
+def _classify(entry: dict[str, object]) -> dict[str, object]:
+    name = str(entry.get("name", ""))
+    status = str(entry.get("status", ""))
+    conclusion = str(entry.get("conclusion", ""))
+    details_url = str(entry.get("detailsUrl", ""))
+    category, guidance = KNOWN_CHECKS.get(
+        name,
+        ("unknown", "Inspect the linked check details and classify whether it is a test, policy, or external failure."),
+    )
+    return {
+        "name": name,
+        "status": status,
+        "conclusion": conclusion,
+        "category": category,
+        "guidance": guidance,
+        "details_url": details_url,
+        "is_failure": conclusion.lower() == "failure",
+    }
+
+
+def _render_text(entries: list[dict[str, object]]) -> str:
+    if not entries:
+        return "No PR checks found."
+
+    lines: list[str] = []
+    failures = [entry for entry in entries if entry["is_failure"]]
+    passes = [entry for entry in entries if not entry["is_failure"]]
+
+    if failures:
+        lines.append("Failing checks:")
+        for entry in failures:
+            lines.append(
+                f"- {entry['name']} [{entry['category']}]: {entry['guidance']} ({entry['details_url']})"
+            )
+    else:
+        lines.append("No failing checks.")
+
+    if passes:
+        lines.append("")
+        lines.append("Passing checks:")
+        for entry in passes:
+            lines.append(f"- {entry['name']} [{entry['category']}]")
+
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    entries = [_classify(entry) for entry in _load_rollup(args.pr)]
+    if args.as_json:
+        print(json.dumps(entries, ensure_ascii=True, indent=2, sort_keys=True))
+    else:
+        print(_render_text(entries))
+    return 1 if any(entry["is_failure"] for entry in entries) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ci_triage_script.py
+++ b/tests/test_ci_triage_script.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_module():
+    script_path = Path(__file__).parent.parent / "scripts" / "triage_pr_checks.py"
+    spec = importlib.util.spec_from_file_location("triage_pr_checks", script_path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_triage_pr_checks_classifies_known_failures() -> None:
+    module = _load_module()
+
+    classified = module._classify(
+        {
+            "name": "python-ci",
+            "status": "COMPLETED",
+            "conclusion": "FAILURE",
+            "detailsUrl": "https://example.invalid/python-ci",
+        }
+    )
+
+    assert classified["category"] == "test_regression"
+    assert classified["is_failure"] is True
+
+
+def test_triage_pr_checks_renders_text_summary() -> None:
+    module = _load_module()
+
+    rendered = module._render_text(
+        [
+            {
+                "name": "python-ci",
+                "category": "test_regression",
+                "guidance": "Inspect failing pytest output.",
+                "details_url": "https://example.invalid/python-ci",
+                "is_failure": True,
+            },
+            {
+                "name": "markdownlint",
+                "category": "docs_lint",
+                "guidance": "Inspect markdown formatting.",
+                "details_url": "https://example.invalid/markdownlint",
+                "is_failure": False,
+            },
+        ]
+    )
+
+    assert "Failing checks:" in rendered
+    assert "python-ci [test_regression]" in rendered
+    assert "Passing checks:" in rendered
+    assert "markdownlint [docs_lint]" in rendered


### PR DESCRIPTION
Closes #107

## Summary

- add a repository-local PR check triage script that classifies current GitHub check results into higher-level failure categories
- document the triage entrypoint in local tooling docs
- add tests for the classification and summary rendering behavior

## Testing

- .venv/bin/pytest tests/test_ci_triage_script.py
- python3 ./scripts/triage_pr_checks.py --pr 112
