### PR TITLE
Add branch freshness guardrails

### DIFF
--- a/.codex/pm/tasks/real-history-quality/stale-branch-rebase-guardrails.md
+++ b/.codex/pm/tasks/real-history-quality/stale-branch-rebase-guardrails.md
@@ -1,0 +1,43 @@
+---
+type: task
+epic: real-history-quality
+slug: stale-branch-rebase-guardrails
+title: Add harness guardrails for stale branches and missed rebases
+status: done
+task_type: implementation
+labels: feature,ops,test
+issue: 114
+---
+
+## Context
+
+Even after adding stronger workflow guardrails, branch freshness still depends too much on memory.
+In practice, stale branches and missed rebases are often caught late, after review has started or after CI has already run. This creates avoidable churn and repeatedly requires manual reminders.
+
+## Deliverable
+
+A harness-level branch freshness check that detects when the current branch no longer contains the latest `upstream/main` and surfaces that problem earlier through the local pre-push and preflight flows.
+
+## Scope
+
+- add one repository-local branch freshness checker that can be called from shell guardrails and tested independently
+- integrate it into the existing pre-push hook
+- integrate it into the unified agent preflight script
+- document the new freshness expectation in repository governance and tooling docs
+
+## Acceptance Criteria
+
+- the harness can detect when a branch is behind the configured base ref
+- the local pre-push path blocks stale branches before push unless explicitly bypassed
+- the preflight path fails early on stale branches before later checks run
+- the guidance tells the user to rebase onto the latest `upstream/main`
+
+## Validation
+
+- `.venv/bin/pytest tests/test_branch_freshness_script.py`
+- `.venv/bin/pytest tests/test_preflight_script.py tests/test_branch_freshness_script.py`
+
+## Implementation Notes
+
+- The first version focuses on detection and messaging, not automatic rebasing.
+- The freshness check should remain bypassable for exceptional cases, but the default path should strongly prefer an up-to-date branch before push.

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -5,6 +5,7 @@ repo_root="$(git rev-parse --show-toplevel)"
 review_file="$repo_root/.codex-review"
 current_branch="$(git branch --show-current)"
 origin_url="$(git remote get-url origin 2>/dev/null || true)"
+base_ref="${OPENPRECEDENT_BASE_REF:-upstream/main}"
 
 extract_owner() {
   local remote_url="$1"
@@ -18,6 +19,12 @@ extract_owner() {
 if [[ "${BYPASS_CODEX_REVIEW:-}" == "1" ]]; then
   echo "Bypassing Codex review hook because BYPASS_CODEX_REVIEW=1"
   exit 0
+fi
+
+if [[ "${BYPASS_BRANCH_FRESHNESS_CHECK:-}" != "1" ]]; then
+  python3 "$repo_root/scripts/check_branch_freshness.py" --base-ref "$base_ref" --allow-missing-base-ref
+else
+  echo "Bypassing branch freshness check because BYPASS_BRANCH_FRESHNESS_CHECK=1"
 fi
 
 if [[ ! -f "$review_file" ]]; then

--- a/docs/engineering/repository-governance.md
+++ b/docs/engineering/repository-governance.md
@@ -58,6 +58,7 @@ Expected local behavior:
 - authors run a Codex review before push
 - authors record the result in `.codex-review`
 - the local pre-push hook blocks the push if the review note is missing
+- the local pre-push hook blocks stale branches that no longer contain the latest `upstream/main`
 - the local pre-push hook also blocks pushes to branches whose PRs have already been merged into `openprecedent/openprecedent`
 
 This is a local reliability measure, not a substitute for repository review requirements.

--- a/docs/engineering/tooling-setup.md
+++ b/docs/engineering/tooling-setup.md
@@ -19,6 +19,7 @@ To enable the local hook:
 ```
 
 After that, each push requires a `.codex-review` file in the repository root unless you explicitly bypass the hook.
+The local hook also expects your branch to contain the latest `upstream/main` by default, so stale branches are caught before push.
 
 ## Codex Review Hook
 
@@ -33,6 +34,7 @@ remaining risks: dependencies not installed locally, tests not executed
 ```
 
 This hook does not replace human judgment. It creates a minimal review checkpoint before code leaves the local branch.
+It also acts as a branch-freshness guardrail: if your branch no longer contains the latest `upstream/main`, rebase before pushing.
 
 ## Merge Validation
 
@@ -43,6 +45,7 @@ For a normal local readiness pass before push, run:
 ```
 
 This checks the local review note, blocks reused merged branches, runs `pytest`, runs `markdownlint` when available locally, and performs a local PR closure sync check when a PR body is available through `gh`.
+It also checks that your branch contains the configured base ref, which defaults to `upstream/main`.
 
 Set `OPENPRECEDENT_PREFLIGHT_RUN_E2E=1` if you also want the standard E2E path included in the same pass.
 

--- a/scripts/check_branch_freshness.py
+++ b/scripts/check_branch_freshness.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="check-branch-freshness")
+    parser.add_argument("--base-ref", default="upstream/main")
+    parser.add_argument("--allow-missing-base-ref", action="store_true")
+    return parser
+
+
+def _git(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", *args], check=False, capture_output=True, text=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    verify = _git("rev-parse", "--verify", args.base_ref)
+    if verify.returncode != 0:
+        if args.allow_missing_base_ref:
+            print(f"Skipping branch freshness check: base ref {args.base_ref} is unavailable")
+            return 0
+        print(f"Branch freshness check failed: base ref {args.base_ref} is unavailable")
+        return 1
+
+    contains = _git("merge-base", "--is-ancestor", args.base_ref, "HEAD")
+    if contains.returncode == 0:
+        print(f"Branch freshness check passed: HEAD contains {args.base_ref}")
+        return 0
+
+    print(
+        f"Branch freshness check failed: current branch does not contain the latest {args.base_ref}. "
+        "Rebase onto the latest upstream/main before pushing."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run-agent-preflight.sh
+++ b/scripts/run-agent-preflight.sh
@@ -18,6 +18,7 @@ fi
 RUN_E2E="${OPENPRECEDENT_PREFLIGHT_RUN_E2E:-0}"
 REVIEW_FILE="${OPENPRECEDENT_REVIEW_FILE:-$ROOT_DIR/.codex-review}"
 PYTEST_ARGS="${OPENPRECEDENT_PREFLIGHT_PYTEST_ARGS:-tests --ignore=tests/test_preflight_script.py}"
+BASE_REF="${OPENPRECEDENT_PREFLIGHT_BASE_REF:-upstream/main}"
 
 check_review_note() {
   if [[ ! -f "$REVIEW_FILE" ]]; then
@@ -59,6 +60,15 @@ check_merged_branch_reuse() {
     echo "Preflight failed: current branch already has a merged PR in openprecedent/openprecedent"
     exit 1
   fi
+}
+
+check_branch_freshness() {
+  if [[ "${BYPASS_BRANCH_FRESHNESS_CHECK:-}" == "1" ]]; then
+    echo "Bypassing branch freshness check because BYPASS_BRANCH_FRESHNESS_CHECK=1"
+    return 0
+  fi
+
+  python3 "$ROOT_DIR/scripts/check_branch_freshness.py" --base-ref "$BASE_REF" --allow-missing-base-ref
 }
 
 run_markdownlint_if_available() {
@@ -113,6 +123,7 @@ run_local_pr_closure_check() {
 
 echo "Running agent preflight in $ROOT_DIR"
 
+check_branch_freshness
 check_review_note
 check_merged_branch_reuse
 

--- a/tests/test_branch_freshness_script.py
+++ b/tests/test_branch_freshness_script.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def test_branch_freshness_script_passes_when_head_contains_base(tmp_path: Path) -> None:
+    repo_root = Path(__file__).parent.parent
+    script = repo_root / "scripts" / "check_branch_freshness.py"
+
+    _git(tmp_path, "init", "-b", "main")
+    _git(tmp_path, "config", "user.name", "Test User")
+    _git(tmp_path, "config", "user.email", "test@example.com")
+    (tmp_path / "README.md").write_text("base\n", encoding="utf-8")
+    _git(tmp_path, "add", "README.md")
+    _git(tmp_path, "commit", "-m", "base")
+    _git(tmp_path, "remote", "add", "upstream", str(tmp_path))
+    _git(tmp_path, "fetch", "upstream")
+
+    result = subprocess.run(
+        ["python3", str(script), "--base-ref", "upstream/main"],
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "Branch freshness check passed" in result.stdout
+
+
+def test_branch_freshness_script_fails_when_branch_is_behind_base(tmp_path: Path) -> None:
+    repo_root = Path(__file__).parent.parent
+    script = repo_root / "scripts" / "check_branch_freshness.py"
+
+    _git(tmp_path, "init", "-b", "main")
+    _git(tmp_path, "config", "user.name", "Test User")
+    _git(tmp_path, "config", "user.email", "test@example.com")
+    (tmp_path / "README.md").write_text("base\n", encoding="utf-8")
+    _git(tmp_path, "add", "README.md")
+    _git(tmp_path, "commit", "-m", "base")
+
+    # Create a bare upstream remote with one extra commit so the local branch becomes stale.
+    upstream_remote = tmp_path / "upstream.git"
+    _git(tmp_path, "clone", "--bare", str(tmp_path), str(upstream_remote))
+    _git(tmp_path, "remote", "add", "upstream", str(upstream_remote))
+    _git(tmp_path, "push", "upstream", "main")
+
+    worktree = tmp_path / "upstream-worktree"
+    _git(tmp_path, "clone", str(upstream_remote), str(worktree))
+    _git(worktree, "config", "user.name", "Test User")
+    _git(worktree, "config", "user.email", "test@example.com")
+    (worktree / "README.md").write_text("base\nupstream change\n", encoding="utf-8")
+    _git(worktree, "add", "README.md")
+    _git(worktree, "commit", "-m", "upstream change")
+    _git(worktree, "push", "origin", "main")
+    _git(tmp_path, "fetch", "upstream")
+
+    result = subprocess.run(
+        ["python3", str(script), "--base-ref", "upstream/main"],
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "does not contain the latest upstream/main" in result.stdout

--- a/tests/test_preflight_script.py
+++ b/tests/test_preflight_script.py
@@ -10,6 +10,7 @@ def test_preflight_script_fails_without_codex_review(tmp_path: Path) -> None:
     env = os.environ.copy()
     env["OPENPRECEDENT_REVIEW_FILE"] = str(tmp_path / ".codex-review")
     env["OPENPRECEDENT_PYTHON_BIN"] = str(repo_root / ".venv" / "bin" / "python")
+    env["OPENPRECEDENT_PREFLIGHT_BASE_REF"] = "HEAD"
 
     result = subprocess.run(
         ["./scripts/run-agent-preflight.sh"],
@@ -36,6 +37,7 @@ def test_preflight_script_runs_and_skips_markdownlint_when_unavailable(tmp_path:
     env["OPENPRECEDENT_REVIEW_FILE"] = str(review_file)
     env["OPENPRECEDENT_PYTHON_BIN"] = str(repo_root / ".venv" / "bin" / "python")
     env["PATH"] = "/usr/bin:/bin"
+    env["OPENPRECEDENT_PREFLIGHT_BASE_REF"] = "HEAD"
 
     result = subprocess.run(
         ["./scripts/run-agent-preflight.sh"],


### PR DESCRIPTION
Closes #114

## Summary

- add a reusable branch freshness checker that detects when the current branch no longer contains the latest upstream/main
- enforce that check in both the local pre-push hook and the unified agent preflight script
- document the new stale-branch expectation in tooling and repository governance docs

## Testing

- .venv/bin/pytest tests/test_branch_freshness_script.py tests/test_preflight_script.py
