### PR TITLE
Integrate Codex /review into a local harness checkpoint

### DIFF
--- a/.codex/pm/tasks/real-history-quality/codex-review-checkpoint.md
+++ b/.codex/pm/tasks/real-history-quality/codex-review-checkpoint.md
@@ -1,0 +1,42 @@
+---
+type: task
+epic: real-history-quality
+slug: codex-review-checkpoint
+title: Integrate Codex /review into a local harness checkpoint
+status: done
+task_type: implementation
+labels: feature,ops,docs
+issue: 116
+---
+
+## Context
+
+Codex now has a native `/review` command, but the repository lacked a consistent local place to trigger it before pushing.
+The harness already enforced the presence of `.codex-review`, but it did not guide authors toward a standard checkpoint or provide a starter note.
+
+## Deliverable
+
+Add a repository-local review checkpoint script, wire the hook and docs to point at it, and keep the outcome compatible with the existing `.codex-review` guardrail.
+
+## Scope
+
+- add a `scripts/run-codex-review-checkpoint.sh` entrypoint
+- update the local pre-push hook to direct authors to the checkpoint
+- document the checkpoint in tooling docs and scripts inventory
+- add tests for template creation and existing-note preservation
+
+## Acceptance Criteria
+
+- a local script exists that creates a `.codex-review` template when missing
+- the script explicitly tells the author to run native Codex `/review`
+- the pre-push hook error points authors to the checkpoint script
+- repository docs describe the checkpoint as the preferred `/review` trigger location
+
+## Validation
+
+- `.venv/bin/pytest tests/test_codex_review_checkpoint.py`
+
+## Implementation Notes
+
+The harness cannot invoke the native Codex slash command directly from a shell hook.
+This first version therefore creates a workflow-fit checkpoint that prepares the review note and tells the author exactly when to run `/review`.

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -31,7 +31,10 @@ if [[ ! -f "$review_file" ]]; then
   cat <<'EOF'
 Push blocked: missing .codex-review
 
-Before pushing, run a Codex review for your staged or branch changes and write a short note to:
+Before pushing, run:
+  ./scripts/run-codex-review-checkpoint.sh
+
+Then use the native Codex /review command for your staged or branch changes and write a short note to:
   .codex-review
 
 Minimum content:
@@ -53,6 +56,9 @@ Include at least:
   - scope reviewed
   - findings or "no findings"
   - remaining risks
+
+If needed, rerun:
+  ./scripts/run-codex-review-checkpoint.sh
 EOF
   exit 1
 fi

--- a/docs/engineering/tooling-setup.md
+++ b/docs/engineering/tooling-setup.md
@@ -8,6 +8,7 @@ The repository already includes:
 - `python-ci` GitHub Actions workflow for dependency install and tests
 - `feishu-pr-notify` GitHub Actions workflow for pull request review notifications
 - a local Git pre-push hook that requires a Codex review note
+- `scripts/run-codex-review-checkpoint.sh` as the preferred local checkpoint for invoking native Codex `/review`
 - `scripts/run-agent-preflight.sh` for the standard local pre-push confidence checks
 - `scripts/triage_pr_checks.py` for local CI failure classification against current PR checks
 - `scripts/run-e2e.sh` for the standard local fixture-backed end-to-end runtime validation path
@@ -23,7 +24,16 @@ The local hook also expects your branch to contain the latest `upstream/main` by
 
 ## Codex Review Hook
 
-Before pushing, create a short review note in `.codex-review`.
+Before pushing, run:
+
+```bash
+./scripts/run-codex-review-checkpoint.sh
+```
+
+This is the preferred local checkpoint for invoking native Codex `/review`.
+The script creates a `.codex-review` template if one does not exist and reminds you to run `/review` before push.
+
+Then update `.codex-review` with a short review note.
 
 Recommended format:
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,5 +7,6 @@ Notable operational entrypoints:
 - `run-collector.sh` runs one collector pass with local-first defaults
 - `run-e2e.sh` runs the standard local fixture-backed end-to-end validation flow
 - `run-agent-preflight.sh` runs the standard local pre-push confidence checks for agent-driven work
+- `run-codex-review-checkpoint.sh` creates or refreshes the local review note before invoking native Codex `/review`
 - `triage_pr_checks.py` summarizes and classifies current PR check results for faster CI diagnosis
 - `install-collector-assets.sh` renders `systemd` / `cron` assets against the current repo path

--- a/scripts/run-agent-preflight.sh
+++ b/scripts/run-agent-preflight.sh
@@ -23,11 +23,13 @@ BASE_REF="${OPENPRECEDENT_PREFLIGHT_BASE_REF:-upstream/main}"
 check_review_note() {
   if [[ ! -f "$REVIEW_FILE" ]]; then
     echo "Preflight failed: missing .codex-review"
+    echo "Run ./scripts/run-codex-review-checkpoint.sh, then use native Codex /review and update the note."
     exit 1
   fi
 
   if ! grep -Eq 'scope reviewed|no findings|remaining risks' "$REVIEW_FILE"; then
     echo "Preflight failed: .codex-review exists but is incomplete"
+    echo "Rerun ./scripts/run-codex-review-checkpoint.sh if you need a fresh template."
     exit 1
   fi
 }

--- a/scripts/run-codex-review-checkpoint.sh
+++ b/scripts/run-codex-review-checkpoint.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+REVIEW_FILE="${OPENPRECEDENT_REVIEW_FILE:-$ROOT_DIR/.codex-review}"
+BASE_REF="${OPENPRECEDENT_REVIEW_BASE_REF:-upstream/main}"
+BRANCH_NAME="$(git branch --show-current)"
+
+build_diff_summary() {
+  local compare_ref="$1"
+
+  if git rev-parse --verify "$compare_ref" >/dev/null 2>&1; then
+    git diff --stat "$compare_ref"...HEAD
+    return 0
+  fi
+
+  if git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
+    git diff --stat HEAD~1...HEAD
+    return 0
+  fi
+
+  echo "No comparison base available."
+}
+
+if [[ ! -f "$REVIEW_FILE" ]]; then
+  diff_summary="$(build_diff_summary "$BASE_REF")"
+  cat >"$REVIEW_FILE" <<EOF
+scope reviewed: branch ${BRANCH_NAME:-detached-head}
+findings: no findings
+remaining risks: native /review has not been run yet
+
+diff summary:
+$diff_summary
+EOF
+  echo "Created review checkpoint template at $REVIEW_FILE"
+else
+  echo "Review checkpoint already exists at $REVIEW_FILE"
+fi
+
+cat <<EOF
+
+Next steps:
+1. In Codex, run the native /review command for the current branch changes.
+2. Update $REVIEW_FILE with the actual review scope, findings, and remaining risks.
+3. Run ./scripts/run-agent-preflight.sh or push again after the review note is complete.
+EOF

--- a/tests/test_codex_review_checkpoint.py
+++ b/tests/test_codex_review_checkpoint.py
@@ -1,0 +1,48 @@
+import os
+import subprocess
+from pathlib import Path
+
+
+def _run_checkpoint(tmp_path: Path, repo_root: Path) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["OPENPRECEDENT_REVIEW_FILE"] = str(tmp_path / ".codex-review")
+    env["OPENPRECEDENT_REVIEW_BASE_REF"] = "HEAD"
+    return subprocess.run(
+        ["./scripts/run-codex-review-checkpoint.sh"],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_review_checkpoint_creates_template(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    review_file = tmp_path / ".codex-review"
+
+    result = _run_checkpoint(tmp_path, repo_root)
+
+    assert result.returncode == 0
+    assert "Created review checkpoint template" in result.stdout
+    content = review_file.read_text()
+    assert "scope reviewed:" in content
+    assert "findings: no findings" in content
+    assert "remaining risks: native /review has not been run yet" in content
+    assert "diff summary:" in content
+
+
+def test_review_checkpoint_preserves_existing_note(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    review_file = tmp_path / ".codex-review"
+    review_file.write_text(
+        "scope reviewed: existing\nfindings: no findings\nremaining risks: low\n"
+    )
+
+    result = _run_checkpoint(tmp_path, repo_root)
+
+    assert result.returncode == 0
+    assert "Review checkpoint already exists" in result.stdout
+    assert review_file.read_text() == (
+        "scope reviewed: existing\nfindings: no findings\nremaining risks: low\n"
+    )


### PR DESCRIPTION
Closes #116

## Summary

- add a local run-codex-review-checkpoint.sh entrypoint that prepares .codex-review and points authors to native Codex /review
- update the existing pre-push and preflight guardrails to direct missing or incomplete review notes through the checkpoint
- document the checkpoint in tooling docs and cover template creation and preservation with tests

## Testing

- .venv/bin/pytest tests/test_codex_review_checkpoint.py tests/test_preflight_script.py
