### PR TITLE
Capture issue-scoped development state for long-running agent work

### DIFF
--- a/.codex/pm/issue-state/106-issue-scoped-development-state.md
+++ b/.codex/pm/issue-state/106-issue-scoped-development-state.md
@@ -1,0 +1,31 @@
+---
+type: issue_state
+issue: 106
+task: .codex/pm/tasks/real-history-quality/issue-scoped-development-state.md
+title: Capture issue-scoped development state for long-running agent work
+status: done
+---
+
+## Summary
+
+Record the current working state for this issue so later sessions do not have to rediscover it.
+
+## Validated Facts
+
+- `codex_pm` now supports issue-scoped state documents under `.codex/pm/issue-state/`.
+- Task metadata can link to a state document through `state_path`.
+- Local preflight can surface missing issue state for in-progress issue branches and optionally enforce it.
+
+## Open Questions
+
+- None for this issue.
+
+## Next Steps
+
+- Use this workflow on future long-running issue branches that need stable local continuity.
+
+## Artifacts
+
+- `src/openprecedent/codex_pm.py`
+- `docs/engineering/tooling-setup.md`
+- `scripts/run-agent-preflight.sh`

--- a/.codex/pm/tasks/real-history-quality/issue-scoped-development-state.md
+++ b/.codex/pm/tasks/real-history-quality/issue-scoped-development-state.md
@@ -1,0 +1,43 @@
+---
+type: task
+epic: real-history-quality
+slug: issue-scoped-development-state
+title: Capture issue-scoped development state for long-running agent work
+status: done
+task_type: implementation
+labels: feature,ops,docs
+issue: 106
+state_path: .codex/pm/issue-state/106-issue-scoped-development-state.md
+---
+
+## Context
+
+Longer issue threads repeatedly lost high-value working memory: what had already been validated, which runtime session proved what, and what remained unresolved.
+The harness needed a lightweight local mechanism that fits existing task twins instead of a separate heavyweight PM system.
+
+## Deliverable
+
+Add an issue-scoped state document workflow to `codex_pm`, connect it to local preflight, and document how authors should use it for in-progress issue branches.
+
+## Scope
+
+- add `issue-state-init`, `issue-state-show`, and `issue-state-check` commands to `openprecedent.codex_pm`
+- store issue state under `.codex/pm/issue-state/` and link it from the matching task metadata
+- have local preflight surface missing state for in-progress issue branches and support an optional enforcement mode
+- document the workflow in engineering tooling docs
+
+## Acceptance Criteria
+
+- an in-progress issue task can initialize a stable local state document
+- the task metadata records the linked state document path
+- local preflight surfaces missing state for in-progress issue branches
+- the workflow stays lightweight enough for routine use
+
+## Validation
+
+- `.venv/bin/pytest tests/test_codex_pm.py`
+
+## Implementation Notes
+
+The default preflight behavior only warns on missing issue state so adoption stays lightweight.
+Teams that want stricter continuity can opt into enforcement with `OPENPRECEDENT_PREFLIGHT_ENFORCE_ISSUE_STATE=1`.

--- a/docs/engineering/tooling-setup.md
+++ b/docs/engineering/tooling-setup.md
@@ -12,6 +12,7 @@ The repository already includes:
 - `scripts/run-agent-preflight.sh` for the standard local pre-push confidence checks
 - `scripts/triage_pr_checks.py` for local CI failure classification against current PR checks
 - `scripts/run-e2e.sh` for the standard local fixture-backed end-to-end runtime validation path
+- `python3 -m openprecedent.codex_pm issue-state-init <task-path>` for preserving issue-scoped working state across longer agent work
 
 To enable the local hook:
 
@@ -56,8 +57,21 @@ For a normal local readiness pass before push, run:
 
 This checks the local review note, blocks reused merged branches, runs `pytest`, runs `markdownlint` when available locally, and performs a local PR closure sync check when a PR body is available through `gh`.
 It also checks that your branch contains the configured base ref, which defaults to `upstream/main`.
+For issue-scoped branches, it also runs a lightweight issue-state check. By default this only warns if an `in_progress` issue is missing a state document.
 
 Set `OPENPRECEDENT_PREFLIGHT_RUN_E2E=1` if you also want the standard E2E path included in the same pass.
+Set `OPENPRECEDENT_PREFLIGHT_ENFORCE_ISSUE_STATE=1` if you want preflight to fail until the issue state document exists.
+
+## Issue-Scoped Development State
+
+For longer-running issues, initialize a local state document from the matching task twin:
+
+```bash
+python3 -m openprecedent.codex_pm issue-state-init .codex/pm/tasks/<epic>/<task>.md
+```
+
+This creates a repository-local issue state document under `.codex/pm/issue-state/` and records its path back into the task metadata.
+Use it to keep validated facts, open questions, next steps, and key artifacts in one stable place as the work evolves across sessions.
 
 For runtime-affecting pull requests, run:
 

--- a/scripts/run-agent-preflight.sh
+++ b/scripts/run-agent-preflight.sh
@@ -19,6 +19,7 @@ RUN_E2E="${OPENPRECEDENT_PREFLIGHT_RUN_E2E:-0}"
 REVIEW_FILE="${OPENPRECEDENT_REVIEW_FILE:-$ROOT_DIR/.codex-review}"
 PYTEST_ARGS="${OPENPRECEDENT_PREFLIGHT_PYTEST_ARGS:-tests --ignore=tests/test_preflight_script.py}"
 BASE_REF="${OPENPRECEDENT_PREFLIGHT_BASE_REF:-upstream/main}"
+ENFORCE_ISSUE_STATE="${OPENPRECEDENT_PREFLIGHT_ENFORCE_ISSUE_STATE:-0}"
 
 check_review_note() {
   if [[ ! -f "$REVIEW_FILE" ]]; then
@@ -123,10 +124,35 @@ run_local_pr_closure_check() {
   PYTHONPATH=src "$PYTHON_BIN" -m openprecedent.codex_pm verify-pr-closure-sync "${body_input[@]}"
 }
 
+check_issue_state() {
+  local output
+  local status
+
+  set +e
+  output="$(
+    PYTHONPATH=src "$PYTHON_BIN" -m openprecedent.codex_pm issue-state-check 2>&1
+  )"
+  status=$?
+  set -e
+  if [[ $status -eq 0 ]]; then
+    echo "$output"
+    return 0
+  fi
+
+  if [[ "$ENFORCE_ISSUE_STATE" == "1" ]]; then
+    echo "$output"
+    exit 1
+  fi
+
+  echo "$output"
+  echo "Continuing without enforced issue-state check. Set OPENPRECEDENT_PREFLIGHT_ENFORCE_ISSUE_STATE=1 to require it."
+}
+
 echo "Running agent preflight in $ROOT_DIR"
 
 check_branch_freshness
 check_review_note
+check_issue_state
 check_merged_branch_reuse
 
 echo "Running pytest"

--- a/src/openprecedent/codex_pm.py
+++ b/src/openprecedent/codex_pm.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 
 PM_ROOT = Path(".codex/pm")
+ISSUE_STATE_ROOT = PM_ROOT / "issue-state"
 VALID_STATUSES = ("backlog", "in_progress", "blocked", "done")
 VALID_TASK_TYPES = ("implementation", "docs", "research", "umbrella")
 CLOSING_ISSUE_PATTERN = re.compile(
@@ -67,6 +68,15 @@ def build_parser() -> argparse.ArgumentParser:
     blocked = subparsers.add_parser("blocked")
     blocked.add_argument("path")
     blocked.add_argument("--reason", required=True)
+
+    issue_state_init = subparsers.add_parser("issue-state-init")
+    issue_state_init.add_argument("path")
+
+    issue_state_show = subparsers.add_parser("issue-state-show")
+    issue_state_show.add_argument("path")
+
+    issue_state_check = subparsers.add_parser("issue-state-check")
+    issue_state_check.add_argument("--branch")
 
     subparsers.add_parser("standup").add_argument("--json", action="store_true", dest="as_json")
 
@@ -203,6 +213,31 @@ def main(argv: list[str] | None = None) -> int:
         _persist_document(document)
         print(document.path)
         return 0
+    if args.action == "issue-state-init":
+        document = _read_document(Path(args.path))
+        state_document = _init_issue_state(document)
+        print(state_document.path)
+        return 0
+    if args.action == "issue-state-show":
+        document = _read_document(Path(args.path))
+        state_document = _load_issue_state(document)
+        if state_document is None:
+            print("No issue state document found for task.", file=sys.stderr)
+            return 1
+        print(state_document.path)
+        print()
+        print(state_document.path.read_text(encoding="utf-8").rstrip())
+        return 0
+    if args.action == "issue-state-check":
+        branch = args.branch or _current_branch()
+        result = _check_issue_state(branch)
+        if result is None:
+            print("Issue state check skipped: current branch is not issue-scoped.")
+            return 0
+        ok, message = result
+        stream = sys.stdout if ok else sys.stderr
+        print(message, file=stream)
+        return 0 if ok else 1
     if args.action == "standup":
         documents = _load_tasks()
         summary = {
@@ -253,7 +288,7 @@ def run() -> None:
 
 
 def _init_pm() -> None:
-    for name in ("prds", "epics", "tasks", "context", "updates"):
+    for name in ("prds", "epics", "tasks", "context", "updates", "issue-state"):
         (PM_ROOT / name).mkdir(parents=True, exist_ok=True)
 
 
@@ -355,9 +390,99 @@ def _doc_to_dict(document: PMDocument) -> dict[str, object]:
         "status": document.metadata.get("status", ""),
         "epic": document.metadata.get("epic", ""),
         "issue": document.metadata.get("issue"),
+        "state_path": document.metadata.get("state_path"),
         "task_type": document.metadata.get("task_type", "implementation"),
         "labels": [item for item in document.metadata.get("labels", "").split(",") if item],
     }
+
+
+def _current_branch() -> str:
+    result = subprocess.run(
+        ["git", "branch", "--show-current"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _parse_issue_from_branch(branch: str) -> int | None:
+    match = re.search(r"\bissue-(\d+)\b", branch)
+    if match is None:
+        return None
+    return int(match.group(1))
+
+
+def _find_task_by_issue(issue: int) -> PMDocument | None:
+    for document in _load_tasks():
+        if _parse_issue_number(document.metadata.get("issue", "")) == issue:
+            return document
+    return None
+
+
+def _issue_state_path(document: PMDocument) -> Path:
+    issue = _parse_issue_number(document.metadata.get("issue", ""))
+    if issue is None:
+        raise ValueError(f"task has no numeric issue reference: {document.path}")
+    slug = document.metadata.get("slug") or document.path.stem
+    return ISSUE_STATE_ROOT / f"{issue}-{slug}.md"
+
+
+def _init_issue_state(document: PMDocument) -> PMDocument:
+    path = _issue_state_path(document)
+    if not path.exists():
+        _write_document(
+            path,
+            metadata={
+                "type": "issue_state",
+                "issue": document.metadata.get("issue", ""),
+                "task": str(document.path),
+                "title": document.metadata.get("title", ""),
+                "status": document.metadata.get("status", ""),
+            },
+            sections={
+                "Summary": "Record the current working state for this issue so later sessions do not have to rediscover it.",
+                "Validated Facts": "- ",
+                "Open Questions": "- ",
+                "Next Steps": "- ",
+                "Artifacts": "- ",
+            },
+        )
+    document.metadata["state_path"] = str(path)
+    _persist_document(document)
+    return _read_document(path)
+
+
+def _load_issue_state(document: PMDocument) -> PMDocument | None:
+    state_path_value = document.metadata.get("state_path")
+    candidate_paths: list[Path] = []
+    if state_path_value:
+        candidate_paths.append(Path(state_path_value))
+    if document.metadata.get("issue", "").isdigit():
+        candidate_paths.append(_issue_state_path(document))
+    for path in candidate_paths:
+        if path.exists():
+            return _read_document(path)
+    return None
+
+
+def _check_issue_state(branch: str) -> tuple[bool, str] | None:
+    issue = _parse_issue_from_branch(branch)
+    if issue is None:
+        return None
+    task = _find_task_by_issue(issue)
+    if task is None:
+        return False, f"Issue state check failed: no task twin found for issue #{issue}."
+    if task.metadata.get("status") != "in_progress":
+        return True, f"Issue state check skipped: task for issue #{issue} is not in progress."
+    state_document = _load_issue_state(task)
+    if state_document is None:
+        return (
+            False,
+            "Issue state check failed: in-progress issue has no state document. "
+            f"Run `python3 -m openprecedent.codex_pm issue-state-init {task.path}`.",
+        )
+    return True, f"Issue state check passed: {state_document.path}"
 
 
 def _print_tasks(documents: list[PMDocument], as_json: bool) -> int:

--- a/tests/test_codex_pm.py
+++ b/tests/test_codex_pm.py
@@ -17,6 +17,7 @@ def test_codex_pm_init_creates_workspace(tmp_path: Path, monkeypatch) -> None:
     assert (tmp_path / ".codex" / "pm" / "prds").exists()
     assert (tmp_path / ".codex" / "pm" / "epics").exists()
     assert (tmp_path / ".codex" / "pm" / "tasks").exists()
+    assert (tmp_path / ".codex" / "pm" / "issue-state").exists()
 
 
 def test_codex_pm_module_invocation_runs_cli(tmp_path: Path) -> None:
@@ -484,3 +485,106 @@ def test_codex_pm_pr_body_omits_closing_clause_for_umbrella_task(tmp_path: Path,
     pr_body = capsys.readouterr().out
 
     assert "Closes #100" not in pr_body
+
+
+def test_codex_pm_issue_state_init_creates_state_doc_and_updates_task(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    assert main(["init"]) == 0
+    capsys.readouterr()
+    assert (
+        main(
+            [
+                "task-new",
+                "real-history-quality",
+                "issue-scoped-dev-state",
+                "--title",
+                "Capture issue-scoped development state",
+                "--issue",
+                "106",
+                "--status",
+                "in_progress",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    task_path = tmp_path / ".codex" / "pm" / "tasks" / "real-history-quality" / "issue-scoped-dev-state.md"
+    assert main(["issue-state-init", str(task_path)]) == 0
+    state_path = (tmp_path / capsys.readouterr().out.strip()).resolve()
+
+    assert state_path == (tmp_path / ".codex" / "pm" / "issue-state" / "106-issue-scoped-dev-state.md").resolve()
+    assert state_path.exists()
+    task_document = task_path.read_text(encoding="utf-8")
+    assert "state_path: .codex/pm/issue-state/106-issue-scoped-dev-state.md" in task_document
+
+
+def test_codex_pm_issue_state_check_fails_for_in_progress_issue_without_state(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    assert main(["init"]) == 0
+    capsys.readouterr()
+    assert (
+        main(
+            [
+                "task-new",
+                "real-history-quality",
+                "issue-scoped-dev-state",
+                "--title",
+                "Capture issue-scoped development state",
+                "--issue",
+                "106",
+                "--status",
+                "in_progress",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    assert main(["issue-state-check", "--branch", "codex/issue-106-issue-scoped-dev-state"]) == 1
+    assert "in-progress issue has no state document" in capsys.readouterr().err
+
+
+def test_codex_pm_issue_state_check_passes_after_state_init(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    assert main(["init"]) == 0
+    capsys.readouterr()
+    assert (
+        main(
+            [
+                "task-new",
+                "real-history-quality",
+                "issue-scoped-dev-state",
+                "--title",
+                "Capture issue-scoped development state",
+                "--issue",
+                "106",
+                "--status",
+                "in_progress",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    task_path = tmp_path / ".codex" / "pm" / "tasks" / "real-history-quality" / "issue-scoped-dev-state.md"
+    assert main(["issue-state-init", str(task_path)]) == 0
+    capsys.readouterr()
+
+    assert main(["issue-state-check", "--branch", "codex/issue-106-issue-scoped-dev-state"]) == 0
+    assert "Issue state check passed" in capsys.readouterr().out


### PR DESCRIPTION
Closes #106

## Summary

- add issue-scoped development state support to codex_pm with init, show, and branch-aware check commands
- store state documents under .codex/pm/issue-state and link them from matching task metadata
- surface missing state during local preflight with an optional enforcement mode and document the workflow

## Testing

- PYTHONPATH=src .venv/bin/pytest tests/test_codex_pm.py tests/test_preflight_script.py
