### PR TITLE
Add a research-harness skill and experiment templates for hypothesis-driven work

### DIFF
--- a/.codex/pm/tasks/real-history-quality/research-harness-skill.md
+++ b/.codex/pm/tasks/real-history-quality/research-harness-skill.md
@@ -1,0 +1,41 @@
+---
+type: task
+epic: real-history-quality
+slug: research-harness-skill
+title: Add a research-harness skill and experiment templates for hypothesis-driven work
+status: done
+task_type: implementation
+labels: feature,docs
+issue: 105
+---
+
+## Context
+
+OpenPrecedent is now in a post-MVP research validation phase, but the repository-local workflow still mostly looks like implementation tracking.
+That makes research issues too easy to frame loosely and too hard to compare across repeated product-learning loops.
+
+## Deliverable
+
+Add a project-local research harness skill and lightweight experiment templates that fit the current issue-task-PR workflow.
+
+## Scope
+
+- add a local `research-harness` skill under `.codex/skills/`
+- include templates for research issue framing, experiment planning, and result capture
+- point the skill at the existing PM and issue-state mechanisms instead of inventing a separate system
+- document the skill as part of the repository's current research validation phase
+
+## Acceptance Criteria
+
+- research issues can be framed with explicit hypothesis, method, artifact, and interpretation structure
+- the skill remains compatible with the current issue-task-PR process
+- later sessions can reuse the templates instead of reconstructing research workflow from memory
+
+## Validation
+
+- `.venv/bin/pytest tests/test_cli.py -k 'research_harness_skill_exists or mvp_status_mentions_research_harness_skill'`
+
+## Implementation Notes
+
+This skill is intentionally lightweight.
+It improves the structure of research-shaped work without turning the repository into a separate experiment-management platform.

--- a/.codex/skills/research-harness/SKILL.md
+++ b/.codex/skills/research-harness/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: research-harness
+description: Use for post-MVP hypothesis-driven work in OpenPrecedent. Provides a lightweight workflow for framing research issues, experiments, evidence, and success or failure interpretation without leaving the existing issue-task-PR process.
+---
+
+# Research Harness
+
+Use this skill when the task is primarily about product learning rather than core-loop plumbing.
+
+Typical triggers:
+
+- retrieval quality evaluation
+- runtime impact validation
+- extraction quality analysis
+- experiment design
+- evidence capture for post-MVP product hypotheses
+
+Do not use this skill for straightforward implementation-only tasks unless the user explicitly wants a hypothesis-driven framing.
+
+## Goal
+
+Keep research work structured enough that later sessions can answer:
+
+- what hypothesis was being tested
+- how it was tested
+- what artifact should count as evidence
+- how success, failure, or ambiguity should be interpreted
+
+The skill should strengthen the existing issue-task-PR workflow rather than creating a parallel planning system.
+
+Parent framework: #100
+
+## Workflow
+
+1. Anchor the work in the current research phase.
+   - Treat GitHub issue `#100` as the long-lived umbrella for post-MVP research evolution.
+   - Use a child issue for the concrete question under test.
+
+2. Create or update the local task twin as `task_type: research`.
+   - Reuse `.codex/skills/ccpm-codex/` for issue/task/PR mechanics.
+   - Prefer one issue per hypothesis, not one issue per broad theme.
+
+3. Initialize issue-scoped state if the work will span multiple sessions.
+   - Run:
+   - `python3 -m openprecedent.codex_pm issue-state-init <task-path>`
+
+4. Copy the research experiment template into the issue state or the task notes.
+   - Use `templates/research-experiment-template.md` for the main structure.
+   - Use `templates/research-issue-template.md` when drafting a new issue body.
+   - Use `templates/research-result-template.md` when recording outcomes.
+
+5. Make the hypothesis explicit before implementation.
+   - State one research question.
+   - State one method.
+   - State the expected artifact.
+   - State how success, failure, and ambiguity will be interpreted.
+
+6. Prefer narrow evidence-producing work over broad speculative refactors.
+   - Good outputs:
+   - validation docs
+   - fixture or eval additions
+   - quality reports
+   - observability improvements
+   - narrow policy or algorithm changes justified by evidence
+
+7. Close only the concrete child issue.
+   - Do not close umbrella issue `#100`.
+   - Keep parent framing in docs and issue links, not in PR closing clauses.
+
+## Recommended Structure
+
+For a research issue, aim to fill these fields:
+
+- hypothesis
+- method
+- expected artifact
+- success signal
+- failure signal
+- ambiguity signal
+
+For a research result, always record:
+
+- what was run
+- what was observed
+- what changed in confidence
+- what follow-up issue, if any, should come next
+
+## Read Next
+
+- `templates/research-experiment-template.md`
+- `templates/research-issue-template.md`
+- `templates/research-result-template.md`
+- [`docs/product/mvp-status.md`](/workspace/02-projects/incubation/openprecedent/docs/product/mvp-status.md)
+- [`docs/engineering/harness-capability-analysis.md`](/workspace/02-projects/incubation/openprecedent/docs/engineering/harness-capability-analysis.md)

--- a/.codex/skills/research-harness/templates/research-experiment-template.md
+++ b/.codex/skills/research-harness/templates/research-experiment-template.md
@@ -1,0 +1,33 @@
+# Research Experiment Template
+
+## Hypothesis
+
+State the smallest product or quality claim being tested.
+
+## Why It Matters
+
+Explain why the result would change product direction, prioritization, or confidence.
+
+## Method
+
+Describe the exact validation method.
+
+## Expected Artifact
+
+State what concrete output should exist after the experiment.
+
+## Success Interpretation
+
+State what result would count as support for the hypothesis.
+
+## Failure Interpretation
+
+State what result would count as evidence against the hypothesis.
+
+## Ambiguity Interpretation
+
+State what result would remain inconclusive and what extra evidence would then be needed.
+
+## Notes
+
+Record constraints, assumptions, or execution details that matter for later comparison.

--- a/.codex/skills/research-harness/templates/research-issue-template.md
+++ b/.codex/skills/research-harness/templates/research-issue-template.md
@@ -1,0 +1,38 @@
+## Summary
+
+State the research question in one sentence.
+
+Parent framework: #100
+
+## Hypothesis
+
+State the claim under test.
+
+## Why
+
+Explain why this question matters now.
+
+## Method
+
+Describe the intended experiment, benchmark, comparison, or validation flow.
+
+## Expected Artifact
+
+State what evidence or output the issue should produce.
+
+## Success / Failure Interpretation
+
+- success means:
+- failure means:
+- ambiguous means:
+
+## Scope
+
+- keep this issue focused on one hypothesis-driven question
+- prefer evidence-producing work over broad refactors
+
+## Acceptance Criteria
+
+- the issue produces the expected artifact
+- the outcome changes confidence in the stated hypothesis
+- the result is recorded in a durable local or in-repo form

--- a/.codex/skills/research-harness/templates/research-result-template.md
+++ b/.codex/skills/research-harness/templates/research-result-template.md
@@ -1,0 +1,25 @@
+# Research Result Template
+
+## Question
+
+Restate the question that was tested.
+
+## What Was Run
+
+Describe the actual experiment or validation steps that were executed.
+
+## Observed Result
+
+Record the key observed facts.
+
+## Interpretation
+
+Explain whether the result supports, weakens, or leaves open the hypothesis.
+
+## Confidence Change
+
+State what changed in product or technical confidence because of this result.
+
+## Follow-Up
+
+State the next most justified issue, if any.

--- a/docs/product/mvp-status.md
+++ b/docs/product/mvp-status.md
@@ -27,6 +27,10 @@ The long-lived umbrella for this phase is GitHub issue `#100`, `Define the post-
 That issue should remain open as the parent framing artifact for later hypothesis-driven child issues.
 Repository docs should point to it, but should not duplicate the full research program each time.
 
+For repository-local execution of those child issues, use the project skill:
+
+- [.codex/skills/research-harness/SKILL.md](/workspace/02-projects/incubation/openprecedent/.codex/skills/research-harness/SKILL.md)
+
 ## Completed Core Loop
 
 The shipped MVP now covers:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -932,6 +932,35 @@ def test_openclaw_skill_bundle_exists() -> None:
     assert "keep it consistent with earlier repository decisions if relevant" in content
 
 
+def test_research_harness_skill_exists() -> None:
+    skill_path = (
+        Path(__file__).parent.parent
+        / ".codex"
+        / "skills"
+        / "research-harness"
+        / "SKILL.md"
+    )
+    template_root = skill_path.parent / "templates"
+
+    content = skill_path.read_text(encoding="utf-8")
+
+    assert content.startswith("---\n")
+    assert "name: research-harness" in content
+    assert "Parent framework: #100" in content
+    assert "issue-state-init" in content
+    assert (template_root / "research-experiment-template.md").exists()
+    assert (template_root / "research-issue-template.md").exists()
+    assert (template_root / "research-result-template.md").exists()
+
+
+def test_mvp_status_mentions_research_harness_skill() -> None:
+    path = Path(__file__).parent.parent / "docs" / "product" / "mvp-status.md"
+
+    content = path.read_text(encoding="utf-8")
+
+    assert ".codex/skills/research-harness/SKILL.md" in content
+
+
 def test_openclaw_runtime_trigger_rerun_doc_exists() -> None:
     path = (
         Path(__file__).parent.parent


### PR DESCRIPTION
Closes #105

## Summary

- add a project-local research-harness skill for post-MVP hypothesis-driven work
- include lightweight templates for research issue framing, experiment planning, and result capture
- point the research workflow at the existing issue-task-PR and issue-state mechanisms and link it from the MVP status note

## Testing

- PYTHONPATH=src .venv/bin/pytest tests/test_cli.py -k "research_harness_skill_exists or mvp_status_mentions_research_harness_skill"
