### PR TITLE
Create an OpenClaw live validation skill for runtime integration tasks

### DIFF
--- a/.codex/pm/tasks/real-history-quality/openclaw-live-validation-skill.md
+++ b/.codex/pm/tasks/real-history-quality/openclaw-live-validation-skill.md
@@ -1,0 +1,41 @@
+---
+type: task
+epic: real-history-quality
+slug: openclaw-live-validation-skill
+title: Create an OpenClaw live validation skill for runtime integration tasks
+status: done
+task_type: implementation
+labels: feature,docs
+issue: 120
+---
+
+## Context
+
+The repository already has a live OpenClaw validation harness script, but Codex still needed an explicit workflow-level reminder about when to run it and how to interpret the result.
+That made runtime smoke validation too dependent on manual prompting.
+
+## Deliverable
+
+Add a project-local `openclaw-live-validation` skill that orchestrates when and how to use the live validation harness for runtime integration work.
+
+## Scope
+
+- add a local `openclaw-live-validation` skill under `.codex/skills/`
+- encode trigger conditions for runtime integration, trigger-policy, and shared-runtime-path changes
+- point the skill at `scripts/run-openclaw-live-validation.sh` and current runtime validation docs
+- require stable outcome capture in issue state or validation notes
+
+## Acceptance Criteria
+
+- runtime integration tasks have a clear skill-based trigger for real OpenClaw smoke validation
+- the skill reuses the existing live validation harness instead of duplicating it
+- expected runtime outcome classes are explicit enough to guide follow-up work
+
+## Validation
+
+- `.venv/bin/pytest tests/test_cli.py -k 'openclaw_live_validation_skill_exists or tooling_setup_mentions_live_validation_skill'`
+
+## Implementation Notes
+
+This skill intentionally orchestrates the existing harness and documentation chain.
+It should make the agent more likely to run live smoke validation at the right moment, not introduce a second validation system.

--- a/.codex/skills/openclaw-live-validation/SKILL.md
+++ b/.codex/skills/openclaw-live-validation/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: openclaw-live-validation
+description: Use for OpenClaw runtime integration work that should be verified through the real live loop. Tells Codex when to run the live validation harness, how to seed shared history, and how to record outcomes in stable local artifacts.
+---
+
+# OpenClaw Live Validation
+
+Use this skill when a change affects the real OpenClaw runtime path rather than only repository-local fixture flows.
+
+Typical triggers:
+
+- changes to `skills/openprecedent-decision-lineage/`
+- changes to `scripts/run-openclaw-live-validation.sh`
+- changes to shared runtime path wiring
+- changes to trigger-policy wording or runtime invocation behavior
+- changes to live validation docs that should be verified against reality
+
+Do not use this skill for pure docs-only updates that do not claim a runtime behavior change.
+
+## Goal
+
+Make sure runtime integration work gets a real OpenClaw smoke validation at the right time instead of relying only on local tests or human memory.
+
+This skill should reuse the existing harness entrypoint, not replace it.
+
+## Workflow
+
+1. Confirm that the issue actually touches the live runtime path.
+   - If the change is only fixture-backed, use repository-local validation instead.
+   - If the change affects runtime integration, continue with this skill.
+
+2. Initialize issue-scoped state if the issue may span multiple sessions.
+   - Run:
+   - `python3 -m openprecedent.codex_pm issue-state-init <task-path>`
+
+3. Prepare the live validation workspace.
+   - Run:
+   - `./scripts/run-openclaw-live-validation.sh`
+   - If prior shared history is needed, pass:
+   - `OPENPRECEDENT_LIVE_SEED_SESSION_FILE=...`
+   - `OPENPRECEDENT_LIVE_SEED_SESSION_ID=...`
+   - `OPENPRECEDENT_LIVE_SEED_CASE_ID=...`
+
+4. Start the isolated OpenClaw gateway with the generated launcher.
+   - Use the launcher written by the harness:
+   - `/tmp/openprecedent-openclaw-live/launch-openclaw-gateway.sh`
+
+5. Run one or two minimal smoke prompts.
+   - Prefer one implicit prior-decision prompt if trigger behavior matters.
+   - Prefer one explicit lineage prompt if runtime retrieval must be proven.
+
+6. Re-run the live harness after the turn.
+   - Refresh:
+   - `output/03-invocation-summary.json`
+   - Inspect:
+   - `output/manifest.json`
+   - `output/00-profile-workspace.txt` when skill-bundle sync matters
+
+7. Record the result in a stable local place.
+   - Update issue state or a validation doc with:
+   - what prompt was used
+   - whether the skill triggered
+   - whether the invocation hit the intended shared runtime home
+   - whether a matched case was returned
+
+## Expected Outcomes
+
+The live smoke result should usually be classified as one of:
+
+- not triggered
+- triggered but wrote to the wrong runtime path
+- triggered with empty brief
+- triggered with non-empty brief
+
+That classification should be recorded explicitly so follow-up work can target the right gap.
+
+## Read Next
+
+- [`docs/engineering/openclaw-live-validation-harness.md`](/workspace/02-projects/incubation/openprecedent/docs/engineering/openclaw-live-validation-harness.md)
+- [`docs/engineering/openclaw-runtime-decision-lineage-trigger-rerun.md`](/workspace/02-projects/incubation/openprecedent/docs/engineering/openclaw-runtime-decision-lineage-trigger-rerun.md)
+- [`docs/engineering/openclaw-real-runtime-decision-lineage-validation.md`](/workspace/02-projects/incubation/openprecedent/docs/engineering/openclaw-real-runtime-decision-lineage-validation.md)

--- a/docs/engineering/tooling-setup.md
+++ b/docs/engineering/tooling-setup.md
@@ -100,6 +100,10 @@ For runtime integration work that must exercise the real OpenClaw loop rather th
 The harness prepares a stable local workspace, shared `OPENPRECEDENT_HOME`, prompt file, gateway launcher, and structured artifact directory under `/tmp/openprecedent-openclaw-live` by default.
 It also synchronizes the installed OpenClaw skill bundle in the target profile workspace so the skill points at that same shared runtime home instead of falling back to a different default path.
 
+For issue-driven runtime integration work, pair that script with the local workflow skill:
+
+- [.codex/skills/openclaw-live-validation/SKILL.md](/workspace/02-projects/incubation/openprecedent/.codex/skills/openclaw-live-validation/SKILL.md)
+
 To seed shared prior history before a live run, point it at an existing OpenClaw session transcript:
 
 ```bash

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -961,6 +961,32 @@ def test_mvp_status_mentions_research_harness_skill() -> None:
     assert ".codex/skills/research-harness/SKILL.md" in content
 
 
+def test_openclaw_live_validation_skill_exists() -> None:
+    skill_path = (
+        Path(__file__).parent.parent
+        / ".codex"
+        / "skills"
+        / "openclaw-live-validation"
+        / "SKILL.md"
+    )
+
+    content = skill_path.read_text(encoding="utf-8")
+
+    assert content.startswith("---\n")
+    assert "name: openclaw-live-validation" in content
+    assert "./scripts/run-openclaw-live-validation.sh" in content
+    assert "not triggered" in content
+    assert "triggered with non-empty brief" in content
+
+
+def test_tooling_setup_mentions_live_validation_skill() -> None:
+    path = Path(__file__).parent.parent / "docs" / "engineering" / "tooling-setup.md"
+
+    content = path.read_text(encoding="utf-8")
+
+    assert ".codex/skills/openclaw-live-validation/SKILL.md" in content
+
+
 def test_openclaw_runtime_trigger_rerun_doc_exists() -> None:
     path = (
         Path(__file__).parent.parent


### PR DESCRIPTION
Closes #120

## Summary

- add a project-local openclaw-live-validation skill for runtime integration tasks that need real OpenClaw smoke validation
- encode trigger conditions, harness usage, and expected outcome classes without duplicating the existing live validation script
- link the skill from tooling setup and cover its presence with lightweight tests

## Testing

- PYTHONPATH=src .venv/bin/pytest tests/test_cli.py -k "openclaw_live_validation_skill_exists or tooling_setup_mentions_live_validation_skill"
