### PR TITLE
Document the current OpenPrecedent harness and how to reuse it in other repositories

### DIFF
--- a/.codex/pm/tasks/real-history-quality/document-harness-reuse-guide.md
+++ b/.codex/pm/tasks/real-history-quality/document-harness-reuse-guide.md
@@ -1,0 +1,40 @@
+---
+type: task
+epic: real-history-quality
+slug: document-harness-reuse-guide
+title: Document the current OpenPrecedent harness and how to reuse it in other repositories
+status: done
+task_type: docs
+labels: docs,ops
+issue: 123
+---
+
+## Context
+
+OpenPrecedent now has a meaningful harness across PM workflow, local guardrails, preflight, repository-local validation, live runtime validation, and research support.
+That capability is distributed across many files, which makes reuse too dependent on repository memory.
+
+## Deliverable
+
+Add one engineering document that inventories the current harness and explains how to reuse or transplant it into another existing repository or a new repository.
+
+## Scope
+
+- summarize the current harness by capability layer
+- distinguish OpenPrecedent-specific parts from broadly reusable patterns
+- document export paths for existing repositories and new repositories
+- keep the output in `docs/engineering/`
+
+## Acceptance Criteria
+
+- one engineering doc can serve as the current harness inventory
+- the doc explains how to export the harness to another repository with reasonable effort
+- reusable patterns are separated from product-specific logic
+
+## Validation
+
+- `.venv/bin/pytest tests/test_cli.py -k 'harness_reuse_guide_exists'`
+
+## Implementation Notes
+
+This document should complement the existing harness analysis rather than duplicate its MVP retrospective framing.

--- a/docs/engineering/harness-capability-analysis.md
+++ b/docs/engineering/harness-capability-analysis.md
@@ -4,6 +4,10 @@
 
 Record a repository-grounded analysis of the current OpenPrecedent development harness so future harness work can build from actual MVP development experience rather than memory or generic agent-tooling advice.
 
+For the current harness inventory and reuse/export path, see:
+
+- [harness-reuse-guide.md](/workspace/02-projects/incubation/openprecedent/docs/engineering/harness-reuse-guide.md)
+
 This document focuses on one question:
 
 - what kind of harness does OpenPrecedent already have

--- a/docs/engineering/harness-reuse-guide.md
+++ b/docs/engineering/harness-reuse-guide.md
@@ -1,0 +1,267 @@
+# Harness Reuse Guide
+
+## Goal
+
+Summarize the full current OpenPrecedent harness and explain how to reuse or transplant that harness into another existing repository or a brand new repository.
+
+This document is about harness capability inventory and reuse strategy.
+It is not a product architecture document.
+
+## Current Harness Inventory
+
+OpenPrecedent now has a repository-local harness with six main layers.
+
+### 1. Workflow and PM layer
+
+This layer keeps agent work issue-scoped and reviewable.
+
+Main components:
+
+- [AGENTS.md](/workspace/02-projects/incubation/openprecedent/AGENTS.md)
+- [.codex/skills/ccpm-codex/SKILL.md](/workspace/02-projects/incubation/openprecedent/.codex/skills/ccpm-codex/SKILL.md)
+- [codex_pm.py](/workspace/02-projects/incubation/openprecedent/src/openprecedent/codex_pm.py)
+- `.codex/pm/tasks/`
+- `.codex/pm/issue-state/`
+
+Key capabilities:
+
+- one issue per branch
+- one issue per PR
+- local task twins for GitHub issues
+- issue-scoped development state
+- explicit task types such as `implementation`, `docs`, `research`, and `umbrella`
+- PR-body and task-closure sync checks
+
+### 2. Local guardrail layer
+
+This layer catches predictable local workflow drift before code is pushed.
+
+Main components:
+
+- [.githooks/pre-push](/workspace/02-projects/incubation/openprecedent/.githooks/pre-push)
+- [install-hooks.sh](/workspace/02-projects/incubation/openprecedent/scripts/install-hooks.sh)
+- [run-codex-review-checkpoint.sh](/workspace/02-projects/incubation/openprecedent/scripts/run-codex-review-checkpoint.sh)
+- [check_branch_freshness.py](/workspace/02-projects/incubation/openprecedent/scripts/check_branch_freshness.py)
+
+Key capabilities:
+
+- require `.codex-review`
+- block pushing to branches whose PRs already merged
+- block stale branches that are behind `upstream/main`
+- provide a fixed local checkpoint for native Codex `/review`
+
+### 3. Local preflight and CI support layer
+
+This layer helps catch common failures before or after opening a PR.
+
+Main components:
+
+- [run-agent-preflight.sh](/workspace/02-projects/incubation/openprecedent/scripts/run-agent-preflight.sh)
+- [triage_pr_checks.py](/workspace/02-projects/incubation/openprecedent/scripts/triage_pr_checks.py)
+- [pr-review-gate.yml](/workspace/02-projects/incubation/openprecedent/.github/workflows/pr-review-gate.yml)
+- [python-ci.yml](/workspace/02-projects/incubation/openprecedent/.github/workflows/python-ci.yml)
+- [markdownlint.yml](/workspace/02-projects/incubation/openprecedent/.github/workflows/markdownlint.yml)
+
+Key capabilities:
+
+- one local preflight entrypoint
+- optional Markdown lint and E2E inclusion
+- local branch freshness and issue-state checks
+- local PR closure sync verification
+- fast CI failure classification
+
+### 4. Repository-local validation layer
+
+This layer validates the product loop without requiring a separate live runtime host.
+
+Main components:
+
+- [run-e2e.sh](/workspace/02-projects/incubation/openprecedent/scripts/run-e2e.sh)
+- [merge-validation.md](/workspace/02-projects/incubation/openprecedent/docs/engineering/merge-validation.md)
+- [openclaw-full-user-journey-validation.md](/workspace/02-projects/incubation/openprecedent/docs/engineering/openclaw-full-user-journey-validation.md)
+
+Key capabilities:
+
+- standard end-to-end validation command
+- fixture-backed OpenClaw journey replay
+- repeatable merge-time validation baseline
+
+### 5. Live runtime validation layer
+
+This layer handles the real OpenClaw integration path.
+
+Main components:
+
+- [run-openclaw-live-validation.sh](/workspace/02-projects/incubation/openprecedent/scripts/run-openclaw-live-validation.sh)
+- [.codex/skills/openclaw-live-validation/SKILL.md](/workspace/02-projects/incubation/openprecedent/.codex/skills/openclaw-live-validation/SKILL.md)
+- [openclaw-live-validation-harness.md](/workspace/02-projects/incubation/openprecedent/docs/engineering/openclaw-live-validation-harness.md)
+
+Key capabilities:
+
+- prepare a shared runtime home for live validation
+- optionally seed prior history
+- sync the installed skill bundle into the target profile workspace
+- generate prompt, launcher, and structured output artifacts
+- tell the agent when a real smoke validation is warranted
+
+### 6. Research workflow layer
+
+This layer supports post-MVP hypothesis-driven work.
+
+Main components:
+
+- [.codex/skills/research-harness/SKILL.md](/workspace/02-projects/incubation/openprecedent/.codex/skills/research-harness/SKILL.md)
+- research templates under `.codex/skills/research-harness/templates/`
+- [mvp-status.md](/workspace/02-projects/incubation/openprecedent/docs/product/mvp-status.md)
+- umbrella issue `#100`
+
+Key capabilities:
+
+- explicit hypothesis, method, artifact, and interpretation framing
+- lightweight experiment templates
+- compatibility with the existing issue-task-PR workflow
+
+## What Is OpenPrecedent-Specific
+
+These parts are tied to this product and should usually not be copied as-is:
+
+- OpenClaw-specific runtime validation docs
+- decision-lineage skill content
+- OpenPrecedent CLI assumptions
+- product-specific issue epics and task names
+- precedent or decision-domain language
+
+When reusing the harness elsewhere, treat these as examples rather than common infrastructure.
+
+## What Is Broadly Reusable
+
+These parts are good candidates for reuse in other repositories:
+
+- issue-task-PR local twin workflow
+- task types and closure sync checks
+- issue-scoped development state
+- `.codex-review` checkpoint pattern
+- stale-branch and merged-branch guardrails
+- unified local preflight
+- CI failure triage helper
+- research-harness templates
+- live-validation skill pattern
+
+These patterns are useful even if the target repository has a different product domain.
+
+## Export Strategy
+
+There are two practical export paths.
+
+### 1. Export into an existing repository
+
+Use this path when the target repo already has its own CI, docs, and contribution model.
+
+Recommended order:
+
+1. copy the minimal workflow layer
+2. copy the local guardrails
+3. adapt preflight and CI checks
+4. add issue-state support
+5. add research or live-validation layers only if the product needs them
+
+Minimal reusable set:
+
+- `AGENTS.md` conventions adapted to the target repo
+- `.codex/skills/ccpm-codex/` or an equivalent local PM skill
+- `src/.../codex_pm.py` equivalent
+- `.githooks/pre-push`
+- `scripts/install-hooks.sh`
+- `scripts/run-agent-preflight.sh`
+- task twin directory layout under `.codex/pm/`
+
+Adaptation work:
+
+- replace product-specific file paths
+- replace target branch defaults if the repo does not use `upstream/main`
+- replace CI workflow names in triage logic
+- align test commands with the target repository
+
+### 2. Export into a brand new repository
+
+Use this path when creating a new agent product repo from scratch.
+
+Recommended bootstrap order:
+
+1. add `AGENTS.md`
+2. add local PM workspace and `codex_pm`-style tooling
+3. add hook installation and pre-push guardrails
+4. add unified preflight
+5. add one standard E2E or smoke validation entrypoint
+6. add research or live-validation skills if the product is expected to need them
+
+For a new repository, it is usually best to start with the reusable harness core and only later add runtime-specific skills.
+
+## Suggested Reuse Profiles
+
+### Profile A: Delivery-only harness
+
+Use when the target repo mainly needs disciplined implementation work.
+
+Include:
+
+- workflow and PM layer
+- local guardrail layer
+- preflight and CI support layer
+
+Skip initially:
+
+- live runtime validation layer
+- research workflow layer
+
+### Profile B: Agent product harness
+
+Use when the target repo has a real runtime integration path similar to OpenPrecedent.
+
+Include:
+
+- workflow and PM layer
+- local guardrail layer
+- preflight and CI support layer
+- repository-local validation layer
+- live runtime validation layer
+
+### Profile C: Research validation harness
+
+Use when the target repo is past MVP plumbing and needs repeated hypothesis loops.
+
+Include:
+
+- workflow and PM layer
+- issue-state support
+- research workflow layer
+- whichever validation layer best matches the product
+
+## Practical Porting Checklist
+
+When moving the harness to another repo, confirm:
+
+- branch naming and default base ref are correct
+- CI workflow names used by triage still match
+- hook messages and docs fit the new repo's terminology
+- preflight test commands match the new repo
+- task twin metadata fields match the new workflow
+- any runtime smoke validation script points at the new product's actual runtime path
+
+## Recommended Packaging Approach
+
+Do not try to transplant everything at once.
+
+The best practical sequence is:
+
+1. start with workflow, hook, and preflight core
+2. use that core in one real repo for a few tasks
+3. only then add runtime-specific or research-specific layers
+
+This keeps the exported harness small enough to adopt and prevents the target repo from inheriting OpenPrecedent-specific complexity it does not actually need.
+
+## Related Docs
+
+- [Harness capability analysis](/workspace/02-projects/incubation/openprecedent/docs/engineering/harness-capability-analysis.md)
+- [Tooling setup](/workspace/02-projects/incubation/openprecedent/docs/engineering/tooling-setup.md)
+- [Repository governance](/workspace/02-projects/incubation/openprecedent/docs/engineering/repository-governance.md)

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -6,6 +6,7 @@
 
 - `product/`: 产品战略与 MVP 需求
 - `architecture/`: MVP 设计文档
+- `engineering/`: 工程流程、验证与 harness 复用文档
 - `research/`: 竞品与赛道研究
 
 说明：

--- a/docs/zh/engineering/harness-reuse-guide.md
+++ b/docs/zh/engineering/harness-reuse-guide.md
@@ -1,0 +1,267 @@
+# Harness 复用指南
+
+## 目标
+
+总结 OpenPrecedent 当前已经具备的 harness 能力，并说明如何把这套 harness 迁移到另一个已有仓库，或者一个全新的仓库里。
+
+这份文档关注的是工程 harness 能力和复用方式。
+它不是产品架构文档。
+
+## 当前 Harness 能力总览
+
+OpenPrecedent 当前的 harness 可以分成六层。
+
+### 1. 工作流与 PM 层
+
+这一层负责把 agent 的开发工作约束到 issue 作用域内。
+
+主要组成：
+
+- [AGENTS.md](/workspace/02-projects/incubation/openprecedent/AGENTS.md)
+- [.codex/skills/ccpm-codex/SKILL.md](/workspace/02-projects/incubation/openprecedent/.codex/skills/ccpm-codex/SKILL.md)
+- [codex_pm.py](/workspace/02-projects/incubation/openprecedent/src/openprecedent/codex_pm.py)
+- `.codex/pm/tasks/`
+- `.codex/pm/issue-state/`
+
+关键能力：
+
+- 一 issue 一分支
+- 一 issue 一 PR
+- 本地 task twin
+- issue-scoped development state
+- `implementation`、`docs`、`research`、`umbrella` 等 task type
+- PR 与 task 状态闭环校验
+
+### 2. 本地护栏层
+
+这一层负责在 push 前拦住高频流程错误。
+
+主要组成：
+
+- [.githooks/pre-push](/workspace/02-projects/incubation/openprecedent/.githooks/pre-push)
+- [install-hooks.sh](/workspace/02-projects/incubation/openprecedent/scripts/install-hooks.sh)
+- [run-codex-review-checkpoint.sh](/workspace/02-projects/incubation/openprecedent/scripts/run-codex-review-checkpoint.sh)
+- [check_branch_freshness.py](/workspace/02-projects/incubation/openprecedent/scripts/check_branch_freshness.py)
+
+关键能力：
+
+- 强制 `.codex-review`
+- 阻止向已合并 PR 的旧分支继续 push
+- 阻止落后于 `upstream/main` 的 stale branch
+- 为原生 Codex `/review` 提供固定触发点
+
+### 3. Preflight 与 CI 支撑层
+
+这一层负责在本地和 PR 阶段提前发现常见问题。
+
+主要组成：
+
+- [run-agent-preflight.sh](/workspace/02-projects/incubation/openprecedent/scripts/run-agent-preflight.sh)
+- [triage_pr_checks.py](/workspace/02-projects/incubation/openprecedent/scripts/triage_pr_checks.py)
+- [pr-review-gate.yml](/workspace/02-projects/incubation/openprecedent/.github/workflows/pr-review-gate.yml)
+- [python-ci.yml](/workspace/02-projects/incubation/openprecedent/.github/workflows/python-ci.yml)
+- [markdownlint.yml](/workspace/02-projects/incubation/openprecedent/.github/workflows/markdownlint.yml)
+
+关键能力：
+
+- 一个统一的本地 preflight 入口
+- 可选 Markdown lint 和 E2E
+- 本地 branch freshness 与 issue-state 检查
+- 本地 PR closure sync 检查
+- CI 失败快速分类
+
+### 4. 仓库内验证层
+
+这一层负责不依赖真实运行时宿主机的标准验证。
+
+主要组成：
+
+- [run-e2e.sh](/workspace/02-projects/incubation/openprecedent/scripts/run-e2e.sh)
+- [merge-validation.md](/workspace/02-projects/incubation/openprecedent/docs/engineering/merge-validation.md)
+- [openclaw-full-user-journey-validation.md](/workspace/02-projects/incubation/openprecedent/docs/engineering/openclaw-full-user-journey-validation.md)
+
+关键能力：
+
+- 标准端到端验证命令
+- 基于 fixture 的 OpenClaw 旅程回放
+- 可重复的合并前验证基线
+
+### 5. Live Runtime 验证层
+
+这一层负责真实 OpenClaw 集成路径。
+
+主要组成：
+
+- [run-openclaw-live-validation.sh](/workspace/02-projects/incubation/openprecedent/scripts/run-openclaw-live-validation.sh)
+- [.codex/skills/openclaw-live-validation/SKILL.md](/workspace/02-projects/incubation/openprecedent/.codex/skills/openclaw-live-validation/SKILL.md)
+- [openclaw-live-validation-harness.md](/workspace/02-projects/incubation/openprecedent/docs/engineering/openclaw-live-validation-harness.md)
+
+关键能力：
+
+- 准备 live validation 用的 shared runtime home
+- 可选 seed prior history
+- 自动同步目标 profile workspace 里的 installed skill bundle
+- 生成 prompt、launcher 和结构化 artifact
+- 告诉 agent 什么时候应该主动跑真实 smoke validation
+
+### 6. 研究工作流层
+
+这一层负责 post-MVP 的 hypothesis-driven work。
+
+主要组成：
+
+- [.codex/skills/research-harness/SKILL.md](/workspace/02-projects/incubation/openprecedent/.codex/skills/research-harness/SKILL.md)
+- `.codex/skills/research-harness/templates/` 下的模板
+- [mvp-status.md](/workspace/02-projects/incubation/openprecedent/docs/product/mvp-status.md)
+- umbrella issue `#100`
+
+关键能力：
+
+- 显式表达 hypothesis、method、artifact、interpretation
+- 轻量实验模板
+- 与现有 issue-task-PR 流程兼容
+
+## 哪些是 OpenPrecedent 专属的
+
+下面这些内容通常不适合原样复制到别的仓库：
+
+- OpenClaw 专属 live validation 文档
+- decision-lineage skill 内容
+- OpenPrecedent CLI 假设
+- 当前产品专属的 issue epic 和 task 名称
+- precedent / decision 领域术语
+
+迁移时应把这些内容视为样例，而不是通用基础设施。
+
+## 哪些能力是通用可复用的
+
+下面这些能力更适合作为通用 harness 复用：
+
+- issue-task-PR 本地 twin 工作流
+- task type 与 closure sync 校验
+- issue-scoped development state
+- `.codex-review` checkpoint 模式
+- stale branch / merged branch 护栏
+- unified local preflight
+- CI failure triage helper
+- research-harness 模板
+- live-validation skill 这种“何时验证”的 workflow pattern
+
+即便目标仓库不是 OpenPrecedent，这些模式通常也仍然有价值。
+
+## 迁移策略
+
+有两种更现实的迁移路径。
+
+### 1. 迁移到已有仓库
+
+适用于目标仓库已经有自己的 CI、文档和协作模式。
+
+推荐顺序：
+
+1. 先迁 workflow 核心
+2. 再迁本地护栏
+3. 再适配 preflight 和 CI
+4. 然后补 issue-state
+5. 最后再决定是否需要 live validation 或 research workflow
+
+最小可复用集合：
+
+- 针对目标仓库改写后的 `AGENTS.md`
+- `.codex/skills/ccpm-codex/` 或等价本地 PM skill
+- `codex_pm.py` 风格的本地 PM 工具
+- `.githooks/pre-push`
+- `scripts/install-hooks.sh`
+- `scripts/run-agent-preflight.sh`
+- `.codex/pm/` 目录结构
+
+需要适配的点：
+
+- 产品专属路径
+- 默认基线分支是否仍然是 `upstream/main`
+- triage 里引用的 CI workflow 名称
+- preflight 中的测试命令
+
+### 2. 迁移到新仓库
+
+适用于新建一个 agent 产品仓库。
+
+推荐顺序：
+
+1. 先加 `AGENTS.md`
+2. 再加本地 PM workspace 和 `codex_pm` 风格工具
+3. 再加 hook 安装和 pre-push 护栏
+4. 再加 unified preflight
+5. 再加一个标准 E2E 或 smoke validation 入口
+6. 最后按需要补 runtime-specific skill 或 research skill
+
+对于新仓库，通常不应该一开始就把所有复杂层全部搬过去。
+
+## 推荐的复用配置
+
+### Profile A：纯交付型 Harness
+
+适合主要做实现交付的仓库。
+
+包含：
+
+- workflow 与 PM 层
+- 本地护栏层
+- preflight 与 CI 支撑层
+
+初期可以不包含：
+
+- live runtime 验证层
+- 研究工作流层
+
+### Profile B：Agent 产品 Harness
+
+适合存在真实 runtime integration 路径的仓库。
+
+包含：
+
+- workflow 与 PM 层
+- 本地护栏层
+- preflight 与 CI 支撑层
+- 仓库内验证层
+- live runtime 验证层
+
+### Profile C：研究验证型 Harness
+
+适合已经过了 MVP plumbing，需要持续做 hypothesis loop 的仓库。
+
+包含：
+
+- workflow 与 PM 层
+- issue-state 支撑
+- 研究工作流层
+- 与产品相匹配的验证层
+
+## 实际迁移检查清单
+
+迁移到别的仓库时，至少确认：
+
+- 分支命名与默认 base ref 是否正确
+- triage 里引用的 CI workflow 名称是否匹配
+- hook 提示语是否符合新仓库术语
+- preflight 里的测试命令是否匹配目标仓库
+- task twin metadata 是否适配目标流程
+- runtime smoke validation 是否真的指向新产品的真实运行路径
+
+## 推荐的打包方式
+
+不要试图一次性复制全部能力。
+
+更合理的顺序是：
+
+1. 先迁 workflow、hook、preflight 核心
+2. 在目标仓库里用几轮真实任务跑起来
+3. 再按需要补 live validation 或 research workflow
+
+这样能避免把 OpenPrecedent 特有复杂度一并带过去。
+
+## 相关文档
+
+- [Harness capability analysis](/workspace/02-projects/incubation/openprecedent/docs/engineering/harness-capability-analysis.md)
+- [Harness reuse guide](/workspace/02-projects/incubation/openprecedent/docs/engineering/harness-reuse-guide.md)
+- [Tooling setup](/workspace/02-projects/incubation/openprecedent/docs/engineering/tooling-setup.md)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -987,6 +987,17 @@ def test_tooling_setup_mentions_live_validation_skill() -> None:
     assert ".codex/skills/openclaw-live-validation/SKILL.md" in content
 
 
+def test_harness_reuse_guide_exists() -> None:
+    path = Path(__file__).parent.parent / "docs" / "engineering" / "harness-reuse-guide.md"
+
+    content = path.read_text(encoding="utf-8")
+
+    assert "Current Harness Inventory" in content
+    assert "Export Strategy" in content
+    assert "existing repository" in content
+    assert "brand new repository" in content
+
+
 def test_openclaw_runtime_trigger_rerun_doc_exists() -> None:
     path = (
         Path(__file__).parent.parent


### PR DESCRIPTION
Closes #123

## Summary

- add an engineering guide that inventories the current OpenPrecedent harness and explains how to reuse it in other existing or brand new repositories
- add a Chinese counterpart under docs/zh/engineering for the same harness reuse guidance
- link the reuse guide from the existing harness analysis and cover the English doc with a lightweight test

## Testing

- PYTHONPATH=src .venv/bin/pytest tests/test_cli.py -k "harness_reuse_guide_exists"
