### PR TITLE
Enforce local closure-sync scanning before push

### DIFF
--- a/.codex/pm/tasks/real-history-quality/enforce-local-closure-sync-before-push.md
+++ b/.codex/pm/tasks/real-history-quality/enforce-local-closure-sync-before-push.md
@@ -1,0 +1,36 @@
+---
+type: task
+epic: real-history-quality
+slug: enforce-local-closure-sync-before-push
+title: Enforce local closure-sync scanning before push in the agent harness
+status: done
+labels: feature,test,docs
+issue: 133
+---
+
+## Context
+
+The repository already had local closure-sync verification in the optional preflight path and in CI, but not in the default pre-push hook.
+That allowed contributors to push branches that would predictably fail `pr-review-gate` later.
+
+## Deliverable
+
+Extend the local agent harness so closure-sync scanning runs in the default pre-push path when local PR context is available.
+
+## Scope
+
+- add a local closure-sync check to `.githooks/pre-push`
+- skip gracefully when the base ref, `gh`, or PR body is unavailable
+- document the new local guardrail behavior
+- add tests covering failing and passing local hook scenarios
+
+## Acceptance Criteria
+
+- a contributor pushing a branch with a `Closes #<issue>` mismatch and unfinished local task file is blocked locally before CI
+- the hook remains usable when no local PR context is available
+- tests cover the new local hook behavior
+- repository docs explain the added guardrail
+
+## Validation
+
+- `PYTHONPATH=src .venv/bin/pytest tests/test_pre_push_hook.py tests/test_preflight_script.py tests/test_branch_freshness_script.py tests/test_codex_pm.py -k 'pre_push or preflight or branch_freshness or closure_sync'`

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -6,6 +6,11 @@ review_file="$repo_root/.codex-review"
 current_branch="$(git branch --show-current)"
 origin_url="$(git remote get-url origin 2>/dev/null || true)"
 base_ref="${OPENPRECEDENT_BASE_REF:-upstream/main}"
+python_bin="${OPENPRECEDENT_PYTHON_BIN:-$repo_root/.venv/bin/python}"
+
+if [[ ! -x "$python_bin" ]]; then
+  python_bin="python3"
+fi
 
 extract_owner() {
   local remote_url="$1"
@@ -14,6 +19,46 @@ extract_owner() {
     return 0
   fi
   return 1
+}
+
+run_local_pr_closure_check() {
+  local branch changed_files pr_body body_input
+  branch="$(git branch --show-current)"
+
+  if [[ -z "$branch" ]]; then
+    return 0
+  fi
+
+  if ! git rev-parse --verify "$base_ref" >/dev/null 2>&1; then
+    echo "Skipping local closure sync check: base ref $base_ref is unavailable"
+    return 0
+  fi
+
+  changed_files="$(git diff --name-only "$base_ref"...HEAD)"
+  if [[ -z "$changed_files" ]]; then
+    return 0
+  fi
+
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "Skipping local closure sync check: gh is unavailable"
+    return 0
+  fi
+
+  pr_body="$(
+    gh pr view --json body --jq .body 2>/dev/null || true
+  )"
+  if [[ -z "$pr_body" ]]; then
+    echo "Skipping local closure sync check: PR body is unavailable"
+    return 0
+  fi
+
+  body_input=("--pr-body" "$pr_body")
+  while IFS= read -r path; do
+    [[ -n "$path" ]] || continue
+    body_input+=("--changed-file" "$path")
+  done <<< "$changed_files"
+
+  PYTHONPATH=src "$python_bin" -m openprecedent.codex_pm verify-pr-closure-sync "${body_input[@]}"
 }
 
 if [[ "${BYPASS_CODEX_REVIEW:-}" == "1" ]]; then
@@ -84,5 +129,7 @@ EOF
     exit 1
   fi
 fi
+
+run_local_pr_closure_check
 
 echo "Codex review note detected."

--- a/docs/engineering/harness-reuse-guide.md
+++ b/docs/engineering/harness-reuse-guide.md
@@ -48,6 +48,7 @@ Key capabilities:
 - require `.codex-review`
 - block pushing to branches whose PRs already merged
 - block stale branches that are behind `upstream/main`
+- run local issue/task closure-sync verification before push when PR context is available through `gh`
 - provide a fixed local checkpoint for native Codex `/review`
 
 ### 3. Local preflight and CI support layer

--- a/docs/engineering/repository-governance.md
+++ b/docs/engineering/repository-governance.md
@@ -60,6 +60,7 @@ Expected local behavior:
 - the local pre-push hook blocks the push if the review note is missing
 - the local pre-push hook blocks stale branches that no longer contain the latest `upstream/main`
 - the local pre-push hook also blocks pushes to branches whose PRs have already been merged into `openprecedent/openprecedent`
+- when a PR body is locally available through `gh`, the local pre-push hook also checks issue/task closure sync before push
 
 This is a local reliability measure, not a substitute for repository review requirements.
 

--- a/docs/engineering/tooling-setup.md
+++ b/docs/engineering/tooling-setup.md
@@ -23,6 +23,7 @@ To enable the local hook:
 
 After that, each push requires a `.codex-review` file in the repository root unless you explicitly bypass the hook.
 The local hook also expects your branch to contain the latest `upstream/main` by default, so stale branches are caught before push.
+When `gh` can resolve the current PR body, the hook also performs a local issue/task closure sync check before push.
 
 ## Codex Review Hook
 
@@ -47,6 +48,7 @@ remaining risks: dependencies not installed locally, tests not executed
 
 This hook does not replace human judgment. It creates a minimal review checkpoint before code leaves the local branch.
 It also acts as a branch-freshness guardrail: if your branch no longer contains the latest `upstream/main`, rebase before pushing.
+If the current PR body includes `Closes #<issue>`, the hook now tries to verify that the matching local task file is also updated consistently before allowing the push.
 
 ## Merge Validation
 

--- a/tests/test_pre_push_hook.py
+++ b/tests/test_pre_push_hook.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def _prepare_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "remote", "add", "origin", "git@github.com:test/openprecedent.git")
+
+    source_root = Path(__file__).parent.parent
+
+    hook_path = repo / ".githooks" / "pre-push"
+    hook_path.parent.mkdir(parents=True, exist_ok=True)
+    hook_path.write_text((source_root / ".githooks" / "pre-push").read_text(encoding="utf-8"), encoding="utf-8")
+    hook_path.chmod(0o755)
+
+    src_pkg = repo / "src" / "openprecedent"
+    src_pkg.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source_root / "src" / "openprecedent" / "codex_pm.py", src_pkg / "codex_pm.py")
+    (src_pkg / "__init__.py").write_text("", encoding="utf-8")
+
+    task_path = repo / ".codex" / "pm" / "tasks" / "test-epic" / "sample-task.md"
+    task_path.parent.mkdir(parents=True, exist_ok=True)
+    task_path.write_text(
+        """---
+type: task
+epic: test-epic
+slug: sample-task
+title: Sample task
+status: in_progress
+labels: feature
+issue: 999
+---
+
+## Context
+
+Test task.
+""",
+        encoding="utf-8",
+    )
+
+    review_file = repo / ".codex-review"
+    review_file.write_text(
+        "scope reviewed: pre-push hook\nfindings: no findings\nremaining risks: local closure sync test only\n",
+        encoding="utf-8",
+    )
+
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "base")
+
+    _git(repo, "checkout", "-b", "feature")
+    task_path.write_text(task_path.read_text(encoding="utf-8") + "\nMore task body.\n", encoding="utf-8")
+    _git(repo, "add", str(task_path.relative_to(repo)))
+    _git(repo, "commit", "-m", "update task")
+
+    return repo
+
+
+def _write_fake_gh(bin_dir: Path, *, pr_body: str) -> Path:
+    script = bin_dir / "gh"
+    script.write_text(
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "pr" && "$2" == "list" ]]; then
+  echo '[]'
+  exit 0
+fi
+if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  printf '%s' {pr_body!r}
+  exit 0
+fi
+echo "unexpected gh invocation: $*" >&2
+exit 1
+""",
+        encoding="utf-8",
+    )
+    script.chmod(0o755)
+    return script
+
+
+def test_pre_push_hook_blocks_local_closure_sync_mismatch(tmp_path: Path) -> None:
+    repo = _prepare_repo(tmp_path)
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _write_fake_gh(fake_bin, pr_body="Closes #999")
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["BYPASS_BRANCH_FRESHNESS_CHECK"] = "1"
+    env["OPENPRECEDENT_BASE_REF"] = "main"
+    env["OPENPRECEDENT_PYTHON_BIN"] = "python3"
+
+    result = subprocess.run(
+        [str(repo / ".githooks" / "pre-push")],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "matching task file is not marked done" in result.stderr
+
+
+def test_pre_push_hook_skips_local_closure_sync_when_pr_body_is_unavailable(tmp_path: Path) -> None:
+    repo = _prepare_repo(tmp_path)
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _write_fake_gh(fake_bin, pr_body="")
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["BYPASS_BRANCH_FRESHNESS_CHECK"] = "1"
+    env["OPENPRECEDENT_BASE_REF"] = "main"
+    env["OPENPRECEDENT_PYTHON_BIN"] = "python3"
+
+    result = subprocess.run(
+        [str(repo / ".githooks" / "pre-push")],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "Skipping local closure sync check: PR body is unavailable" in result.stdout
+    assert "Codex review note detected." in result.stdout


### PR DESCRIPTION
Closes #133

## Summary
- add local closure-sync verification to the default pre-push hook when PR context is available
- document the new local guardrail behavior in governance, tooling, and harness docs
- add pre-push hook tests for failure and skip scenarios

## Validation
- `PYTHONPATH=src .venv/bin/pytest tests/test_pre_push_hook.py tests/test_preflight_script.py tests/test_branch_freshness_script.py tests/test_codex_pm.py -k 'pre_push or preflight or branch_freshness or closure_sync'`
