### PR TITLE
Harden the agent harness against fork-targeted PR creation drift

### DIFF
--- a/.codex/pm/tasks/real-history-quality/harden-pr-targeting.md
+++ b/.codex/pm/tasks/real-history-quality/harden-pr-targeting.md
@@ -1,0 +1,33 @@
+---
+type: task
+epic: real-history-quality
+slug: harden-pr-targeting
+title: Harden the agent harness against fork-targeted PR creation drift
+status: done
+labels: feature,test,docs
+issue: 136
+---
+
+## Context
+
+Repeated PR creation attempts can still drift toward the fork or inferred default repository instead of the intended upstream target.
+
+## Deliverable
+
+Add a repository-local PR creation path that pins the upstream repository and explicit fork head owner.
+
+## Scope
+
+- add a local PR creation command to `openprecedent.codex_pm`
+- fail fast when fork owner or upstream targeting is ambiguous
+- update workflow documentation and the local skill command map
+
+## Acceptance Criteria
+
+- default local PR creation targets `openprecedent/openprecedent`
+- the local command does not rely on `gh` repository inference
+- ambiguous remote targeting fails locally with a clear error
+
+## Validation
+
+- `PYTHONPATH=src .venv/bin/pytest tests/test_codex_pm.py -k 'pr_create or pr_body'`

--- a/.codex/skills/ccpm-codex/SKILL.md
+++ b/.codex/skills/ccpm-codex/SKILL.md
@@ -23,6 +23,7 @@ Use this skill for project-management work in this repository when the task invo
 5. Generate GitHub text from the task file instead of rewriting it each time:
    - issue body: `python3 -m openprecedent.codex_pm issue-body <task-path>`
    - PR body: `python3 -m openprecedent.codex_pm pr-body <task-path> --issue <n> --tests "..."`
+   - PR creation: `python3 -m openprecedent.codex_pm pr-create <task-path> --tests "..."`
 6. Pick the next local task with:
    - `python3 -m openprecedent.codex_pm next`
 

--- a/.codex/skills/ccpm-codex/references/command-map.md
+++ b/.codex/skills/ccpm-codex/references/command-map.md
@@ -35,6 +35,9 @@ This skill ports the ccpm command model into Codex-friendly local commands.
 - `/pm:pr-body`
   - Codex equivalent:
     `python3 -m openprecedent.codex_pm pr-body <task-path> --issue <n> --tests "<cmd>"`
+- `/pm:pr-create`
+  - Codex equivalent:
+    `python3 -m openprecedent.codex_pm pr-create <task-path> --tests "<cmd>"`
 - `/pm:standup`
   - Codex equivalent: `python3 -m openprecedent.codex_pm standup`
 
@@ -45,6 +48,6 @@ Pair the local commands with `gh`:
 - create issue:
   - `gh issue create --body-file <(python3 -m openprecedent.codex_pm issue-body <task-path>) ...`
 - create PR:
-  - `gh pr create --body-file <(python3 -m openprecedent.codex_pm pr-body <task-path> --issue <n> --tests "...") ...`
+  - `python3 -m openprecedent.codex_pm pr-create <task-path> --tests "..."`
 
 If process substitution is inconvenient, redirect output to a temp file first.

--- a/docs/engineering/harness-reuse-guide.md
+++ b/docs/engineering/harness-reuse-guide.md
@@ -31,6 +31,7 @@ Key capabilities:
 - issue-scoped development state
 - explicit task types such as `implementation`, `docs`, `research`, and `umbrella`
 - PR-body and task-closure sync checks
+- repository-local PR creation that pins the upstream repo and fork head explicitly
 
 ### 2. Local guardrail layer
 

--- a/docs/engineering/repository-governance.md
+++ b/docs/engineering/repository-governance.md
@@ -77,6 +77,7 @@ Additional branch hygiene rule:
 - once a pull request branch has been merged, that branch must be treated as closed
 - any follow-up work must start from a new branch created from the latest `upstream/main`
 - do not append new commits to a branch that already maps to a merged PR
+- local PR creation should use the repository-local `codex_pm pr-create` path so upstream targeting does not drift to a fork by accident
 
 ## Review Gate Model
 

--- a/docs/engineering/tooling-setup.md
+++ b/docs/engineering/tooling-setup.md
@@ -25,6 +25,14 @@ After that, each push requires a `.codex-review` file in the repository root unl
 The local hook also expects your branch to contain the latest `upstream/main` by default, so stale branches are caught before push.
 When `gh` can resolve the current PR body, the hook also performs a local issue/task closure sync check before push.
 
+For PR creation, prefer the repository-local command:
+
+```bash
+python3 -m openprecedent.codex_pm pr-create .codex/pm/tasks/<epic>/<task>.md --tests "<cmd>"
+```
+
+This command forces the upstream target repo and explicit fork head reference instead of relying on whatever repository context `gh` infers from the local clone.
+
 ## Codex Review Hook
 
 Before pushing, run:

--- a/src/openprecedent/codex_pm.py
+++ b/src/openprecedent/codex_pm.py
@@ -17,6 +17,7 @@ CLOSING_ISSUE_PATTERN = re.compile(
     r"\b(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s+#(\d+)\b",
     re.IGNORECASE,
 )
+GITHUB_REMOTE_PATTERN = re.compile(r"github\.com[:/]([^/]+)/([^/.]+?)(?:\.git)?$")
 
 
 @dataclass
@@ -87,6 +88,16 @@ def build_parser() -> argparse.ArgumentParser:
     pr_body.add_argument("path")
     pr_body.add_argument("--issue", type=int)
     pr_body.add_argument("--tests", action="append", default=[])
+
+    pr_create = subparsers.add_parser("pr-create")
+    pr_create.add_argument("path")
+    pr_create.add_argument("--issue", type=int)
+    pr_create.add_argument("--tests", action="append", default=[])
+    pr_create.add_argument("--title")
+    pr_create.add_argument("--base-repo", default="openprecedent/openprecedent")
+    pr_create.add_argument("--base-branch", default="main")
+    pr_create.add_argument("--head-owner")
+    pr_create.add_argument("--head-branch")
 
     verify_pr_closure = subparsers.add_parser("verify-pr-closure-sync")
     verify_pr_closure.add_argument("--pr-body")
@@ -264,6 +275,28 @@ def main(argv: list[str] | None = None) -> int:
         document = _read_document(Path(args.path))
         print(_render_pr_body(document, issue=args.issue, tests=args.tests))
         return 0
+    if args.action == "pr-create":
+        document = _read_document(Path(args.path))
+        try:
+            pr_url = _create_pr(
+                document,
+                issue=args.issue,
+                tests=args.tests,
+                title=args.title,
+                base_repo=args.base_repo,
+                base_branch=args.base_branch,
+                head_owner=args.head_owner,
+                head_branch=args.head_branch,
+            )
+        except ValueError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+        except subprocess.CalledProcessError as exc:
+            message = exc.stderr.strip() or exc.stdout.strip() or str(exc)
+            print(message, file=sys.stderr)
+            return exc.returncode or 1
+        print(pr_url)
+        return 0
     if args.action == "verify-pr-closure-sync":
         pr_body = _resolve_pr_body(args.pr_body, args.event_path)
         changed_files = _resolve_changed_files(
@@ -397,13 +430,26 @@ def _doc_to_dict(document: PMDocument) -> dict[str, object]:
 
 
 def _current_branch() -> str:
+    return _git_output(["git", "branch", "--show-current"]) or ""
+
+
+def _git_output(args: list[str]) -> str | None:
     result = subprocess.run(
-        ["git", "branch", "--show-current"],
+        args,
         check=False,
         capture_output=True,
         text=True,
     )
+    if result.returncode != 0:
+        return None
     return result.stdout.strip()
+
+
+def _parse_github_remote(remote_url: str) -> tuple[str, str] | None:
+    match = GITHUB_REMOTE_PATTERN.search(remote_url)
+    if match is None:
+        return None
+    return match.group(1), match.group(2)
 
 
 def _parse_issue_from_branch(branch: str) -> int | None:
@@ -540,6 +586,74 @@ def _render_pr_body(document: PMDocument, *, issue: int | None, tests: list[str]
         for test in tests:
             lines.append(f"- `{test}`")
     return "\n".join(lines).rstrip()
+
+
+def _create_pr(
+    document: PMDocument,
+    *,
+    issue: int | None,
+    tests: list[str],
+    title: str | None,
+    base_repo: str,
+    base_branch: str,
+    head_owner: str | None,
+    head_branch: str | None,
+) -> str:
+    branch = head_branch or _current_branch()
+    if not branch:
+        raise ValueError("PR creation failed: current branch is unavailable.")
+
+    origin_url = _git_output(["git", "remote", "get-url", "origin"])
+    if head_owner is None:
+        if origin_url is None:
+            raise ValueError("PR creation failed: origin remote is unavailable.")
+        origin_remote = _parse_github_remote(origin_url)
+        if origin_remote is None:
+            raise ValueError(
+                "PR creation failed: could not derive the fork owner from the origin remote. "
+                "Pass --head-owner explicitly."
+            )
+        head_owner = origin_remote[0]
+
+    upstream_url = _git_output(["git", "remote", "get-url", "upstream"])
+    if upstream_url is not None:
+        upstream_remote = _parse_github_remote(upstream_url)
+        if upstream_remote is None:
+            raise ValueError(
+                "PR creation failed: could not parse the upstream remote. "
+                "Fix the upstream remote or pass --base-repo explicitly."
+            )
+        upstream_repo = f"{upstream_remote[0]}/{upstream_remote[1]}"
+        if upstream_repo != base_repo:
+            raise ValueError(
+                f"PR creation failed: upstream remote points to {upstream_repo}, not {base_repo}. "
+                "Use the intended upstream repository explicitly."
+            )
+
+    pr_title = title or document.metadata.get("title") or document.path.stem
+    pr_body = _render_pr_body(document, issue=issue, tests=tests)
+
+    result = subprocess.run(
+        [
+            "gh",
+            "pr",
+            "create",
+            "--repo",
+            base_repo,
+            "--base",
+            base_branch,
+            "--head",
+            f"{head_owner}:{branch}",
+            "--title",
+            pr_title,
+            "--body",
+            pr_body,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
 
 
 def _parse_issue_number(value: str) -> int | None:

--- a/tests/test_codex_pm.py
+++ b/tests/test_codex_pm.py
@@ -487,6 +487,152 @@ def test_codex_pm_pr_body_omits_closing_clause_for_umbrella_task(tmp_path: Path,
     assert "Closes #100" not in pr_body
 
 
+def test_codex_pm_pr_create_uses_explicit_upstream_repo_and_fork_head(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    assert main(["init"]) == 0
+    capsys.readouterr()
+    assert (
+        main(
+            [
+                "task-new",
+                "real-history-quality",
+                "pr-targeting",
+                "--title",
+                "Harden PR targeting",
+                "--issue",
+                "136",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    task_path = tmp_path / ".codex" / "pm" / "tasks" / "real-history-quality" / "pr-targeting.md"
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], check: bool, capture_output: bool, text: bool):
+        calls.append(cmd)
+        if cmd == ["git", "branch", "--show-current"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="codex/harden-pr-targeting\n", stderr="")
+        if cmd == ["git", "remote", "get-url", "origin"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="git@github.com:yaoyinnan/openprecedent.git\n", stderr="")
+        if cmd == ["git", "remote", "get-url", "upstream"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="https://github.com/openprecedent/openprecedent.git\n", stderr="")
+        if cmd[:3] == ["gh", "pr", "create"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="https://github.com/openprecedent/openprecedent/pull/999\n", stderr="")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert (
+        main(
+            [
+                "pr-create",
+                str(task_path),
+                "--tests",
+                "PYTHONPATH=src .venv/bin/pytest tests/test_codex_pm.py",
+            ]
+        )
+        == 0
+    )
+    output = capsys.readouterr().out
+
+    assert "https://github.com/openprecedent/openprecedent/pull/999" in output
+    gh_call = next(cmd for cmd in calls if cmd[:3] == ["gh", "pr", "create"])
+    assert "--repo" in gh_call
+    assert gh_call[gh_call.index("--repo") + 1] == "openprecedent/openprecedent"
+    assert gh_call[gh_call.index("--head") + 1] == "yaoyinnan:codex/harden-pr-targeting"
+    assert gh_call[gh_call.index("--base") + 1] == "main"
+
+
+def test_codex_pm_pr_create_fails_when_origin_owner_is_ambiguous(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    assert main(["init"]) == 0
+    capsys.readouterr()
+    assert (
+        main(
+            [
+                "task-new",
+                "real-history-quality",
+                "pr-targeting",
+                "--title",
+                "Harden PR targeting",
+                "--issue",
+                "136",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    task_path = tmp_path / ".codex" / "pm" / "tasks" / "real-history-quality" / "pr-targeting.md"
+
+    def fake_run(cmd: list[str], check: bool, capture_output: bool, text: bool):
+        if cmd == ["git", "branch", "--show-current"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="codex/harden-pr-targeting\n", stderr="")
+        if cmd == ["git", "remote", "get-url", "origin"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="ssh://internal.example/openprecedent.git\n", stderr="")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert main(["pr-create", str(task_path)]) == 1
+    assert "could not derive the fork owner from the origin remote" in capsys.readouterr().err
+
+
+def test_codex_pm_pr_create_fails_when_upstream_repo_does_not_match(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    assert main(["init"]) == 0
+    capsys.readouterr()
+    assert (
+        main(
+            [
+                "task-new",
+                "real-history-quality",
+                "pr-targeting",
+                "--title",
+                "Harden PR targeting",
+                "--issue",
+                "136",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    task_path = tmp_path / ".codex" / "pm" / "tasks" / "real-history-quality" / "pr-targeting.md"
+
+    def fake_run(cmd: list[str], check: bool, capture_output: bool, text: bool):
+        if cmd == ["git", "branch", "--show-current"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="codex/harden-pr-targeting\n", stderr="")
+        if cmd == ["git", "remote", "get-url", "origin"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="git@github.com:yaoyinnan/openprecedent.git\n", stderr="")
+        if cmd == ["git", "remote", "get-url", "upstream"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="https://github.com/someone-else/openprecedent.git\n", stderr="")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert main(["pr-create", str(task_path)]) == 1
+    assert "upstream remote points to someone-else/openprecedent" in capsys.readouterr().err
+
+
 def test_codex_pm_issue_state_init_creates_state_doc_and_updates_task(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
Closes #136

Add a repository-local PR creation path that pins the upstream repository and explicit fork head owner.

Validation:
- `PYTHONPATH=src .venv/bin/pytest tests/test_codex_pm.py -k 'pr_create or pr_body'`
- `PYTHONPATH=src .venv/bin/pytest tests/test_codex_pm.py -k 'pr_create or pr_body'`