### PR TITLE
Make the pre-push standard review flow enforceable instead of note-only

### DIFF
--- a/.codex/pm/tasks/real-history-quality/enforce-review-proof-before-push.md
+++ b/.codex/pm/tasks/real-history-quality/enforce-review-proof-before-push.md
@@ -1,0 +1,34 @@
+---
+type: task
+epic: real-history-quality
+slug: enforce-review-proof-before-push
+title: Make the pre-push standard review flow enforceable instead of note-only
+status: done
+labels: feature,test,docs
+issue: 139
+---
+
+## Context
+
+The repository currently gates pushes on `.codex-review`, but that alone does not prove the standard review checkpoint was run for the current commit set.
+
+## Deliverable
+
+Add a machine-generated review proof and enforce it in the local pre-push and preflight flows.
+
+## Scope
+
+- refresh a review proof file during the checkpoint script
+- require the proof to match the current branch and `HEAD`
+- require the review note to be updated after the latest checkpoint
+- update docs and regression coverage
+
+## Acceptance Criteria
+
+- push-time review enforcement is stronger than note-only gating
+- stale or missing review proof blocks push locally
+- the workflow is documented in the repository tooling docs
+
+## Validation
+
+- `PYTHONPATH=src .venv/bin/pytest tests/test_codex_review_checkpoint.py tests/test_pre_push_hook.py tests/test_preflight_script.py`

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -3,6 +3,7 @@ set -euo pipefail
 
 repo_root="$(git rev-parse --show-toplevel)"
 review_file="$repo_root/.codex-review"
+review_proof_file="${OPENPRECEDENT_REVIEW_PROOF_FILE:-$repo_root/.codex-review-proof}"
 current_branch="$(git branch --show-current)"
 origin_url="$(git remote get-url origin 2>/dev/null || true)"
 base_ref="${OPENPRECEDENT_BASE_REF:-upstream/main}"
@@ -19,6 +20,13 @@ extract_owner() {
     return 0
   fi
   return 1
+}
+
+read_proof_value() {
+  local key="$1"
+  local value
+  value="$(sed -n "s/^${key}=//p" "$review_proof_file" | head -n 1)"
+  printf '%s' "$value"
 }
 
 run_local_pr_closure_check() {
@@ -93,7 +101,9 @@ EOF
   exit 1
 fi
 
-if ! grep -Eq 'scope reviewed|no findings|remaining risks' "$review_file"; then
+if ! grep -Eq '^scope reviewed:' "$review_file" \
+  || ! grep -Eq '^(findings:|no findings$)' "$review_file" \
+  || ! grep -Eq '^remaining risks:' "$review_file"; then
   cat <<'EOF'
 Push blocked: .codex-review exists but is incomplete.
 
@@ -104,6 +114,69 @@ Include at least:
 
 If needed, rerun:
   ./scripts/run-codex-review-checkpoint.sh
+EOF
+  exit 1
+fi
+
+if grep -Fq 'native /review has not been run yet' "$review_file"; then
+  cat <<'EOF'
+Push blocked: .codex-review still contains the checkpoint placeholder.
+
+Run the native Codex /review flow, then replace the placeholder remaining-risks text with the real review outcome before pushing.
+EOF
+  exit 1
+fi
+
+if [[ ! -f "$review_proof_file" ]]; then
+  cat <<'EOF'
+Push blocked: missing .codex-review-proof
+
+Before pushing, run:
+  ./scripts/run-codex-review-checkpoint.sh
+
+The review checkpoint now writes a machine-generated proof for the current HEAD. Pushes require both the review note and a current proof file.
+EOF
+  exit 1
+fi
+
+proof_head_sha="$(read_proof_value head_sha)"
+proof_branch="$(read_proof_value branch)"
+current_head_sha="$(git rev-parse HEAD)"
+
+if [[ -z "$proof_head_sha" ]]; then
+  echo "Push blocked: .codex-review-proof is missing head_sha."
+  exit 1
+fi
+
+if [[ "$proof_head_sha" != "$current_head_sha" ]]; then
+  cat <<EOF
+Push blocked: .codex-review-proof does not match the current HEAD.
+
+Proof HEAD:   $proof_head_sha
+Current HEAD: $current_head_sha
+
+Rerun ./scripts/run-codex-review-checkpoint.sh and update .codex-review after the native Codex /review step.
+EOF
+  exit 1
+fi
+
+if [[ -n "$current_branch" ]] && [[ -n "$proof_branch" ]] && [[ "$proof_branch" != "$current_branch" ]]; then
+  cat <<EOF
+Push blocked: .codex-review-proof was generated for a different branch.
+
+Proof branch:   $proof_branch
+Current branch: $current_branch
+
+Rerun ./scripts/run-codex-review-checkpoint.sh on the current branch.
+EOF
+  exit 1
+fi
+
+if [[ "$review_file" -ot "$review_proof_file" ]]; then
+  cat <<'EOF'
+Push blocked: .codex-review has not been updated since the latest review checkpoint.
+
+After running ./scripts/run-codex-review-checkpoint.sh, run the native Codex /review flow and update .codex-review with the actual findings before pushing.
 EOF
   exit 1
 fi

--- a/docs/engineering/repository-governance.md
+++ b/docs/engineering/repository-governance.md
@@ -57,7 +57,7 @@ Expected local behavior:
 
 - authors run a Codex review before push
 - authors record the result in `.codex-review`
-- the local pre-push hook blocks the push if the review note is missing
+- the local pre-push hook blocks the push if the review note or the machine-generated `.codex-review-proof` file is missing
 - the local pre-push hook blocks stale branches that no longer contain the latest `upstream/main`
 - the local pre-push hook also blocks pushes to branches whose PRs have already been merged into `openprecedent/openprecedent`
 - when a PR body is locally available through `gh`, the local pre-push hook also checks issue/task closure sync before push

--- a/docs/engineering/review-policy.md
+++ b/docs/engineering/review-policy.md
@@ -83,7 +83,8 @@ The intended behavior is:
 
 - before pushing, the author runs a Codex review
 - the author records the result in `.codex-review`
-- the pre-push hook blocks the push if no review note is present
+- the review checkpoint refreshes a machine-generated `.codex-review-proof` file for the current `HEAD`
+- the pre-push hook blocks the push if no review note is present, if the proof is missing or stale, or if the note was not updated after the latest checkpoint
 
 This is a lightweight reliability mechanism, not a substitute for PR review.
 

--- a/docs/engineering/tooling-setup.md
+++ b/docs/engineering/tooling-setup.md
@@ -21,7 +21,7 @@ To enable the local hook:
 ./scripts/install-hooks.sh
 ```
 
-After that, each push requires a `.codex-review` file in the repository root unless you explicitly bypass the hook.
+After that, each push requires both a `.codex-review` file and a current `.codex-review-proof` file in the repository root unless you explicitly bypass the hook.
 The local hook also expects your branch to contain the latest `upstream/main` by default, so stale branches are caught before push.
 When `gh` can resolve the current PR body, the hook also performs a local issue/task closure sync check before push.
 
@@ -42,9 +42,10 @@ Before pushing, run:
 ```
 
 This is the preferred local checkpoint for invoking native Codex `/review`.
-The script creates a `.codex-review` template if one does not exist and reminds you to run `/review` before push.
+The script creates or refreshes a `.codex-review-proof` file for the current `HEAD`, creates a `.codex-review` template if one does not exist, and reminds you to run `/review` before push.
 
 Then update `.codex-review` with a short review note.
+Pushes now fail if the proof does not match the current `HEAD`, if the note still contains the placeholder review text, or if the note was not updated after the latest checkpoint refresh.
 
 Recommended format:
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,6 +8,6 @@ Notable operational entrypoints:
 - `run-e2e.sh` runs the standard local fixture-backed end-to-end validation flow
 - `run-openclaw-live-validation.sh` prepares a reusable live OpenClaw validation workspace and summarizes runtime evidence
 - `run-agent-preflight.sh` runs the standard local pre-push confidence checks for agent-driven work
-- `run-codex-review-checkpoint.sh` creates or refreshes the local review note before invoking native Codex `/review`
+- `run-codex-review-checkpoint.sh` creates or refreshes the local review note and the current-HEAD review proof before invoking native Codex `/review`
 - `triage_pr_checks.py` summarizes and classifies current PR check results for faster CI diagnosis
 - `install-collector-assets.sh` renders `systemd` / `cron` assets against the current repo path

--- a/scripts/run-agent-preflight.sh
+++ b/scripts/run-agent-preflight.sh
@@ -17,6 +17,7 @@ fi
 
 RUN_E2E="${OPENPRECEDENT_PREFLIGHT_RUN_E2E:-0}"
 REVIEW_FILE="${OPENPRECEDENT_REVIEW_FILE:-$ROOT_DIR/.codex-review}"
+REVIEW_PROOF_FILE="${OPENPRECEDENT_REVIEW_PROOF_FILE:-$ROOT_DIR/.codex-review-proof}"
 PYTEST_ARGS="${OPENPRECEDENT_PREFLIGHT_PYTEST_ARGS:-tests --ignore=tests/test_preflight_script.py}"
 BASE_REF="${OPENPRECEDENT_PREFLIGHT_BASE_REF:-upstream/main}"
 ENFORCE_ISSUE_STATE="${OPENPRECEDENT_PREFLIGHT_ENFORCE_ISSUE_STATE:-0}"
@@ -28,9 +29,59 @@ check_review_note() {
     exit 1
   fi
 
-  if ! grep -Eq 'scope reviewed|no findings|remaining risks' "$REVIEW_FILE"; then
+  if ! grep -Eq '^scope reviewed:' "$REVIEW_FILE" \
+    || ! grep -Eq '^(findings:|no findings$)' "$REVIEW_FILE" \
+    || ! grep -Eq '^remaining risks:' "$REVIEW_FILE"; then
     echo "Preflight failed: .codex-review exists but is incomplete"
     echo "Rerun ./scripts/run-codex-review-checkpoint.sh if you need a fresh template."
+    exit 1
+  fi
+
+  if grep -Fq 'native /review has not been run yet' "$REVIEW_FILE"; then
+    echo "Preflight failed: .codex-review still contains the checkpoint placeholder"
+    echo "Run native Codex /review and replace the placeholder text with the real review result."
+    exit 1
+  fi
+}
+
+read_review_proof_value() {
+  local key="$1"
+  sed -n "s/^${key}=//p" "$REVIEW_PROOF_FILE" | head -n 1
+}
+
+check_review_proof() {
+  local current_head proof_head proof_branch current_branch
+
+  if [[ ! -f "$REVIEW_PROOF_FILE" ]]; then
+    echo "Preflight failed: missing .codex-review-proof"
+    echo "Run ./scripts/run-codex-review-checkpoint.sh before preflight."
+    exit 1
+  fi
+
+  current_head="$(git rev-parse HEAD)"
+  current_branch="$(git branch --show-current)"
+  proof_head="$(read_review_proof_value head_sha)"
+  proof_branch="$(read_review_proof_value branch)"
+
+  if [[ -z "$proof_head" ]]; then
+    echo "Preflight failed: .codex-review-proof is missing head_sha"
+    exit 1
+  fi
+
+  if [[ "$proof_head" != "$current_head" ]]; then
+    echo "Preflight failed: .codex-review-proof does not match the current HEAD"
+    echo "Run ./scripts/run-codex-review-checkpoint.sh again for the current commit set."
+    exit 1
+  fi
+
+  if [[ -n "$current_branch" ]] && [[ -n "$proof_branch" ]] && [[ "$proof_branch" != "$current_branch" ]]; then
+    echo "Preflight failed: .codex-review-proof was generated for a different branch"
+    exit 1
+  fi
+
+  if [[ "$REVIEW_FILE" -ot "$REVIEW_PROOF_FILE" ]]; then
+    echo "Preflight failed: .codex-review has not been updated since the latest review checkpoint"
+    echo "Update .codex-review after the native Codex /review step."
     exit 1
   fi
 }
@@ -152,6 +203,7 @@ echo "Running agent preflight in $ROOT_DIR"
 
 check_branch_freshness
 check_review_note
+check_review_proof
 check_issue_state
 check_merged_branch_reuse
 

--- a/scripts/run-codex-review-checkpoint.sh
+++ b/scripts/run-codex-review-checkpoint.sh
@@ -5,8 +5,19 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
 REVIEW_FILE="${OPENPRECEDENT_REVIEW_FILE:-$ROOT_DIR/.codex-review}"
+REVIEW_PROOF_FILE="${OPENPRECEDENT_REVIEW_PROOF_FILE:-$ROOT_DIR/.codex-review-proof}"
 BASE_REF="${OPENPRECEDENT_REVIEW_BASE_REF:-upstream/main}"
 BRANCH_NAME="$(git branch --show-current)"
+HEAD_SHA="$(git rev-parse HEAD)"
+
+write_review_proof() {
+  cat >"$REVIEW_PROOF_FILE" <<EOF
+branch=${BRANCH_NAME:-detached-head}
+head_sha=$HEAD_SHA
+base_ref=$BASE_REF
+generated_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+EOF
+}
 
 build_diff_summary() {
   local compare_ref="$1"
@@ -39,10 +50,13 @@ else
   echo "Review checkpoint already exists at $REVIEW_FILE"
 fi
 
+write_review_proof
+echo "Refreshed review proof at $REVIEW_PROOF_FILE for HEAD $HEAD_SHA"
+
 cat <<EOF
 
 Next steps:
 1. In Codex, run the native /review command for the current branch changes.
-2. Update $REVIEW_FILE with the actual review scope, findings, and remaining risks.
+2. Update $REVIEW_FILE with the actual review scope, findings, and remaining risks after the review completes.
 3. Run ./scripts/run-agent-preflight.sh or push again after the review note is complete.
 EOF

--- a/tests/test_codex_review_checkpoint.py
+++ b/tests/test_codex_review_checkpoint.py
@@ -6,6 +6,7 @@ from pathlib import Path
 def _run_checkpoint(tmp_path: Path, repo_root: Path) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     env["OPENPRECEDENT_REVIEW_FILE"] = str(tmp_path / ".codex-review")
+    env["OPENPRECEDENT_REVIEW_PROOF_FILE"] = str(tmp_path / ".codex-review-proof")
     env["OPENPRECEDENT_REVIEW_BASE_REF"] = "HEAD"
     return subprocess.run(
         ["./scripts/run-codex-review-checkpoint.sh"],
@@ -20,21 +21,27 @@ def _run_checkpoint(tmp_path: Path, repo_root: Path) -> subprocess.CompletedProc
 def test_review_checkpoint_creates_template(tmp_path: Path) -> None:
     repo_root = Path(__file__).resolve().parents[1]
     review_file = tmp_path / ".codex-review"
+    proof_file = tmp_path / ".codex-review-proof"
 
     result = _run_checkpoint(tmp_path, repo_root)
 
     assert result.returncode == 0
     assert "Created review checkpoint template" in result.stdout
+    assert "Refreshed review proof" in result.stdout
     content = review_file.read_text()
     assert "scope reviewed:" in content
     assert "findings: no findings" in content
     assert "remaining risks: native /review has not been run yet" in content
     assert "diff summary:" in content
+    proof = proof_file.read_text()
+    assert "head_sha=" in proof
+    assert "branch=" in proof
 
 
 def test_review_checkpoint_preserves_existing_note(tmp_path: Path) -> None:
     repo_root = Path(__file__).resolve().parents[1]
     review_file = tmp_path / ".codex-review"
+    proof_file = tmp_path / ".codex-review-proof"
     review_file.write_text(
         "scope reviewed: existing\nfindings: no findings\nremaining risks: low\n"
     )
@@ -43,6 +50,7 @@ def test_review_checkpoint_preserves_existing_note(tmp_path: Path) -> None:
 
     assert result.returncode == 0
     assert "Review checkpoint already exists" in result.stdout
+    assert proof_file.exists()
     assert review_file.read_text() == (
         "scope reviewed: existing\nfindings: no findings\nremaining risks: low\n"
     )

--- a/tests/test_pre_push_hook.py
+++ b/tests/test_pre_push_hook.py
@@ -50,12 +50,6 @@ Test task.
         encoding="utf-8",
     )
 
-    review_file = repo / ".codex-review"
-    review_file.write_text(
-        "scope reviewed: pre-push hook\nfindings: no findings\nremaining risks: local closure sync test only\n",
-        encoding="utf-8",
-    )
-
     (repo / "README.md").write_text("base\n", encoding="utf-8")
     _git(repo, "add", ".")
     _git(repo, "commit", "-m", "base")
@@ -64,6 +58,19 @@ Test task.
     task_path.write_text(task_path.read_text(encoding="utf-8") + "\nMore task body.\n", encoding="utf-8")
     _git(repo, "add", str(task_path.relative_to(repo)))
     _git(repo, "commit", "-m", "update task")
+
+    head_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    proof_file = repo / ".codex-review-proof"
+    proof_file.write_text(
+        f"branch=feature\nhead_sha={head_sha}\nbase_ref=main\ngenerated_at=2026-03-11T00:00:00Z\n",
+        encoding="utf-8",
+    )
+
+    review_file = repo / ".codex-review"
+    review_file.write_text(
+        "scope reviewed: pre-push hook\nfindings: no findings\nremaining risks: local closure sync test only\n",
+        encoding="utf-8",
+    )
 
     return repo
 
@@ -139,3 +146,58 @@ def test_pre_push_hook_skips_local_closure_sync_when_pr_body_is_unavailable(tmp_
     assert result.returncode == 0
     assert "Skipping local closure sync check: PR body is unavailable" in result.stdout
     assert "Codex review note detected." in result.stdout
+
+
+def test_pre_push_hook_blocks_missing_review_proof(tmp_path: Path) -> None:
+    repo = _prepare_repo(tmp_path)
+    (repo / ".codex-review-proof").unlink()
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _write_fake_gh(fake_bin, pr_body="")
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["BYPASS_BRANCH_FRESHNESS_CHECK"] = "1"
+    env["OPENPRECEDENT_BASE_REF"] = "main"
+    env["OPENPRECEDENT_PYTHON_BIN"] = "python3"
+
+    result = subprocess.run(
+        [str(repo / ".githooks" / "pre-push")],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "missing .codex-review-proof" in result.stdout
+
+
+def test_pre_push_hook_blocks_stale_review_proof(tmp_path: Path) -> None:
+    repo = _prepare_repo(tmp_path)
+    (repo / ".codex-review-proof").write_text(
+        "branch=feature\nhead_sha=deadbeef\nbase_ref=main\ngenerated_at=2026-03-11T00:00:00Z\n",
+        encoding="utf-8",
+    )
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _write_fake_gh(fake_bin, pr_body="")
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["BYPASS_BRANCH_FRESHNESS_CHECK"] = "1"
+    env["OPENPRECEDENT_BASE_REF"] = "main"
+    env["OPENPRECEDENT_PYTHON_BIN"] = "python3"
+
+    result = subprocess.run(
+        [str(repo / ".githooks" / "pre-push")],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "does not match the current HEAD" in result.stdout

--- a/tests/test_preflight_script.py
+++ b/tests/test_preflight_script.py
@@ -28,6 +28,21 @@ def test_preflight_script_fails_without_codex_review(tmp_path: Path) -> None:
 def test_preflight_script_runs_and_skips_markdownlint_when_unavailable(tmp_path: Path) -> None:
     repo_root = Path(__file__).parent.parent
     review_file = tmp_path / ".codex-review"
+    proof_file = tmp_path / ".codex-review-proof"
+    head_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    proof_file.write_text(
+        f"branch={subprocess.run(['git', 'branch', '--show-current'], cwd=repo_root, capture_output=True, text=True, check=True).stdout.strip()}\n"
+        f"head_sha={head_sha}\n"
+        "base_ref=HEAD\n"
+        "generated_at=2026-03-11T00:00:00Z\n",
+        encoding="utf-8",
+    )
     review_file.write_text(
         "scope reviewed: preflight script\nfindings: no findings\nremaining risks: markdownlint unavailable locally\n",
         encoding="utf-8",
@@ -35,9 +50,11 @@ def test_preflight_script_runs_and_skips_markdownlint_when_unavailable(tmp_path:
 
     env = os.environ.copy()
     env["OPENPRECEDENT_REVIEW_FILE"] = str(review_file)
+    env["OPENPRECEDENT_REVIEW_PROOF_FILE"] = str(proof_file)
     env["OPENPRECEDENT_PYTHON_BIN"] = str(repo_root / ".venv" / "bin" / "python")
     env["PATH"] = "/usr/bin:/bin"
     env["OPENPRECEDENT_PREFLIGHT_BASE_REF"] = "HEAD"
+    env["OPENPRECEDENT_PREFLIGHT_PYTEST_ARGS"] = "tests/test_codex_review_checkpoint.py"
 
     result = subprocess.run(
         ["./scripts/run-agent-preflight.sh"],
@@ -51,3 +68,30 @@ def test_preflight_script_runs_and_skips_markdownlint_when_unavailable(tmp_path:
     assert result.returncode == 0, result.stderr
     assert "Skipping markdownlint" in result.stdout
     assert "Agent preflight passed." in result.stdout
+
+
+def test_preflight_script_fails_without_review_proof(tmp_path: Path) -> None:
+    repo_root = Path(__file__).parent.parent
+    review_file = tmp_path / ".codex-review"
+    review_file.write_text(
+        "scope reviewed: preflight script\nfindings: no findings\nremaining risks: updated after review\n",
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    env["OPENPRECEDENT_REVIEW_FILE"] = str(review_file)
+    env["OPENPRECEDENT_REVIEW_PROOF_FILE"] = str(tmp_path / ".codex-review-proof")
+    env["OPENPRECEDENT_PYTHON_BIN"] = str(repo_root / ".venv" / "bin" / "python")
+    env["OPENPRECEDENT_PREFLIGHT_BASE_REF"] = "HEAD"
+
+    result = subprocess.run(
+        ["./scripts/run-agent-preflight.sh"],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "missing .codex-review-proof" in result.stdout


### PR DESCRIPTION
Closes #139

Add a machine-generated review proof and enforce it in the local pre-push and preflight flows.

Validation:
- `PYTHONPATH=src .venv/bin/pytest tests/test_codex_review_checkpoint.py tests/test_pre_push_hook.py tests/test_preflight_script.py`
- `PYTHONPATH=src .venv/bin/pytest tests/test_codex_review_checkpoint.py tests/test_pre_push_hook.py tests/test_preflight_script.py`