### PR TITLE
Add a harness-gap closure skill for repeated workflow failures

### DIFF
--- a/.codex/pm/tasks/real-history-quality/add-harness-gap-closure-skill.md
+++ b/.codex/pm/tasks/real-history-quality/add-harness-gap-closure-skill.md
@@ -1,0 +1,33 @@
+---
+type: task
+epic: real-history-quality
+slug: add-harness-gap-closure-skill
+title: Add a harness-gap closure skill for repeated workflow failures
+status: done
+labels: docs,feature
+issue: 142
+---
+
+## Context
+
+Repeated workflow mistakes are often really harness gaps, but the repository does not yet have a reusable local skill that turns that signal into issue-scoped hardening work.
+
+## Deliverable
+
+Add a repository-local skill that guides Codex to diagnose, issue-track, implement, and regression-protect harness fixes.
+
+## Scope
+
+- define when a repeated workflow failure should be treated as a harness gap
+- codify the issue-scoped hardening loop
+- register the skill in repository guidance
+
+## Acceptance Criteria
+
+- the new skill is concise and reusable
+- it requires issue linkage before harness code changes
+- it covers diagnosis, implementation, tests or guardrails, and documentation follow-through
+
+## Validation
+
+- manual review of the skill against recent harness hardening issues such as `#133`, `#136`, and `#139`

--- a/.codex/skills/harness-gap-closure/SKILL.md
+++ b/.codex/skills/harness-gap-closure/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: harness-gap-closure
+description: Use when a repeated agent workflow mistake, user reminder, or self-detected failure reveals that the local harness should have prevented the problem. Guides Codex to diagnose the harness gap, create or link the issue, add the guardrail, and add regression protection.
+---
+
+# Harness Gap Closure
+
+Use this skill when a failure should have been prevented by the repository's local harness rather than left to user correction or memory.
+
+Typical triggers:
+
+- the user says a mistake should have been caught by the harness
+- the same workflow failure has happened more than once
+- a push, PR, review, branch, or issue-scoped workflow mistake exposes a missing local guardrail
+- Codex recognizes that a repeated workaround should become a reusable harness rule
+
+Do not use this skill for one-off product bugs that do not imply a harness deficiency.
+
+## Goal
+
+Turn repeated workflow failures into issue-scoped harness hardening work with a complete loop:
+
+1. identify the harness gap
+2. anchor it in a GitHub issue and local task twin
+3. implement the local guardrail or workflow fix
+4. add regression protection where practical
+5. update the repository guidance so later sessions reuse the fix
+
+## Workflow
+
+1. Confirm that the problem is a harness gap, not just a one-off mistake.
+   - Ask: should the local workflow, hook, preflight, skill, or command path have prevented this?
+   - If the answer is no, do not use this skill.
+
+2. Look for repetition.
+   - If the same class of error has happened before, treat that as sufficient evidence that the harness is incomplete.
+   - If it is a new but clearly preventable workflow failure, the skill can still be used.
+
+3. Create or link an explicit GitHub issue before editing implementation.
+   - Reuse `.codex/skills/ccpm-codex/` for issue, task, branch, and PR mechanics.
+   - Do not patch harness code on a discussion-only branch.
+
+4. State the gap precisely.
+   - Record:
+   - what failed
+   - why the current harness allowed it
+   - what local signal could have blocked or clarified it earlier
+
+5. Prefer the smallest reliable guardrail.
+   - Typical fixes:
+   - pre-push hook checks
+   - preflight checks
+   - repository-local command wrappers
+   - workflow skill instructions
+   - fail-fast local validation scripts
+   - clearer repository guidance tied to enforced behavior
+
+6. Add regression protection.
+   - If the gap is scriptable, add or update automated tests.
+   - If the gap is primarily procedural, add the strongest practical local proof or fail-fast behavior.
+   - Do not stop at docs-only guidance when the failure can be detected locally.
+
+7. Update guidance where contributors will actually see it.
+   - Usually one or more of:
+   - `AGENTS.md`
+   - `docs/engineering/tooling-setup.md`
+   - `docs/engineering/repository-governance.md`
+   - local skill command maps
+
+8. Close the loop in the PR.
+   - Explain:
+   - the repeated failure mode
+   - the new harness behavior
+   - the regression coverage
+
+## Expected Outcome
+
+After using this skill, the repository should be stronger in a concrete way:
+
+- the same mistake should be blocked earlier, or
+- the workflow should now fail locally with a clear explanation, or
+- the repository should provide a standard path that removes the ambiguity
+
+## Read Next
+
+- `.codex/skills/ccpm-codex/SKILL.md`
+- [`docs/engineering/tooling-setup.md`](/workspace/02-projects/incubation/openprecedent/docs/engineering/tooling-setup.md)
+- [`docs/engineering/repository-governance.md`](/workspace/02-projects/incubation/openprecedent/docs/engineering/repository-governance.md)
+- [`docs/engineering/harness-capability-analysis.md`](/workspace/02-projects/incubation/openprecedent/docs/engineering/harness-capability-analysis.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ The first implementation target is a local single-agent workflow. The current go
 
 - For project-management work in this repository, use the local skill at `.codex/skills/ccpm-codex/`.
 - Use it for PRD, epic, task, issue, and PR workflow management instead of inventing an ad hoc process each time.
+- When a repeated workflow failure reveals a missing local guardrail, use `.codex/skills/harness-gap-closure/` to turn that failure into issue-scoped harness hardening with regression follow-through.
 
 ## Documentation Rules
 

--- a/docs/engineering/harness-capability-analysis.md
+++ b/docs/engineering/harness-capability-analysis.md
@@ -45,9 +45,11 @@ Relevant components:
 
 - [AGENTS.md](/workspace/02-projects/incubation/openprecedent/AGENTS.md)
 - [.codex/skills/ccpm-codex/SKILL.md](/workspace/02-projects/incubation/openprecedent/.codex/skills/ccpm-codex/SKILL.md)
+- [.codex/skills/harness-gap-closure/SKILL.md](/workspace/02-projects/incubation/openprecedent/.codex/skills/harness-gap-closure/SKILL.md)
 - [codex_pm.py](/workspace/02-projects/incubation/openprecedent/src/openprecedent/codex_pm.py)
 
 This is already better than a normal lightweight repo because it gives Codex a defined delivery state machine instead of relying on memory.
+The harness-gap closure skill also gives the repository a reusable way to convert repeated workflow failures into issue-scoped hardening work instead of relying on ad hoc reminders.
 
 ### 2. Local push guardrails
 

--- a/docs/engineering/harness-reuse-guide.md
+++ b/docs/engineering/harness-reuse-guide.md
@@ -19,6 +19,7 @@ Main components:
 
 - [AGENTS.md](/workspace/02-projects/incubation/openprecedent/AGENTS.md)
 - [.codex/skills/ccpm-codex/SKILL.md](/workspace/02-projects/incubation/openprecedent/.codex/skills/ccpm-codex/SKILL.md)
+- [.codex/skills/harness-gap-closure/SKILL.md](/workspace/02-projects/incubation/openprecedent/.codex/skills/harness-gap-closure/SKILL.md)
 - [codex_pm.py](/workspace/02-projects/incubation/openprecedent/src/openprecedent/codex_pm.py)
 - `.codex/pm/tasks/`
 - `.codex/pm/issue-state/`
@@ -32,6 +33,7 @@ Key capabilities:
 - explicit task types such as `implementation`, `docs`, `research`, and `umbrella`
 - PR-body and task-closure sync checks
 - repository-local PR creation that pins the upstream repo and fork head explicitly
+- a reusable workflow for turning repeated failures into harness hardening work
 
 ### 2. Local guardrail layer
 


### PR DESCRIPTION
Closes #142

Add a repository-local skill that guides Codex to diagnose, issue-track, implement, and regression-protect harness fixes.

Validation:
- manual review of the skill against recent harness hardening issues such as `#133`, `#136`, and `#139`