### PR TITLE
Preserve valid GitHub closing references in generated PR bodies

### DIFF
--- a/.codex/pm/tasks/real-history-quality/preserve-valid-github-closing-references-in-generated-pr-bodies.md
+++ b/.codex/pm/tasks/real-history-quality/preserve-valid-github-closing-references-in-generated-pr-bodies.md
@@ -1,0 +1,33 @@
+---
+type: task
+epic: real-history-quality
+slug: preserve-valid-github-closing-references-in-generated-pr-bodies
+title: Preserve valid GitHub closing references in generated PR bodies
+status: done
+labels: feature,test
+issue: 146
+---
+
+## Context
+
+The repository PR-creation harness generated a malformed PR body in PR #145, so GitHub did not auto-close issue #130 after merge.
+
+## Deliverable
+
+Make the PR-creation flow preserve clean multiline PR bodies and valid standalone closing references.
+
+## Scope
+
+- pass generated PR bodies to `gh pr create` through a temporary body file instead of an inline `--body` argument
+- filter placeholder-only validation bullets out of generated PR bodies
+- add regression coverage for clean closing references and preserved body formatting
+
+## Acceptance Criteria
+
+- generated PR bodies preserve normal multiline formatting
+- a trailing closing reference such as `Closes #123` is emitted as a clean standalone line
+- regression coverage would have caught the malformed PR body seen in PR #145
+
+## Validation
+
+- `PYTHONPATH=src .venv/bin/pytest tests/test_codex_pm.py -k 'pr_create or pr_body'`

--- a/src/openprecedent/codex_pm.py
+++ b/src/openprecedent/codex_pm.py
@@ -5,6 +5,7 @@ import json
 import re
 import subprocess
 import sys
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -582,7 +583,11 @@ def _render_pr_body(document: PMDocument, *, issue: int | None, tests: list[str]
     if validation or tests:
         lines.append("Validation:")
         if validation:
-            lines.extend(validation.splitlines())
+            for line in validation.splitlines():
+                stripped = line.strip()
+                if not stripped or stripped == "-":
+                    continue
+                lines.append(line)
         for test in tests:
             lines.append(f"- `{test}`")
     return "\n".join(lines).rstrip()
@@ -632,28 +637,34 @@ def _create_pr(
 
     pr_title = title or document.metadata.get("title") or document.path.stem
     pr_body = _render_pr_body(document, issue=issue, tests=tests)
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
+        handle.write(pr_body)
+        body_path = Path(handle.name)
 
-    result = subprocess.run(
-        [
-            "gh",
-            "pr",
-            "create",
-            "--repo",
-            base_repo,
-            "--base",
-            base_branch,
-            "--head",
-            f"{head_owner}:{branch}",
-            "--title",
-            pr_title,
-            "--body",
-            pr_body,
-        ],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    return result.stdout.strip()
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "create",
+                "--repo",
+                base_repo,
+                "--base",
+                base_branch,
+                "--head",
+                f"{head_owner}:{branch}",
+                "--title",
+                pr_title,
+                "--body-file",
+                str(body_path),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.strip()
+    finally:
+        body_path.unlink(missing_ok=True)
 
 
 def _parse_issue_number(value: str) -> int | None:

--- a/tests/test_codex_pm.py
+++ b/tests/test_codex_pm.py
@@ -515,6 +515,7 @@ def test_codex_pm_pr_create_uses_explicit_upstream_repo_and_fork_head(
     task_path = tmp_path / ".codex" / "pm" / "tasks" / "real-history-quality" / "pr-targeting.md"
 
     calls: list[list[str]] = []
+    captured_body: dict[str, str] = {}
 
     def fake_run(cmd: list[str], check: bool, capture_output: bool, text: bool):
         calls.append(cmd)
@@ -525,6 +526,8 @@ def test_codex_pm_pr_create_uses_explicit_upstream_repo_and_fork_head(
         if cmd == ["git", "remote", "get-url", "upstream"]:
             return subprocess.CompletedProcess(cmd, 0, stdout="https://github.com/openprecedent/openprecedent.git\n", stderr="")
         if cmd[:3] == ["gh", "pr", "create"]:
+            body_path = Path(cmd[cmd.index("--body-file") + 1])
+            captured_body["value"] = body_path.read_text(encoding="utf-8")
             return subprocess.CompletedProcess(cmd, 0, stdout="https://github.com/openprecedent/openprecedent/pull/999\n", stderr="")
         raise AssertionError(f"unexpected command: {cmd}")
 
@@ -549,6 +552,71 @@ def test_codex_pm_pr_create_uses_explicit_upstream_repo_and_fork_head(
     assert gh_call[gh_call.index("--repo") + 1] == "openprecedent/openprecedent"
     assert gh_call[gh_call.index("--head") + 1] == "yaoyinnan:codex/harden-pr-targeting"
     assert gh_call[gh_call.index("--base") + 1] == "main"
+    assert "--body-file" in gh_call
+    assert "--body" not in gh_call
+    assert "Closes #136" in captured_body["value"]
+    assert "- `PYTHONPATH=src .venv/bin/pytest tests/test_codex_pm.py`" in captured_body["value"]
+    assert "\\n" not in captured_body["value"]
+
+
+def test_codex_pm_pr_create_body_file_preserves_clean_closing_reference(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    assert main(["init"]) == 0
+    capsys.readouterr()
+    assert (
+        main(
+            [
+                "task-new",
+                "real-history-quality",
+                "closing-reference-preservation",
+                "--title",
+                "Preserve valid GitHub closing references in generated PR bodies",
+                "--issue",
+                "146",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    task_path = (
+        tmp_path
+        / ".codex"
+        / "pm"
+        / "tasks"
+        / "real-history-quality"
+        / "closing-reference-preservation.md"
+    )
+
+    captured_body: dict[str, str] = {}
+
+    def fake_run(cmd: list[str], check: bool, capture_output: bool, text: bool):
+        if cmd == ["git", "branch", "--show-current"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="codex/closing-reference-preservation\n", stderr="")
+        if cmd == ["git", "remote", "get-url", "origin"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="git@github.com:yaoyinnan/openprecedent.git\n", stderr="")
+        if cmd == ["git", "remote", "get-url", "upstream"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="https://github.com/openprecedent/openprecedent.git\n", stderr="")
+        if cmd[:3] == ["gh", "pr", "create"]:
+            body_path = Path(cmd[cmd.index("--body-file") + 1])
+            captured_body["value"] = body_path.read_text(encoding="utf-8")
+            return subprocess.CompletedProcess(cmd, 0, stdout="https://github.com/openprecedent/openprecedent/pull/1000\n", stderr="")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert main(["pr-create", str(task_path), "--tests", "echo done"]) == 0
+    body = captured_body["value"]
+
+    assert body.splitlines()[0] == "Closes #146"
+    assert body.splitlines()[-1] == "- `echo done`"
+    assert "\n\nValidation:\n- `echo done`" in body
+    assert "\\nCloses #146" not in body
 
 
 def test_codex_pm_pr_create_fails_when_origin_owner_is_ambiguous(


### PR DESCRIPTION
Closes #146

Make the PR-creation flow preserve clean multiline PR bodies and valid standalone closing references.

Validation:
- `PYTHONPATH=src .venv/bin/pytest tests/test_codex_pm.py -k 'pr_create or pr_body'`
- `PYTHONPATH=src .venv/bin/pytest tests/test_codex_pm.py -k 'pr_create or pr_body'`
- `./scripts/run-agent-preflight.sh`