### PR TITLE
Document and validate end-to-end Codex runtime recording startup

### DIFF
--- a/.codex/pm/tasks/codex-runtime-research/document-and-validate-end-to-end-codex-runtime-recording-startup.md
+++ b/.codex/pm/tasks/codex-runtime-research/document-and-validate-end-to-end-codex-runtime-recording-startup.md
@@ -1,0 +1,36 @@
+---
+type: task
+epic: codex-runtime-research
+slug: document-and-validate-end-to-end-codex-runtime-recording-startup
+title: Document and validate end-to-end Codex runtime recording startup
+status: done
+labels: docs,test,feature
+issue: 148
+depends_on: 130
+---
+
+## Context
+
+Codex minimal runtime support exists, but the repository still needs one practical guide that a human or agent can follow to start OpenPrecedent for Codex project work and verify that runtime recording is actually happening.
+
+## Deliverable
+
+Add one end-to-end startup guide for Codex runtime recording and validate the full startup-and-recording loop in the same PR.
+
+## Scope
+
+- write a practical guide for humans and agents
+- add a reusable repository-local Codex live-validation harness
+- record one durable startup validation artifact
+- file follow-up issues only if the validation reveals missing capabilities
+
+## Acceptance Criteria
+
+- one durable guide explains how to start OpenPrecedent for Codex project work and how to verify recording
+- the guide is usable by both humans and agents without hidden local context
+- the PR includes a documented end-to-end validation of multiple Codex runtime interactions producing inspectable records
+
+## Validation
+
+- `PYTHONPATH=src .venv/bin/pytest tests/test_codex_live_validation_script.py`
+- `PYTHONPATH=src .venv/bin/pytest tests/test_cli.py -k 'codex_runtime_decision_lineage_skill_exists'`

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ The repository now includes:
 - real OpenClaw runtime decision-lineage validation: [docs/engineering/openclaw-real-runtime-decision-lineage-validation.md](/workspace/02-projects/incubation/openprecedent/docs/engineering/openclaw-real-runtime-decision-lineage-validation.md)
 - Codex runtime research boundary: [docs/engineering/codex-runtime-boundary.md](/workspace/02-projects/incubation/openprecedent/docs/engineering/codex-runtime-boundary.md)
 - Codex runtime workflow: [docs/engineering/codex-runtime-decision-lineage-workflow.md](/workspace/02-projects/incubation/openprecedent/docs/engineering/codex-runtime-decision-lineage-workflow.md)
+- Codex runtime startup guide: [docs/engineering/codex-runtime-startup-guide.md](/workspace/02-projects/incubation/openprecedent/docs/engineering/codex-runtime-startup-guide.md)
+- Codex runtime startup validation: [docs/engineering/codex-runtime-startup-validation.md](/workspace/02-projects/incubation/openprecedent/docs/engineering/codex-runtime-startup-validation.md)
 
 For live OpenClaw skill installs, set `OPENPRECEDENT_HOME` to a stable shared directory so runtime brief lookups and invocation logs do not fall back to workspace-local files.
 

--- a/docs/engineering/codex-runtime-startup-guide.md
+++ b/docs/engineering/codex-runtime-startup-guide.md
@@ -1,0 +1,149 @@
+# Codex Runtime Startup Guide
+
+## Goal
+
+Show both a human operator and a Codex-driven workflow how to start OpenPrecedent for a new Codex project, request decision-lineage context during work, and verify that runtime records are actually being written.
+
+This is a practical startup guide.
+It is not a generic multi-agent integration manual.
+
+## What This Enables Today
+
+Today, Codex runtime support can do three concrete things:
+
+- use a shared `OPENPRECEDENT_HOME` for Codex runtime state
+- request semantic decision-lineage briefs during work
+- record each runtime invocation so it can be listed and inspected later
+
+It does not yet automatically ingest an entire new project's Codex transcript history continuously.
+The current runtime recording loop is centered on inspectable lineage requests.
+
+## Shared Runtime Setup
+
+Use a stable shared runtime home instead of letting each repository choose its own runtime database and log:
+
+```bash
+export OPENPRECEDENT_HOME="$HOME/.openprecedent/runtime"
+```
+
+With that one setting, Codex runtime use will share:
+
+- `$OPENPRECEDENT_HOME/openprecedent.db`
+- `$OPENPRECEDENT_HOME/openprecedent-runtime-invocations.jsonl`
+
+This is the recommended starting point for both humans and agents.
+
+## For Humans
+
+### 1. Start from the repository-local workflow
+
+Use:
+
+```bash
+./scripts/run-codex-decision-lineage-workflow.sh \
+  --query-reason initial_planning \
+  --task-summary "Describe the new project task here."
+```
+
+This will:
+
+- build a semantic decision-lineage brief from the shared runtime home
+- append a runtime invocation record to the shared invocation log
+
+### 2. Use the workflow at the right moments
+
+The current supported `query_reason` values are:
+
+- `initial_planning`
+- `before_file_write`
+- `after_failure`
+
+Typical examples:
+
+```bash
+./scripts/run-codex-decision-lineage-workflow.sh \
+  --query-reason before_file_write \
+  --task-summary "Stay within docs-only scope while updating the first project README." \
+  --current-plan "Draft the project README before any broader implementation." \
+  --candidate-action "Edit README.md"
+```
+
+```bash
+./scripts/run-codex-decision-lineage-workflow.sh \
+  --query-reason after_failure \
+  --task-summary "Recover from a broader implementation attempt and stay within the approved docs-only scope." \
+  --current-plan "Narrow back to documentation guidance." \
+  --candidate-action "Retry broad implementation changes"
+```
+
+### 3. Verify that recording is happening
+
+List recorded invocations:
+
+```bash
+openprecedent runtime list-decision-lineage-invocations
+```
+
+Inspect one invocation:
+
+```bash
+openprecedent runtime inspect-decision-lineage-invocation \
+  --invocation-id <invocation_id>
+```
+
+You should see:
+
+- `query_reason`
+- `task_summary`
+- matched case ids
+- semantic brief content such as constraints and authority signals
+
+## For Agents
+
+Treat OpenPrecedent as a semantic judgment layer, not as a tool-selection engine.
+
+An agent should:
+
+- use `initial_planning` when it needs prior framing before work starts
+- use `before_file_write` when a risky change should be checked against prior approvals or scope limits
+- use `after_failure` when the failure is directional or semantic, not just transient execution noise
+- continue normally if the returned brief is empty
+
+An agent should not:
+
+- use OpenPrecedent to imitate old tool choices mechanically
+- call the workflow on every turn
+- treat the brief as a replacement for current local context
+
+## End-To-End Startup Harness
+
+For a repeatable startup-and-recording validation flow, use:
+
+```bash
+./scripts/run-codex-live-validation.sh
+```
+
+By default this prepares a workspace under `/tmp/openprecedent-codex-live` with:
+
+- `runtime-home/` for the shared Codex runtime home
+- `prompts/` with three round prompts
+- `output/manifest.json`
+- `output/20-invocation-list.json`
+- `output/21-latest-invocation-summary.json`
+- `next-steps.txt`
+
+If you want the harness to execute a three-round repository-local validation automatically, run:
+
+```bash
+OPENPRECEDENT_CODEX_LIVE_RESET=1 \
+OPENPRECEDENT_CODEX_LIVE_AUTO_RUN=1 \
+./scripts/run-codex-live-validation.sh
+```
+
+That path is useful for validating that startup, runtime recording, listing, and inspection are all wired correctly before using the workflow in a different project.
+
+## Read Next
+
+- [codex-runtime-decision-lineage-workflow.md](/workspace/02-projects/incubation/openprecedent/docs/engineering/codex-runtime-decision-lineage-workflow.md)
+- [codex-runtime-boundary.md](/workspace/02-projects/incubation/openprecedent/docs/engineering/codex-runtime-boundary.md)
+- [codex-runtime-startup-validation.md](/workspace/02-projects/incubation/openprecedent/docs/engineering/codex-runtime-startup-validation.md)

--- a/docs/engineering/codex-runtime-startup-validation.md
+++ b/docs/engineering/codex-runtime-startup-validation.md
@@ -1,0 +1,96 @@
+# Codex Runtime Startup Validation
+
+## Goal
+
+Record one durable end-to-end validation of the current Codex startup flow for OpenPrecedent.
+
+The question under test was:
+
+Can a new Codex project start from the documented runtime setup, run several decision-lineage requests, and verify that those requests are recorded and inspectable?
+
+## Method
+
+The validation used the repository-local harness:
+
+```bash
+OPENPRECEDENT_CODEX_LIVE_RESET=1 \
+OPENPRECEDENT_CODEX_LIVE_AUTO_RUN=1 \
+./scripts/run-codex-live-validation.sh
+```
+
+This run:
+
+- prepared a fresh shared runtime home
+- seeded prior Codex precedent fixtures into that runtime home
+- executed three runtime workflow rounds
+- listed the resulting runtime invocations
+- inspected the latest invocation
+
+## Round Coverage
+
+The run covered three Codex runtime interaction points:
+
+1. `initial_planning`
+2. `before_file_write`
+3. `after_failure`
+
+This is enough to prove the current startup-and-recording loop, even though it is still narrower than a full long-running real project study.
+
+## Observed Result
+
+The current flow worked end to end.
+
+Observed outcomes:
+
+- the shared runtime home was created successfully
+- prior Codex precedent history was seeded successfully
+- three runtime invocations were recorded
+- `list-decision-lineage-invocations` returned those records
+- `inspect-decision-lineage-invocation` returned the latest invocation as an inspectable artifact
+- the latest invocation still contained semantic matched case ids rather than empty output
+
+The recorded query-reason sequence for the validation run was:
+
+1. `initial_planning`
+2. `before_file_write`
+3. `after_failure`
+
+The latest invocation summary reported:
+
+- `invocation_count = 3`
+- `latest_query_reason = after_failure`
+- non-empty matched case ids:
+  - `case_codex_live_semantic`
+  - `case_codex_live_current`
+  - `case_codex_live_operational`
+
+## Why This Matters
+
+This validation proves that a new project can start from:
+
+- one shared runtime home
+- one repository-local Codex workflow entrypoint
+- one inspection path for verifying records
+
+That is the minimum startup loop needed before `#131` can be executed in a later real project.
+
+## Current Limits
+
+This validation does not prove:
+
+- natural long-running Codex behavior in a second real project
+- cross-project portability of semantic decision lineage
+- continuous automatic Codex history capture
+
+Those remain part of `#131` and `#100`.
+
+## Artifacts Produced By The Harness
+
+The validation harness writes:
+
+- `output/manifest.json`
+- `output/20-invocation-list.json`
+- `output/21-latest-invocation-summary.json`
+- `output/22-latest-invocation-inspection.json`
+
+These are the files a human or agent should inspect first when verifying a new Codex runtime setup.

--- a/docs/engineering/using-openprecedent.md
+++ b/docs/engineering/using-openprecedent.md
@@ -289,6 +289,8 @@ For Codex-driven development work, the repository-local runtime workflow is:
 That workflow is documented here:
 
 - [codex-runtime-decision-lineage-workflow.md](/workspace/02-projects/incubation/openprecedent/docs/engineering/codex-runtime-decision-lineage-workflow.md)
+- [codex-runtime-startup-guide.md](/workspace/02-projects/incubation/openprecedent/docs/engineering/codex-runtime-startup-guide.md)
+- [codex-runtime-startup-validation.md](/workspace/02-projects/incubation/openprecedent/docs/engineering/codex-runtime-startup-validation.md)
 - [SKILL.md](/workspace/02-projects/incubation/openprecedent/.codex/skills/codex-runtime-decision-lineage/SKILL.md)
 
 ### Runtime decision-lineage brief

--- a/scripts/run-codex-live-validation.sh
+++ b/scripts/run-codex-live-validation.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if [[ -n "${OPENPRECEDENT_BIN:-}" ]]; then
+  OPENPRECEDENT_BIN="$OPENPRECEDENT_BIN"
+elif [[ -x "$ROOT_DIR/.venv/bin/openprecedent" ]]; then
+  OPENPRECEDENT_BIN="$ROOT_DIR/.venv/bin/openprecedent"
+else
+  OPENPRECEDENT_BIN="openprecedent"
+fi
+
+PYTHON_BIN="${OPENPRECEDENT_PYTHON_BIN:-$ROOT_DIR/.venv/bin/python}"
+if [[ ! -x "$PYTHON_BIN" ]]; then
+  PYTHON_BIN="python3"
+fi
+
+export PYTHONPATH="$ROOT_DIR/src${PYTHONPATH:+:$PYTHONPATH}"
+
+LIVE_ROOT="${OPENPRECEDENT_CODEX_LIVE_ROOT:-/tmp/openprecedent-codex-live}"
+RUNTIME_HOME="${OPENPRECEDENT_CODEX_LIVE_RUNTIME_HOME:-$LIVE_ROOT/runtime-home}"
+OUTPUT_ROOT="$LIVE_ROOT/output"
+PROMPTS_ROOT="$LIVE_ROOT/prompts"
+RESET="${OPENPRECEDENT_CODEX_LIVE_RESET:-0}"
+AUTO_RUN="${OPENPRECEDENT_CODEX_LIVE_AUTO_RUN:-0}"
+
+SEED_CURRENT_FIXTURE="${OPENPRECEDENT_CODEX_LIVE_SEED_CURRENT_FIXTURE:-$ROOT_DIR/tests/fixtures/codex_rollout_precedent_current.jsonl}"
+SEED_SEMANTIC_FIXTURE="${OPENPRECEDENT_CODEX_LIVE_SEED_SEMANTIC_FIXTURE:-$ROOT_DIR/tests/fixtures/codex_rollout_precedent_semantic_match.jsonl}"
+SEED_OPERATIONAL_FIXTURE="${OPENPRECEDENT_CODEX_LIVE_SEED_OPERATIONAL_FIXTURE:-$ROOT_DIR/tests/fixtures/codex_rollout_precedent_operational_overlap.jsonl}"
+
+if [[ "$RESET" == "1" ]]; then
+  rm -rf "$LIVE_ROOT"
+fi
+
+mkdir -p "$RUNTIME_HOME" "$OUTPUT_ROOT" "$PROMPTS_ROOT"
+
+run_openprecedent() {
+  OPENPRECEDENT_HOME="$RUNTIME_HOME" "$OPENPRECEDENT_BIN" "$@"
+}
+
+run_workflow() {
+  OPENPRECEDENT_HOME="$RUNTIME_HOME" \
+  OPENPRECEDENT_PYTHON_BIN="$PYTHON_BIN" \
+  ./scripts/run-codex-decision-lineage-workflow.sh "$@"
+}
+
+write_prompt_files() {
+  cat >"$PROMPTS_ROOT/01-initial-planning.txt" <<'EOF'
+Use prior Codex lineage before planning.
+Stay within docs-only scope and provide a short written recommendation.
+EOF
+
+  cat >"$PROMPTS_ROOT/02-before-file-write.txt" <<'EOF'
+Before writing a file, check whether prior Codex lineage narrows the scope or confirms approval.
+Use this before any risky file write.
+EOF
+
+  cat >"$PROMPTS_ROOT/03-after-failure.txt" <<'EOF'
+After a directional failure, request prior Codex lineage to recover without widening scope.
+Do not use this for transient command noise.
+EOF
+}
+
+seed_history() {
+  run_openprecedent runtime import-codex-rollout \
+    "$SEED_CURRENT_FIXTURE" \
+    --case-id case_codex_live_current \
+    --title "Codex live seed current" \
+    >"$OUTPUT_ROOT/01-seed-current.json"
+  run_openprecedent extract decisions case_codex_live_current \
+    >"$OUTPUT_ROOT/02-seed-current-decisions.json"
+
+  run_openprecedent runtime import-codex-rollout \
+    "$SEED_SEMANTIC_FIXTURE" \
+    --case-id case_codex_live_semantic \
+    --title "Codex live seed semantic" \
+    >"$OUTPUT_ROOT/03-seed-semantic.json"
+  run_openprecedent extract decisions case_codex_live_semantic \
+    >"$OUTPUT_ROOT/04-seed-semantic-decisions.json"
+
+  run_openprecedent runtime import-codex-rollout \
+    "$SEED_OPERATIONAL_FIXTURE" \
+    --case-id case_codex_live_operational \
+    --title "Codex live seed operational" \
+    >"$OUTPUT_ROOT/05-seed-operational.json"
+  run_openprecedent extract decisions case_codex_live_operational \
+    >"$OUTPUT_ROOT/06-seed-operational-decisions.json"
+}
+
+run_validation_rounds() {
+  run_workflow \
+    --query-reason initial_planning \
+    --task-summary "Do not edit code. Provide a short written recommendation only and keep it consistent with earlier Codex runtime decisions." \
+    >"$OUTPUT_ROOT/10-initial-planning-brief.json"
+
+  run_workflow \
+    --query-reason before_file_write \
+    --task-summary "Stay within docs-only scope. Before writing README.md, confirm whether prior Codex lineage narrows the allowed change." \
+    --current-plan "Draft a short docs-only recommendation before any edits." \
+    --candidate-action "Edit README.md" \
+    >"$OUTPUT_ROOT/11-before-file-write-brief.json"
+
+  run_workflow \
+    --inspect-latest \
+    --query-reason after_failure \
+    --task-summary "A broader implementation path was rejected. Recover with prior Codex lineage and stay within docs-only scope." \
+    --current-plan "Recover from a broader path by narrowing back to documentation guidance." \
+    --candidate-action "Retry broad implementation changes" \
+    >"$OUTPUT_ROOT/12-after-failure-and-inspect.json"
+}
+
+write_manifest() {
+  python3 - "$OUTPUT_ROOT/manifest.json" <<'PY'
+import json
+import os
+import sys
+
+manifest = {
+    "live_root": os.environ["LIVE_ROOT"],
+    "runtime_home": os.environ["RUNTIME_HOME"],
+    "output_root": os.environ["OUTPUT_ROOT"],
+    "prompts_root": os.environ["PROMPTS_ROOT"],
+    "auto_run": os.environ["AUTO_RUN"] == "1",
+}
+with open(sys.argv[1], "w", encoding="utf-8") as handle:
+    json.dump(manifest, handle, ensure_ascii=True, indent=2, sort_keys=True)
+    handle.write("\n")
+PY
+}
+
+write_invocation_artifacts() {
+  run_openprecedent runtime list-decision-lineage-invocations \
+    >"$OUTPUT_ROOT/20-invocation-list.json"
+
+  python3 - "$OUTPUT_ROOT/20-invocation-list.json" "$OUTPUT_ROOT/21-latest-invocation-summary.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+items = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+summary = {
+    "invocation_count": len(items),
+    "latest_invocation_id": None,
+    "latest_query_reason": None,
+    "latest_matched_case_ids": [],
+    "latest_task_summary": None,
+}
+if items:
+    latest = items[-1]
+    summary.update(
+        {
+            "latest_invocation_id": latest.get("invocation_id"),
+            "latest_query_reason": latest.get("query_reason"),
+            "latest_matched_case_ids": latest.get("matched_case_ids", []),
+            "latest_task_summary": latest.get("task_summary"),
+        }
+    )
+
+Path(sys.argv[2]).write_text(json.dumps(summary, ensure_ascii=True, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+
+  python3 - "$OUTPUT_ROOT/20-invocation-list.json" <<'PY' >"$OUTPUT_ROOT/.latest-invocation-id"
+import json
+import sys
+from pathlib import Path
+
+items = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+if items:
+    print(items[-1]["invocation_id"])
+PY
+
+  if [[ -s "$OUTPUT_ROOT/.latest-invocation-id" ]]; then
+    run_openprecedent runtime inspect-decision-lineage-invocation \
+      --invocation-id "$(cat "$OUTPUT_ROOT/.latest-invocation-id")" \
+      >"$OUTPUT_ROOT/22-latest-invocation-inspection.json"
+  fi
+  rm -f "$OUTPUT_ROOT/.latest-invocation-id"
+}
+
+write_next_steps() {
+  cat >"$LIVE_ROOT/next-steps.txt" <<EOF
+Codex live validation workspace: $LIVE_ROOT
+
+1. Export the shared runtime home:
+   export OPENPRECEDENT_HOME="$RUNTIME_HOME"
+
+2. Read the round prompts under:
+   $PROMPTS_ROOT
+
+3. During real Codex work, call:
+   ./scripts/run-codex-decision-lineage-workflow.sh --query-reason <reason> --task-summary "<summary>"
+
+4. Re-run this harness with OPENPRECEDENT_CODEX_LIVE_AUTO_RUN=0 to refresh the invocation artifacts:
+   ./scripts/run-codex-live-validation.sh
+
+5. Inspect:
+   $OUTPUT_ROOT/20-invocation-list.json
+   $OUTPUT_ROOT/21-latest-invocation-summary.json
+   $OUTPUT_ROOT/22-latest-invocation-inspection.json
+EOF
+}
+
+export LIVE_ROOT RUNTIME_HOME OUTPUT_ROOT PROMPTS_ROOT AUTO_RUN
+
+write_prompt_files
+seed_history
+if [[ "$AUTO_RUN" == "1" ]]; then
+  run_validation_rounds
+fi
+write_manifest
+write_invocation_artifacts
+write_next_steps
+
+echo "Codex live validation workspace prepared."
+echo "Workspace: $LIVE_ROOT"
+echo "Artifacts:"
+echo "  $OUTPUT_ROOT/manifest.json"
+echo "  $OUTPUT_ROOT/20-invocation-list.json"
+echo "  $OUTPUT_ROOT/21-latest-invocation-summary.json"
+if [[ -f "$OUTPUT_ROOT/22-latest-invocation-inspection.json" ]]; then
+  echo "  $OUTPUT_ROOT/22-latest-invocation-inspection.json"
+fi

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1157,6 +1157,27 @@ def test_codex_runtime_decision_lineage_skill_exists() -> None:
     assert "python3 -m openprecedent.cli runtime" not in workflow
 
 
+def test_codex_runtime_startup_docs_exist() -> None:
+    repo_root = Path(__file__).parent.parent
+    guide_path = repo_root / "docs" / "engineering" / "codex-runtime-startup-guide.md"
+    validation_path = repo_root / "docs" / "engineering" / "codex-runtime-startup-validation.md"
+    readme_path = repo_root / "README.md"
+    usage_path = repo_root / "docs" / "engineering" / "using-openprecedent.md"
+
+    guide = guide_path.read_text(encoding="utf-8")
+    validation = validation_path.read_text(encoding="utf-8")
+    readme = readme_path.read_text(encoding="utf-8")
+    usage = usage_path.read_text(encoding="utf-8")
+
+    assert "./scripts/run-codex-live-validation.sh" in guide
+    assert "For Humans" in guide
+    assert "For Agents" in guide
+    assert "three runtime invocations were recorded" in validation
+    assert "Codex runtime startup guide" in readme
+    assert "codex-runtime-startup-guide.md" in usage
+    assert "codex-runtime-startup-validation.md" in usage
+
+
 def test_tooling_setup_mentions_live_validation_skill() -> None:
     path = Path(__file__).parent.parent / "docs" / "engineering" / "tooling-setup.md"
 

--- a/tests/test_codex_live_validation_script.py
+++ b/tests/test_codex_live_validation_script.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+def test_codex_live_validation_script_records_multiple_invocations(tmp_path: Path) -> None:
+    repo_root = Path(__file__).parent.parent
+    env = os.environ.copy()
+    env["OPENPRECEDENT_CODEX_LIVE_ROOT"] = str(tmp_path / "codex-live")
+    env["OPENPRECEDENT_CODEX_LIVE_RESET"] = "1"
+    env["OPENPRECEDENT_CODEX_LIVE_AUTO_RUN"] = "1"
+    env["PYTHONPATH"] = str(repo_root / "src")
+
+    result = subprocess.run(
+        ["./scripts/run-codex-live-validation.sh"],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    output_root = Path(env["OPENPRECEDENT_CODEX_LIVE_ROOT"]) / "output"
+    manifest = json.loads((output_root / "manifest.json").read_text(encoding="utf-8"))
+    invocation_list = json.loads((output_root / "20-invocation-list.json").read_text(encoding="utf-8"))
+    summary = json.loads((output_root / "21-latest-invocation-summary.json").read_text(encoding="utf-8"))
+    inspection = json.loads((output_root / "22-latest-invocation-inspection.json").read_text(encoding="utf-8"))
+
+    assert manifest["auto_run"] is True
+    assert manifest["runtime_home"] == str(Path(env["OPENPRECEDENT_CODEX_LIVE_ROOT"]) / "runtime-home")
+    assert len(invocation_list) == 3
+    assert summary["invocation_count"] == 3
+    assert summary["latest_query_reason"] == "after_failure"
+    assert summary["latest_matched_case_ids"]
+    assert inspection["invocation"]["query_reason"] == "after_failure"
+    assert (Path(env["OPENPRECEDENT_CODEX_LIVE_ROOT"]) / "prompts" / "01-initial-planning.txt").exists()
+    assert (Path(env["OPENPRECEDENT_CODEX_LIVE_ROOT"]) / "next-steps.txt").exists()


### PR DESCRIPTION
Closes #148

Add one end-to-end startup guide for Codex runtime recording and validate the full startup-and-recording loop in the same PR.

Validation:
- `PYTHONPATH=src .venv/bin/pytest tests/test_codex_live_validation_script.py`
- `PYTHONPATH=src .venv/bin/pytest tests/test_cli.py -k 'codex_runtime_decision_lineage_skill_exists'`
- `PYTHONPATH=src .venv/bin/pytest tests/test_codex_live_validation_script.py`
- `PYTHONPATH=src .venv/bin/pytest tests/test_cli.py -k 'codex_runtime_decision_lineage_skill_exists or codex_runtime_startup_docs_exist'`
- `./scripts/run-agent-preflight.sh`