### PR TITLE
feat: validate HarnessHub matched case retrieval

### DIFF
--- a/.codex/pm/issue-state/154-validate-non-empty-matched-case-ids-for-a-later-harnesshub-runtime-query.md
+++ b/.codex/pm/issue-state/154-validate-non-empty-matched-case-ids-for-a-later-harnesshub-runtime-query.md
@@ -1,0 +1,33 @@
+---
+type: issue_state
+issue: 154
+task: .codex/pm/tasks/codex-runtime-research/validate-non-empty-matched-case-ids-for-a-later-harnesshub-runtime-query.md
+title: Validate non-empty matched_case_ids for a later HarnessHub runtime query
+status: done
+---
+
+## Summary
+
+Validate that imported HarnessHub searchable history produces non-empty `matched_case_ids` for a later semantically related runtime query.
+
+## Validated Facts
+
+- Issue `#153` now imports exported HarnessHub round bundles into a runtime and extracts searchable decisions.
+- The next missing proof point is a later runtime query that actually retrieves one of those imported cases.
+- `scripts/run-harnesshub-matched-case-validation.sh` now imports one prior HarnessHub round bundle, runs a later semantically related runtime query, and writes brief plus invocation artifacts.
+- Regression coverage now verifies non-empty `matched_case_ids` in an isolated runtime.
+- Real validation against the exported HarnessHub issue `#53` bundle produced non-empty `matched_case_ids` pointing to `case_harnesshub_issue_53_refine-verification-into-explicit-readiness-clas`.
+
+## Open Questions
+
+- Retrieval quality still depends on lexical overlap; follow-up issue `#155` should improve matching beyond the stable wording used here.
+
+## Next Steps
+
+- open the issue-scoped PR for `#154`
+- continue to follow-up retrieval-quality work in `#155`
+
+## Artifacts
+
+- `scripts/run-harnesshub-matched-case-validation.sh`
+- `tests/test_harnesshub_matched_case_validation_script.py`

--- a/.codex/pm/tasks/codex-runtime-research/validate-non-empty-matched-case-ids-for-a-later-harnesshub-runtime-query.md
+++ b/.codex/pm/tasks/codex-runtime-research/validate-non-empty-matched-case-ids-for-a-later-harnesshub-runtime-query.md
@@ -1,0 +1,45 @@
+---
+type: task
+epic: codex-runtime-research
+slug: validate-non-empty-matched-case-ids-for-a-later-harnesshub-runtime-query
+title: Validate non-empty matched_case_ids for a later HarnessHub runtime query
+status: done
+task_type: implementation
+labels: feature,test
+depends_on: 153
+issue: 154
+state_path: .codex/pm/issue-state/154-validate-non-empty-matched-case-ids-for-a-later-harnesshub-runtime-query.md
+---
+
+## Context
+
+Issue `#153` populates the shared runtime with searchable HarnessHub history, but the research loop is still incomplete until a later runtime query actually retrieves that prior history as non-empty `matched_case_ids`.
+
+## Deliverable
+
+Add a minimal HarnessHub validation flow that seeds one imported prior round, runs a later semantically related runtime query, and records non-empty `matched_case_ids` as durable output.
+
+## Scope
+
+- import one exported HarnessHub round bundle into an isolated runtime
+- run one later semantically related runtime decision-lineage query
+- capture invocation summary and inspection artifacts showing non-empty matched case ids
+
+## Acceptance Criteria
+
+- at least one later HarnessHub runtime invocation records non-empty `matched_case_ids`
+- the matched case is traceable to the imported prior HarnessHub round bundle
+- the validation flow is covered by a regression test
+
+## Validation
+
+- run the new HarnessHub matched-case validation harness
+- verify the summary artifact contains non-empty `latest_matched_case_ids`
+- verify the inspection artifact points back to the imported HarnessHub case id
+
+## Implementation Notes
+
+- Keep this issue focused on validation and evidence production, not retrieval-quality tuning.
+- Implemented via `scripts/run-harnesshub-matched-case-validation.sh`.
+- Regression coverage added in `tests/test_harnesshub_matched_case_validation_script.py`.
+- Real validation against the exported HarnessHub issue `#53` bundle produced non-empty `matched_case_ids` pointing back to the imported prior round.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -11,5 +11,6 @@ Notable operational entrypoints:
 - `run-codex-review-checkpoint.sh` creates or refreshes the local review note and the current-HEAD review proof before invoking native Codex `/review`
 - `export_harnesshub_codex_round.py` exports one completed HarnessHub Codex development round as a minimal importable searchable-history bundle
 - `import_harnesshub_codex_round.py` imports one exported HarnessHub round bundle into the shared runtime and extracts decisions
+- `run-harnesshub-matched-case-validation.sh` imports one prior HarnessHub round bundle, runs a later semantically related runtime query, and writes matched-case summary artifacts
 - `triage_pr_checks.py` summarizes and classifies current PR check results for faster CI diagnosis
 - `install-collector-assets.sh` renders `systemd` / `cron` assets against the current repo path

--- a/scripts/run-harnesshub-matched-case-validation.sh
+++ b/scripts/run-harnesshub-matched-case-validation.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if [[ -n "${OPENPRECEDENT_BIN:-}" ]]; then
+  OPENPRECEDENT_BIN="$OPENPRECEDENT_BIN"
+elif [[ -x "$ROOT_DIR/.venv/bin/openprecedent" ]]; then
+  OPENPRECEDENT_BIN="$ROOT_DIR/.venv/bin/openprecedent"
+elif [[ -x "$ROOT_DIR/../openprecedent/.venv/bin/openprecedent" ]]; then
+  OPENPRECEDENT_BIN="$ROOT_DIR/../openprecedent/.venv/bin/openprecedent"
+else
+  OPENPRECEDENT_BIN="openprecedent"
+fi
+
+if [[ -n "${OPENPRECEDENT_PYTHON_BIN:-}" ]]; then
+  PYTHON_BIN="$OPENPRECEDENT_PYTHON_BIN"
+elif [[ -x "$ROOT_DIR/.venv/bin/python" ]]; then
+  PYTHON_BIN="$ROOT_DIR/.venv/bin/python"
+elif [[ -x "$ROOT_DIR/../openprecedent/.venv/bin/python" ]]; then
+  PYTHON_BIN="$ROOT_DIR/../openprecedent/.venv/bin/python"
+else
+  PYTHON_BIN="python3"
+fi
+
+LIVE_ROOT="${OPENPRECEDENT_HARNESSHUB_MATCH_ROOT:-/tmp/openprecedent-harnesshub-match}"
+RUNTIME_HOME="${OPENPRECEDENT_HARNESSHUB_MATCH_RUNTIME_HOME:-$LIVE_ROOT/runtime-home}"
+OUTPUT_ROOT="$LIVE_ROOT/output"
+RESET="${OPENPRECEDENT_HARNESSHUB_MATCH_RESET:-0}"
+BUNDLE_DIR="${OPENPRECEDENT_HARNESSHUB_BUNDLE_DIR:-$ROOT_DIR/research-artifacts/harnesshub-rounds/issue-53-refine-verification-into-explicit-readiness-clas-2026-03-12T082148Z}"
+QUERY_REASON="${OPENPRECEDENT_HARNESSHUB_QUERY_REASON:-before_file_write}"
+TASK_SUMMARY="${OPENPRECEDENT_HARNESSHUB_TASK_SUMMARY:-HarnessHub later task: refine verify output so imported images report explicit readiness classes instead of a binary runtimeReady signal.}"
+CURRENT_PLAN="${OPENPRECEDENT_HARNESSHUB_CURRENT_PLAN:-Keep the verification scope narrow and map current runtime-readiness issues into explicit readiness classes for operators.}"
+CANDIDATE_ACTION="${OPENPRECEDENT_HARNESSHUB_CANDIDATE_ACTION:-Update verification output and tests to describe explicit readiness classes.}"
+KNOWN_FILES="${OPENPRECEDENT_HARNESSHUB_KNOWN_FILES:-HarnessHub/src/core/verifier.ts,HarnessHub/test/e2e.test.ts}"
+
+if [[ "$RESET" == "1" ]]; then
+  rm -rf "$LIVE_ROOT"
+fi
+
+mkdir -p "$RUNTIME_HOME" "$OUTPUT_ROOT"
+export PYTHONPATH="$ROOT_DIR/src${PYTHONPATH:+:$PYTHONPATH}"
+export LIVE_ROOT RUNTIME_HOME OUTPUT_ROOT BUNDLE_DIR
+
+IFS=',' read -r -a KNOWN_FILE_ARGS <<<"$KNOWN_FILES"
+
+run_openprecedent() {
+  OPENPRECEDENT_HOME="$RUNTIME_HOME" "$OPENPRECEDENT_BIN" "$@"
+}
+
+run_workflow() {
+  OPENPRECEDENT_HOME="$RUNTIME_HOME" \
+  OPENPRECEDENT_PYTHON_BIN="$PYTHON_BIN" \
+  ./scripts/run-codex-decision-lineage-workflow.sh "$@"
+}
+
+"$PYTHON_BIN" scripts/import_harnesshub_codex_round.py \
+  --bundle-dir "$BUNDLE_DIR" \
+  --runtime-home "$RUNTIME_HOME" \
+  --python-bin "$PYTHON_BIN" \
+  --skip-if-case-exists \
+  >"$OUTPUT_ROOT/01-import-summary.json"
+
+WORKFLOW_ARGS=(
+  --query-reason "$QUERY_REASON"
+  --task-summary "$TASK_SUMMARY"
+  --current-plan "$CURRENT_PLAN"
+  --candidate-action "$CANDIDATE_ACTION"
+)
+
+for file in "${KNOWN_FILE_ARGS[@]}"; do
+  if [[ -n "$file" ]]; then
+    WORKFLOW_ARGS+=(--known-file "$file")
+  fi
+done
+
+run_workflow "${WORKFLOW_ARGS[@]}" >"$OUTPUT_ROOT/10-brief.json"
+run_openprecedent runtime list-decision-lineage-invocations >"$OUTPUT_ROOT/20-invocation-list.json"
+
+"$PYTHON_BIN" - "$BUNDLE_DIR/round-manifest.json" "$OUTPUT_ROOT/20-invocation-list.json" "$OUTPUT_ROOT/21-latest-invocation-summary.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+invocations = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+latest = invocations[-1] if invocations else {}
+summary = {
+    "bundle_case_id": manifest["case_id"],
+    "invocation_count": len(invocations),
+    "latest_invocation_id": latest.get("invocation_id"),
+    "latest_query_reason": latest.get("query_reason"),
+    "latest_matched_case_ids": latest.get("matched_case_ids", []),
+    "latest_task_summary": latest.get("task_summary"),
+}
+Path(sys.argv[3]).write_text(json.dumps(summary, ensure_ascii=True, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+
+"$PYTHON_BIN" - "$OUTPUT_ROOT/20-invocation-list.json" <<'PY' >"$OUTPUT_ROOT/.latest-invocation-id"
+import json
+import sys
+from pathlib import Path
+
+items = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+if items:
+    print(items[-1]["invocation_id"])
+PY
+
+if [[ -s "$OUTPUT_ROOT/.latest-invocation-id" ]]; then
+  run_openprecedent runtime inspect-decision-lineage-invocation \
+    --invocation-id "$(cat "$OUTPUT_ROOT/.latest-invocation-id")" \
+    >"$OUTPUT_ROOT/22-latest-invocation-inspection.json"
+fi
+rm -f "$OUTPUT_ROOT/.latest-invocation-id"
+
+"$PYTHON_BIN" - "$BUNDLE_DIR/round-manifest.json" "$OUTPUT_ROOT/manifest.json" <<'PY'
+import json
+import os
+import sys
+from pathlib import Path
+
+bundle_manifest = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+manifest = {
+    "live_root": os.environ["LIVE_ROOT"],
+    "runtime_home": os.environ["RUNTIME_HOME"],
+    "output_root": os.environ["OUTPUT_ROOT"],
+    "bundle_dir": os.environ["BUNDLE_DIR"],
+    "bundle_case_id": bundle_manifest["case_id"],
+}
+Path(sys.argv[2]).write_text(json.dumps(manifest, ensure_ascii=True, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+
+echo "HarnessHub matched-case validation workspace prepared."
+echo "Workspace: $LIVE_ROOT"
+echo "Artifacts:"
+echo "  $OUTPUT_ROOT/manifest.json"
+echo "  $OUTPUT_ROOT/01-import-summary.json"
+echo "  $OUTPUT_ROOT/10-brief.json"
+echo "  $OUTPUT_ROOT/20-invocation-list.json"
+echo "  $OUTPUT_ROOT/21-latest-invocation-summary.json"
+echo "  $OUTPUT_ROOT/22-latest-invocation-inspection.json"

--- a/tests/test_harnesshub_matched_case_validation_script.py
+++ b/tests/test_harnesshub_matched_case_validation_script.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+def test_harnesshub_matched_case_validation_produces_non_empty_matches(tmp_path: Path) -> None:
+    repo_root = Path(__file__).parent.parent
+    python_bin = repo_root / ".venv" / "bin" / "python"
+    openprecedent_bin = repo_root / ".venv" / "bin" / "openprecedent"
+    if not python_bin.exists():
+        python_bin = repo_root.parent / "openprecedent" / ".venv" / "bin" / "python"
+        openprecedent_bin = repo_root.parent / "openprecedent" / ".venv" / "bin" / "openprecedent"
+
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+    case_id = "case_harnesshub_issue_53_readiness"
+    (bundle_dir / "round-manifest.json").write_text(
+        json.dumps(
+            {
+                "case_id": case_id,
+                "case_title": "HarnessHub issue #53: Refine verification into explicit readiness classes",
+                "import_hints": {
+                    "agent_id": "codex",
+                    "event_import_path": "events.jsonl",
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (bundle_dir / "events.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "case_id": case_id,
+                        "event_id": f"{case_id}-1",
+                        "event_type": "case.started",
+                        "actor": "system",
+                        "timestamp": "2026-03-12T07:41:00Z",
+                        "sequence_no": 1,
+                        "payload": {"source": "test"},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "case_id": case_id,
+                        "event_id": f"{case_id}-2",
+                        "event_type": "message.user",
+                        "actor": "user",
+                        "timestamp": "2026-03-12T07:41:30Z",
+                        "sequence_no": 2,
+                        "payload": {
+                            "message": "Issue #53: refine verification into explicit readiness classes. Focus only on verification output, imported images, runtime-readiness issues, and tests."
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "case_id": case_id,
+                        "event_id": f"{case_id}-3",
+                        "event_type": "message.agent",
+                        "actor": "agent",
+                        "timestamp": "2026-03-12T07:42:00Z",
+                        "sequence_no": 3,
+                        "payload": {
+                            "message": "I will keep the verification scope narrow and map runtime-readiness issues into explicit readiness classes for imported images."
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "case_id": case_id,
+                        "event_id": f"{case_id}-4",
+                        "event_type": "case.completed",
+                        "actor": "system",
+                        "timestamp": "2026-03-12T07:46:00Z",
+                        "sequence_no": 4,
+                        "payload": {"message": "Completed HarnessHub issue #53."},
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    live_root = tmp_path / "live"
+    env = os.environ.copy()
+    env["OPENPRECEDENT_HARNESSHUB_MATCH_ROOT"] = str(live_root)
+    env["OPENPRECEDENT_HARNESSHUB_MATCH_RESET"] = "1"
+    env["OPENPRECEDENT_HARNESSHUB_BUNDLE_DIR"] = str(bundle_dir)
+    env["OPENPRECEDENT_BIN"] = str(openprecedent_bin)
+    env["OPENPRECEDENT_PYTHON_BIN"] = str(python_bin)
+    env["PYTHONPATH"] = str(repo_root / "src")
+
+    result = subprocess.run(
+        ["./scripts/run-harnesshub-matched-case-validation.sh"],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    output_root = live_root / "output"
+    brief = json.loads((output_root / "10-brief.json").read_text(encoding="utf-8"))
+    summary = json.loads((output_root / "21-latest-invocation-summary.json").read_text(encoding="utf-8"))
+    inspection = json.loads((output_root / "22-latest-invocation-inspection.json").read_text(encoding="utf-8"))
+
+    assert brief["matched_cases"][0]["case_id"] == case_id
+    assert summary["latest_matched_case_ids"] == [case_id]
+    assert inspection["invocation"]["matched_case_ids"] == [case_id]


### PR DESCRIPTION
Closes #154

## Summary
- add a HarnessHub matched-case validation harness that imports one prior round bundle and runs a later semantically related runtime query
- capture brief, invocation summary, and inspection artifacts showing non-empty matched case ids
- cover the validation flow with regression tests and document the script entrypoint

## Validation
- ../openprecedent/.venv/bin/pytest -q tests/test_harnesshub_round_import_script.py tests/test_harnesshub_matched_case_validation_script.py
- OPENPRECEDENT_HARNESSHUB_MATCH_ROOT=/tmp/openprecedent-issue154-RhuF5x OPENPRECEDENT_HARNESSHUB_MATCH_RESET=1 OPENPRECEDENT_PYTHON_BIN=../openprecedent/.venv/bin/python OPENPRECEDENT_BIN=../openprecedent/.venv/bin/openprecedent ./scripts/run-harnesshub-matched-case-validation.sh
- inspect /tmp/openprecedent-issue154-RhuF5x/output/10-brief.json
- inspect /tmp/openprecedent-issue154-RhuF5x/output/21-latest-invocation-summary.json
- inspect /tmp/openprecedent-issue154-RhuF5x/output/22-latest-invocation-inspection.json