### PR TITLE
feat: auto-seed shared runtime from HarnessHub rounds

### DIFF
--- a/.codex/pm/issue-state/161-auto-seed-shared-runtime-from-completed-harnesshub-rounds.md
+++ b/.codex/pm/issue-state/161-auto-seed-shared-runtime-from-completed-harnesshub-rounds.md
@@ -1,0 +1,34 @@
+---
+type: issue_state
+issue: 161
+task: .codex/pm/tasks/codex-runtime-research/auto-seed-shared-runtime-from-completed-harnesshub-rounds.md
+title: Auto-seed shared runtime from completed HarnessHub rounds
+status: done
+---
+
+## Summary
+
+Auto-seed the live shared runtime from completed HarnessHub rounds and backfill a baseline searchable history set.
+
+## Validated Facts
+
+- `scripts/sync_harnesshub_shared_runtime.py` now scans completed HarnessHub task twins, resolves a commit from repository history, exports round bundles, and imports missing cases into the chosen runtime.
+- `scripts/run-harnesshub-decision-lineage-workflow.sh` now auto-runs shared-runtime sync before the standard decision-lineage brief workflow.
+- Regression coverage now verifies both baseline backfill and incremental import of a newly completed round, plus automatic sync before a live brief query.
+- Real validation seeded `/root/.openprecedent/runtime` from completed HarnessHub issues `#53`, `#59`, `#61`, and `#62`, producing `cases=19`, `events=154`, and `decisions=73`.
+- Real validation then ran the auto-seeded wrapper workflow and retrieved non-empty matched cases from the shared runtime for a live wording-drift query.
+
+## Open Questions
+
+- Some older completed HarnessHub rounds still need stronger commit-resolution heuristics; the sync summary records these as non-fatal unresolved items rather than blocking live workflow.
+
+## Next Steps
+
+- open the issue-scoped PR for `#161`
+- fold the shared-runtime seeding result back into the ongoing HarnessHub validation research thread
+
+## Artifacts
+
+- `scripts/sync_harnesshub_shared_runtime.py`
+- `scripts/run-harnesshub-decision-lineage-workflow.sh`
+- `tests/test_harnesshub_shared_runtime_sync_script.py`

--- a/.codex/pm/tasks/codex-runtime-research/auto-seed-shared-runtime-from-completed-harnesshub-rounds.md
+++ b/.codex/pm/tasks/codex-runtime-research/auto-seed-shared-runtime-from-completed-harnesshub-rounds.md
@@ -1,0 +1,49 @@
+---
+type: task
+epic: codex-runtime-research
+slug: auto-seed-shared-runtime-from-completed-harnesshub-rounds
+title: Auto-seed shared runtime from completed HarnessHub rounds
+status: done
+task_type: implementation
+labels: feature,test
+depends_on: 155
+issue: 161
+state_path: .codex/pm/issue-state/161-auto-seed-shared-runtime-from-completed-harnesshub-rounds.md
+---
+
+## Context
+
+OpenPrecedent can now export completed HarnessHub rounds, import them into a runtime, extract searchable decisions, validate non-empty `matched_case_ids`, and improve retrieval under wording drift.
+
+But the live shared runtime used by current HarnessHub development still remained empty because completed rounds were not automatically imported into it.
+
+## Deliverable
+
+Build a minimal shared-runtime seeding loop that automatically imports newly completed HarnessHub rounds into the shared runtime and backfills a baseline set of previously completed HarnessHub rounds.
+
+## Scope
+
+- define the minimal trigger or command flow that treats a completed HarnessHub round as ready for shared-runtime ingestion
+- backfill a small baseline set of prior completed HarnessHub rounds into the shared runtime
+- verify that the shared runtime database used by live development now contains non-zero HarnessHub cases, events, and decisions
+
+## Acceptance Criteria
+
+- newly completed HarnessHub rounds are automatically imported into the shared runtime through the defined workflow
+- previously completed HarnessHub rounds are backfilled into the shared runtime as baseline searchable history
+- the shared runtime used by real HarnessHub development shows non-zero `cases`, `events`, and `decisions` after seeding
+- the automatic import path is verified as successful and documented as the expected live-development workflow
+
+## Validation
+
+- run the automatic import workflow against at least one newly completed HarnessHub round
+- backfill at least two prior completed HarnessHub rounds into the same shared runtime
+- inspect the shared runtime database and confirm non-zero `cases`, `events`, and `decisions`
+- record the resulting evidence in the HarnessHub validation log and sanitized archive artifacts
+
+## Implementation Notes
+
+- Implemented with `scripts/sync_harnesshub_shared_runtime.py` and `scripts/run-harnesshub-decision-lineage-workflow.sh`.
+- Regression coverage added in `tests/test_harnesshub_shared_runtime_sync_script.py`.
+- Real validation seeded `/root/.openprecedent/runtime` from completed HarnessHub issues `#53`, `#59`, `#61`, and `#62`, resulting in `cases=19`, `events=154`, and `decisions=73`.
+- Real validation then used the auto-seeded wrapper workflow to retrieve non-empty matched cases from the shared runtime during a live `before_file_write` query.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,6 +13,8 @@ Notable operational entrypoints:
 - `run-codex-review-checkpoint.sh` creates or refreshes the local review note and the current-HEAD review proof before invoking native Codex `/review`
 - `export_harnesshub_codex_round.py` exports one completed HarnessHub Codex development round as a minimal importable searchable-history bundle
 - `import_harnesshub_codex_round.py` imports one exported HarnessHub round bundle into the shared runtime and extracts decisions
+- `sync_harnesshub_shared_runtime.py` backfills and incrementally auto-seeds the shared runtime from completed HarnessHub rounds
+- `run-harnesshub-decision-lineage-workflow.sh` auto-syncs completed HarnessHub rounds into the shared runtime before running the standard decision-lineage workflow
 - `run-harnesshub-matched-case-validation.sh` imports one prior HarnessHub round bundle, runs a later semantically related runtime query, and writes matched-case summary artifacts
 - `triage_pr_checks.py` summarizes and classifies current PR check results for faster CI diagnosis
 - `install-collector-assets.sh` renders `systemd` / `cron` assets against the current repo path

--- a/scripts/run-harnesshub-decision-lineage-workflow.sh
+++ b/scripts/run-harnesshub-decision-lineage-workflow.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+PYTHON_BIN="${OPENPRECEDENT_PYTHON_BIN:-$ROOT_DIR/.venv/bin/python}"
+if [[ ! -x "$PYTHON_BIN" ]]; then
+  if [[ -x "$ROOT_DIR/../openprecedent/.venv/bin/python" ]]; then
+    PYTHON_BIN="$ROOT_DIR/../openprecedent/.venv/bin/python"
+  else
+    PYTHON_BIN="python3"
+  fi
+fi
+
+if [[ -z "${OPENPRECEDENT_HOME:-}" ]]; then
+  export OPENPRECEDENT_HOME="$HOME/.openprecedent/runtime"
+fi
+
+HARNESSHUB_REPO_ROOT="${OPENPRECEDENT_HARNESSHUB_REPO_ROOT:-/workspace/02-projects/active/HarnessHub}"
+
+"$PYTHON_BIN" ./scripts/sync_harnesshub_shared_runtime.py \
+  --repo-root "$HARNESSHUB_REPO_ROOT" \
+  --runtime-home "$OPENPRECEDENT_HOME" \
+  --python-bin "$PYTHON_BIN" \
+  --export-output-root "$OPENPRECEDENT_HOME/harnesshub-round-bundles" \
+  >"${OPENPRECEDENT_HARNESSHUB_SYNC_SUMMARY_PATH:-$OPENPRECEDENT_HOME/harnesshub-sync-summary.json}"
+
+OPENPRECEDENT_PYTHON_BIN="$PYTHON_BIN" \
+./scripts/run-codex-decision-lineage-workflow.sh "$@"

--- a/scripts/sync_harnesshub_shared_runtime.py
+++ b/scripts/sync_harnesshub_shared_runtime.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Backfill and auto-seed the shared OpenPrecedent runtime from completed HarnessHub rounds."
+    )
+    parser.add_argument("--repo-root", required=True, help="HarnessHub repository root")
+    parser.add_argument(
+        "--runtime-home",
+        help="Override OPENPRECEDENT_HOME. Defaults to the environment variable or ~/.openprecedent/runtime.",
+    )
+    parser.add_argument(
+        "--python-bin",
+        help="Python binary used to run the local OpenPrecedent scripts. Defaults to .venv/bin/python or python3.",
+    )
+    parser.add_argument(
+        "--export-output-root",
+        help="Directory used for intermediate exported round bundles. Defaults to <runtime-home>/harnesshub-round-bundles.",
+    )
+    parser.add_argument(
+        "--issue",
+        dest="issues",
+        type=int,
+        action="append",
+        help="Restrict sync to one or more HarnessHub issue numbers.",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero when any completed round cannot yet be resolved for export/import.",
+    )
+    return parser.parse_args()
+
+
+def resolve_runtime_home(explicit: str | None) -> Path:
+    if explicit:
+        return Path(explicit).expanduser().resolve()
+    env_value = os.environ.get("OPENPRECEDENT_HOME")
+    if env_value:
+        return Path(env_value).expanduser().resolve()
+    return Path.home() / ".openprecedent" / "runtime"
+
+
+def resolve_python_bin(explicit: str | None) -> str:
+    if explicit:
+        return explicit
+    root_dir = Path(__file__).resolve().parents[1]
+    bundled = root_dir / ".venv" / "bin" / "python"
+    if bundled.exists():
+        return str(bundled)
+    parent_bundled = root_dir.parent / "openprecedent" / ".venv" / "bin" / "python"
+    if parent_bundled.exists():
+        return str(parent_bundled)
+    return sys.executable
+
+
+def parse_frontmatter(path: Path) -> dict[str, str]:
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---\n"):
+        return {}
+    end = text.find("\n---\n", 4)
+    if end < 0:
+        return {}
+    result: dict[str, str] = {}
+    for line in text[4:end].splitlines():
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        result[key.strip()] = value.strip()
+    return result
+
+
+def slugify(text: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
+    return slug or "round"
+
+
+def run_git(repo_root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def resolve_task_candidates(repo_root: Path, selected_issues: set[int] | None) -> list[dict[str, object]]:
+    tasks_root = repo_root / ".codex" / "pm" / "tasks"
+    candidates: list[dict[str, object]] = []
+    for task_path in sorted(tasks_root.rglob("*.md")):
+        frontmatter = parse_frontmatter(task_path)
+        if frontmatter.get("status") != "done":
+            continue
+        issue_text = frontmatter.get("issue")
+        if issue_text is None or not issue_text.isdigit():
+            continue
+        issue = int(issue_text)
+        if selected_issues and issue not in selected_issues:
+            continue
+        title = frontmatter.get("title")
+        if not title:
+            continue
+        state_path_text = frontmatter.get("state_path")
+        state_path = repo_root / state_path_text if state_path_text else None
+        if state_path is None or not state_path.exists():
+            continue
+        candidates.append(
+            {
+                "issue": issue,
+                "title": title,
+                "task_path": task_path,
+                "state_path": state_path,
+                "case_id": f"case_harnesshub_issue_{issue}_{slugify(title)[:48]}",
+            }
+        )
+    return candidates
+
+
+def resolve_commit_for_task(repo_root: Path, issue: int, title: str) -> str | None:
+    merge_subject = run_git(repo_root, "log", "--merges", "--format=%H\t%s", "--grep", f"issue-{issue}", "-n", "1").strip()
+    if merge_subject:
+        return merge_subject.split("\t", 1)[0]
+
+    title_subject = run_git(repo_root, "log", "--format=%H\t%s", "--grep", title, "-n", "1").strip()
+    if title_subject:
+        return title_subject.split("\t", 1)[0]
+
+    return None
+
+
+def case_exists(runtime_home: Path, case_id: str) -> bool:
+    db_path = runtime_home / "openprecedent.db"
+    if not db_path.exists():
+        return False
+    conn = sqlite3.connect(db_path)
+    try:
+        row = conn.execute("SELECT 1 FROM cases WHERE case_id = ? LIMIT 1", (case_id,)).fetchone()
+    finally:
+        conn.close()
+    return row is not None
+
+
+def db_counts(runtime_home: Path) -> dict[str, int]:
+    db_path = runtime_home / "openprecedent.db"
+    if not db_path.exists():
+        return {"cases": 0, "events": 0, "decisions": 0}
+    conn = sqlite3.connect(db_path)
+    try:
+        return {
+            "cases": conn.execute("SELECT COUNT(*) FROM cases").fetchone()[0],
+            "events": conn.execute("SELECT COUNT(*) FROM events").fetchone()[0],
+            "decisions": conn.execute("SELECT COUNT(*) FROM decisions").fetchone()[0],
+        }
+    finally:
+        conn.close()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = Path(args.repo_root).expanduser().resolve()
+    runtime_home = resolve_runtime_home(args.runtime_home)
+    python_bin = resolve_python_bin(args.python_bin)
+    export_output_root = (
+        Path(args.export_output_root).expanduser().resolve()
+        if args.export_output_root
+        else runtime_home / "harnesshub-round-bundles"
+    )
+    export_output_root.mkdir(parents=True, exist_ok=True)
+    runtime_home.mkdir(parents=True, exist_ok=True)
+
+    selected_issues = set(args.issues or [])
+    candidates = resolve_task_candidates(repo_root, selected_issues or None)
+
+    script_root = Path(__file__).resolve().parent
+    export_script = script_root / "export_harnesshub_codex_round.py"
+    import_script = script_root / "import_harnesshub_codex_round.py"
+
+    imported: list[dict[str, object]] = []
+    skipped_existing: list[dict[str, object]] = []
+    unresolved: list[dict[str, object]] = []
+
+    for candidate in candidates:
+        issue = int(candidate["issue"])
+        title = str(candidate["title"])
+        case_id = str(candidate["case_id"])
+        if case_exists(runtime_home, case_id):
+            skipped_existing.append({"issue": issue, "case_id": case_id, "reason": "case_exists"})
+            continue
+
+        commit = resolve_commit_for_task(repo_root, issue, title)
+        if commit is None:
+            unresolved.append({"issue": issue, "title": title, "reason": "commit_not_found"})
+            continue
+
+        export_result = subprocess.run(
+            [
+                python_bin,
+                str(export_script),
+                "--repo-root",
+                str(repo_root),
+                "--issue",
+                str(issue),
+                "--task-path",
+                str(candidate["task_path"]),
+                "--state-path",
+                str(candidate["state_path"]),
+                "--commit",
+                commit,
+                "--runtime-home",
+                str(runtime_home),
+                "--output-root",
+                str(export_output_root),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if export_result.returncode != 0:
+            unresolved.append(
+                {"issue": issue, "title": title, "reason": "export_failed", "detail": export_result.stderr.strip()}
+            )
+            continue
+
+        bundle_dir = Path(export_result.stdout.strip())
+        import_result = subprocess.run(
+            [
+                python_bin,
+                str(import_script),
+                "--bundle-dir",
+                str(bundle_dir),
+                "--runtime-home",
+                str(runtime_home),
+                "--python-bin",
+                python_bin,
+                "--skip-if-case-exists",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if import_result.returncode != 0:
+            unresolved.append(
+                {"issue": issue, "title": title, "reason": "import_failed", "detail": import_result.stderr.strip()}
+            )
+            continue
+
+        imported.append(
+            {
+                "issue": issue,
+                "title": title,
+                "case_id": case_id,
+                "commit": commit,
+                "bundle_dir": str(bundle_dir),
+                "import_summary": json.loads(import_result.stdout),
+            }
+        )
+
+    print(
+        json.dumps(
+            {
+                "repo_root": str(repo_root),
+                "runtime_home": str(runtime_home),
+                "export_output_root": str(export_output_root),
+                "candidate_issue_count": len(candidates),
+                "imported_count": len(imported),
+                "skipped_existing_count": len(skipped_existing),
+                "unresolved_count": len(unresolved),
+                "imported": imported,
+                "skipped_existing": skipped_existing,
+                "unresolved": unresolved,
+                "db_counts": db_counts(runtime_home),
+            },
+            ensure_ascii=True,
+            indent=2,
+        )
+    )
+    return 0 if (not unresolved or not args.strict) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_harnesshub_shared_runtime_sync_script.py
+++ b/tests/test_harnesshub_shared_runtime_sync_script.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+def _python_bin(repo_root: Path) -> Path:
+    candidate = repo_root / ".venv" / "bin" / "python"
+    if candidate.exists():
+        return candidate
+    return repo_root.parent / "openprecedent" / ".venv" / "bin" / "python"
+
+
+def _openprecedent_bin(repo_root: Path) -> Path:
+    candidate = repo_root / ".venv" / "bin" / "openprecedent"
+    if candidate.exists():
+        return candidate
+    return repo_root.parent / "openprecedent" / ".venv" / "bin" / "openprecedent"
+
+
+def _write_round_files(repo_root: Path, issue: int, title: str) -> tuple[Path, Path]:
+    slug = title.lower().replace(" ", "-")
+    task_path = repo_root / ".codex" / "pm" / "tasks" / "product-direction" / f"{slug}.md"
+    state_path = repo_root / ".codex" / "pm" / "issue-state" / f"{issue}-{slug}.md"
+    task_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    task_path.write_text(
+        "\n".join(
+            [
+                "---",
+                "type: task",
+                "epic: product-direction",
+                f"slug: {slug}",
+                f"title: {title}",
+                "status: done",
+                "task_type: implementation",
+                "labels: feature,test",
+                f"issue: {issue}",
+                f"state_path: {state_path.relative_to(repo_root)}",
+                "---",
+                "",
+                "## Deliverable",
+                "",
+                title,
+                "",
+                "## Scope",
+                "",
+                "- keep the change narrow",
+                "- keep operator-facing behavior explicit",
+                "",
+                "## Acceptance Criteria",
+                "",
+                "- the round is completed",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    state_path.write_text(
+        "\n".join(
+            [
+                "---",
+                "type: issue_state",
+                f"issue: {issue}",
+                f"task: {task_path.relative_to(repo_root)}",
+                f"title: {title}",
+                "status: done",
+                "---",
+                "",
+                "## Summary",
+                "",
+                title,
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return task_path, state_path
+
+
+def _commit_round(repo_root: Path, issue: int, title: str, touched_file: str) -> None:
+    file_path = repo_root / touched_file
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text(f"{title}\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=repo_root, check=True, capture_output=True, text=True)
+    subprocess.run(["git", "commit", "-m", title], cwd=repo_root, check=True, capture_output=True, text=True)
+
+
+def _init_fake_harnesshub_repo(tmp_path: Path) -> Path:
+    repo_root = tmp_path / "HarnessHub"
+    repo_root.mkdir()
+    subprocess.run(["git", "init", "-b", "main"], cwd=repo_root, check=True, capture_output=True, text=True)
+    subprocess.run(["git", "config", "user.email", "codex@example.com"], cwd=repo_root, check=True, capture_output=True, text=True)
+    subprocess.run(["git", "config", "user.name", "Codex"], cwd=repo_root, check=True, capture_output=True, text=True)
+    (repo_root / "README.md").write_text("# HarnessHub\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=repo_root, check=True, capture_output=True, text=True)
+    subprocess.run(["git", "commit", "-m", "bootstrap"], cwd=repo_root, check=True, capture_output=True, text=True)
+    return repo_root
+
+
+def test_sync_harnesshub_shared_runtime_backfills_and_imports_new_rounds(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    python_bin = _python_bin(repo_root)
+    fake_repo = _init_fake_harnesshub_repo(tmp_path)
+
+    _write_round_files(fake_repo, 53, "Refine verification into explicit readiness classes")
+    _commit_round(fake_repo, 53, "Refine verification into explicit readiness classes", "src/readiness.txt")
+    _write_round_files(fake_repo, 59, "Close the inspect-to-export operator workflow")
+    _commit_round(fake_repo, 59, "Close the inspect-to-export operator workflow", "src/inspect.txt")
+
+    runtime_home = tmp_path / "runtime"
+    result = subprocess.run(
+        [
+            str(python_bin),
+            str(repo_root / "scripts" / "sync_harnesshub_shared_runtime.py"),
+            "--repo-root",
+            str(fake_repo),
+            "--runtime-home",
+            str(runtime_home),
+            "--python-bin",
+            str(python_bin),
+            "--export-output-root",
+            str(tmp_path / "bundles"),
+        ],
+        cwd=repo_root,
+        env={**os.environ, "PYTHONPATH": str(repo_root / "src")},
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    summary = json.loads(result.stdout)
+    assert summary["imported_count"] == 2
+    assert summary["db_counts"]["cases"] == 2
+    assert summary["db_counts"]["events"] > 0
+    assert summary["db_counts"]["decisions"] > 0
+
+    _write_round_files(fake_repo, 61, "Add remediation guidance to verify readiness output")
+    _commit_round(fake_repo, 61, "Add remediation guidance to verify readiness output", "src/remediation.txt")
+
+    second = subprocess.run(
+        [
+            str(python_bin),
+            str(repo_root / "scripts" / "sync_harnesshub_shared_runtime.py"),
+            "--repo-root",
+            str(fake_repo),
+            "--runtime-home",
+            str(runtime_home),
+            "--python-bin",
+            str(python_bin),
+            "--export-output-root",
+            str(tmp_path / "bundles"),
+        ],
+        cwd=repo_root,
+        env={**os.environ, "PYTHONPATH": str(repo_root / "src")},
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    second_summary = json.loads(second.stdout)
+    assert second_summary["imported_count"] == 1
+    assert second_summary["skipped_existing_count"] == 2
+    assert second_summary["db_counts"]["cases"] == 3
+
+
+def test_harnesshub_workflow_auto_syncs_before_brief_query(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    python_bin = _python_bin(repo_root)
+    openprecedent_bin = _openprecedent_bin(repo_root)
+    fake_repo = _init_fake_harnesshub_repo(tmp_path)
+
+    _write_round_files(fake_repo, 53, "Refine verification into explicit readiness classes")
+    _commit_round(fake_repo, 53, "Refine verification into explicit readiness classes", "src/readiness.txt")
+
+    runtime_home = tmp_path / "runtime"
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(repo_root / "src")
+    env["OPENPRECEDENT_HOME"] = str(runtime_home)
+    env["OPENPRECEDENT_PYTHON_BIN"] = str(python_bin)
+    env["OPENPRECEDENT_HARNESSHUB_REPO_ROOT"] = str(fake_repo)
+    env["OPENPRECEDENT_HARNESSHUB_SYNC_SUMMARY_PATH"] = str(tmp_path / "sync-summary.json")
+    env["OPENPRECEDENT_BIN"] = str(openprecedent_bin)
+
+    result = subprocess.run(
+        [
+            "./scripts/run-harnesshub-decision-lineage-workflow.sh",
+            "--query-reason",
+            "before_file_write",
+            "--task-summary",
+            "Replace a yes/no readiness signal with operator-facing stages that explain what extra setup reused images still need.",
+        ],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    brief = json.loads(result.stdout)
+    sync_summary = json.loads(Path(env["OPENPRECEDENT_HARNESSHUB_SYNC_SUMMARY_PATH"]).read_text(encoding="utf-8"))
+    assert brief["matched_cases"]
+    assert sync_summary["imported_count"] == 1
+    assert sync_summary["db_counts"]["cases"] == 1


### PR DESCRIPTION
Closes #161

## Summary
- add a shared-runtime sync script that backfills and incrementally imports completed HarnessHub rounds
- add an auto-seeded HarnessHub decision-lineage wrapper that syncs before each live query
- cover both baseline backfill and automatic import-before-query with regression tests

## Validation
- ../openprecedent/.venv/bin/pytest -q tests/test_harnesshub_shared_runtime_sync_script.py
- ../openprecedent/.venv/bin/python scripts/sync_harnesshub_shared_runtime.py --repo-root /workspace/02-projects/active/HarnessHub --runtime-home /root/.openprecedent/runtime --python-bin ../openprecedent/.venv/bin/python --issue 53 --issue 59 --issue 61 --issue 62
- inspect /root/.openprecedent/runtime/openprecedent.db and confirm non-zero cases/events/decisions after seeding
- OPENPRECEDENT_HOME=/root/.openprecedent/runtime OPENPRECEDENT_PYTHON_BIN=../openprecedent/.venv/bin/python OPENPRECEDENT_BIN=../openprecedent/.venv/bin/openprecedent OPENPRECEDENT_HARNESSHUB_REPO_ROOT=/workspace/02-projects/active/HarnessHub ./scripts/run-harnesshub-decision-lineage-workflow.sh --query-reason before_file_write --task-summary "Replace a yes/no readiness signal with operator-facing stages that explain what extra setup reused images still need."