### PR TITLE
chore: add codex session-start workflow

### DIFF
--- a/.codex/pm/epics/real-history-quality.md
+++ b/.codex/pm/epics/real-history-quality.md
@@ -27,6 +27,7 @@ Improve the quality of replay, evaluation, and precedent behavior on real or ano
 
 - `#26` Add anonymized real-session fixtures to the evaluation suite
 - `#28` Improve precedent ranking quality on larger real-case history
+- `#166` Add a standard Codex session-start workflow for issue continuity and default direct-fix behavior
 - `#164` Resolve repository-local test runner before reporting missing pytest
 
 ## Notes

--- a/.codex/pm/issue-state/166-add-standard-codex-session-start-workflow.md
+++ b/.codex/pm/issue-state/166-add-standard-codex-session-start-workflow.md
@@ -1,0 +1,34 @@
+---
+type: issue_state
+issue: 166
+task: .codex/pm/tasks/real-history-quality/add-standard-codex-session-start-workflow.md
+title: Add a standard Codex session-start workflow for issue continuity and default direct-fix behavior
+status: done
+---
+
+## Summary
+
+Add a standard Codex session-start entrypoint so fresh sessions restore branch-local issue context and restate the repository's default direct-fix execution policy.
+
+## Validated Facts
+
+- `openprecedent.codex_pm` now exposes a `session-start` command that summarizes branch, issue, task, issue-state, PR context, and default execution policies.
+- `scripts/run-codex-session-start.sh` provides the repository-local startup entrypoint for agents and humans.
+- The startup output explicitly tells Codex to directly diagnose, implement, verify, and close the loop for concrete user-reported problems unless blocked or high-risk.
+- Tooling and agent guidance now point new sessions at the startup command instead of relying on prior chat memory alone.
+
+## Open Questions
+
+- Whether the session-start command should later become an enforced pre-work checkpoint rather than a documented standard path.
+
+## Next Steps
+
+- Open and merge the issue-scoped PR for `#166`.
+- Reuse this startup surface in future harness-gap closures where session continuity drift appears again.
+
+## Artifacts
+
+- `scripts/run-codex-session-start.sh`
+- `src/openprecedent/codex_pm.py`
+- `docs/engineering/tooling-setup.md`
+- `AGENTS.md`

--- a/.codex/pm/tasks/real-history-quality/add-standard-codex-session-start-workflow.md
+++ b/.codex/pm/tasks/real-history-quality/add-standard-codex-session-start-workflow.md
@@ -1,0 +1,43 @@
+---
+type: task
+epic: real-history-quality
+slug: add-standard-codex-session-start-workflow
+title: Add a standard Codex session-start workflow for issue continuity and default direct-fix behavior
+status: done
+task_type: implementation
+labels: ops,test
+issue: 166
+state_path: .codex/pm/issue-state/166-add-standard-codex-session-start-workflow.md
+---
+
+## Context
+
+Codex sessions can restart without reliably recovering repository-specific execution behavior, especially around issue continuity, closure state, and the default expectation to directly fix concrete problems through implementation and verification.
+
+## Deliverable
+
+Add a standard session-start harness entrypoint that surfaces the active issue/task/PR context and the repository's default direct-fix behavior so later Codex sessions start from the same durable workflow state.
+
+## Scope
+
+- add one repository-local startup entrypoint for Codex sessions
+- surface branch, issue, task status, issue-state availability, and PR context
+- restate the default execution rule for concrete user-reported problems: diagnose, implement, verify, and close the loop unless blocked or high-risk
+- document the startup workflow in contributor-facing harness docs
+- add regression coverage for the startup surface
+
+## Acceptance Criteria
+
+- a new Codex session has one standard local command to restore active issue context
+- the startup output includes enough issue/task/state information to reduce branch-local workflow drift
+- the startup output explicitly states the repository's default direct-fix behavior for concrete problems
+- automated coverage exists for the startup surface
+
+## Validation
+
+- run targeted pytest coverage for `codex_pm` and the docs guardrails
+- verify the startup output includes the direct-fix policy and state warnings where appropriate
+
+## Implementation Notes
+
+- Prefer building on the existing `codex_pm`, task twin, and issue-state mechanisms instead of inventing a second state system.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,8 @@ The first implementation target is a local single-agent workflow. The current go
 - After completing one issue, open exactly one PR for that issue instead of batching multiple issues into the same PR.
 - Link the PR to its issue in the PR body using a closing reference such as `Closes #24` so the issue is closed automatically when the PR is merged.
 - After a PR is merged, continue the next task on a new branch and a new PR linked to the next issue.
+- When starting or resuming a Codex session, run `./scripts/run-codex-session-start.sh` to restore the active branch, issue, task, and PR context before doing substantive work.
+- When the user points out a concrete problem in this repository, default to directly diagnosing and fixing it through implementation, verification, and workflow closure unless the change is destructive, high-risk, or blocked by missing external information.
 - When running Python tests, do not stop at a missing global `pytest`; use `./scripts/run-pytest.sh` or the repository-local `.venv` resolution path first.
 
 ## Project-Local Codex Skill

--- a/docs/engineering/tooling-setup.md
+++ b/docs/engineering/tooling-setup.md
@@ -11,6 +11,7 @@ The repository already includes:
 - `scripts/run-codex-review-checkpoint.sh` as the preferred local checkpoint for invoking native Codex `/review`
 - `scripts/run-agent-preflight.sh` for the standard local pre-push confidence checks
 - `scripts/run-pytest.sh` for repository-local pytest resolution before falling back to global commands
+- `scripts/run-codex-session-start.sh` for restoring branch, issue, task, issue-state, and PR context at the start of a Codex session
 - `scripts/triage_pr_checks.py` for local CI failure classification against current PR checks
 - `scripts/run-e2e.sh` for the standard local fixture-backed end-to-end runtime validation path
 - `scripts/run-openclaw-live-validation.sh` for preparing a reusable live OpenClaw validation workspace and summarizing runtime evidence
@@ -62,6 +63,25 @@ If the current PR body includes `Closes #<issue>`, the hook now tries to verify 
 
 ## Merge Validation
 
+## Codex Session Start
+
+When starting or resuming a Codex session in this repository, run:
+
+```bash
+./scripts/run-codex-session-start.sh
+```
+
+The command surfaces the current branch, issue number, matching local task twin, issue-state availability, and open PR context when available.
+It also restates the repository's default execution policy:
+
+- when the user reports a concrete problem, directly diagnose, implement, verify, and close the loop unless the work is destructive, high-risk, or blocked
+- prefer repository-local execution paths such as `./scripts/run-pytest.sh`
+- keep issue, task twin, issue-state, and PR closure state synchronized
+
+Use this startup entrypoint before substantive work so a fresh session does not rely on prior chat memory alone.
+
+## Merge Validation
+
 For a normal local readiness pass before push, run:
 
 ```bash
@@ -94,6 +114,7 @@ python3 -m openprecedent.codex_pm issue-state-init .codex/pm/tasks/<epic>/<task>
 
 This creates a repository-local issue state document under `.codex/pm/issue-state/` and records its path back into the task metadata.
 Use it to keep validated facts, open questions, next steps, and key artifacts in one stable place as the work evolves across sessions.
+The standard session-start command will warn if an in-progress issue branch is missing this state document.
 
 For runtime-affecting pull requests, run:
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,6 +9,7 @@ Notable operational entrypoints:
 - `run-openclaw-live-validation.sh` prepares a reusable live OpenClaw validation workspace and summarizes runtime evidence
 - `run-agent-preflight.sh` runs the standard local pre-push confidence checks for agent-driven work
 - `run-pytest.sh` resolves the repository-local pytest runner before falling back to global Python or `pytest`
+- `run-codex-session-start.sh` restores active issue and PR context and restates the repository's default direct-fix workflow at session start
 - `run-codex-review-checkpoint.sh` creates or refreshes the local review note and the current-HEAD review proof before invoking native Codex `/review`
 - `export_harnesshub_codex_round.py` exports one completed HarnessHub Codex development round as a minimal importable searchable-history bundle
 - `import_harnesshub_codex_round.py` imports one exported HarnessHub round bundle into the shared runtime and extracts decisions

--- a/scripts/run-codex-session-start.sh
+++ b/scripts/run-codex-session-start.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+PYTHON_BIN="${OPENPRECEDENT_PYTHON_BIN:-$ROOT_DIR/.venv/bin/python}"
+if [[ ! -x "$PYTHON_BIN" ]]; then
+  PYTHON_BIN="python3"
+fi
+
+PYTHONPATH=src "$PYTHON_BIN" -m openprecedent.codex_pm session-start "$@"

--- a/src/openprecedent/codex_pm.py
+++ b/src/openprecedent/codex_pm.py
@@ -81,6 +81,9 @@ def build_parser() -> argparse.ArgumentParser:
     issue_state_check.add_argument("--branch")
 
     subparsers.add_parser("standup").add_argument("--json", action="store_true", dest="as_json")
+    session_start = subparsers.add_parser("session-start")
+    session_start.add_argument("--branch")
+    session_start.add_argument("--json", action="store_true", dest="as_json")
 
     issue_body = subparsers.add_parser("issue-body")
     issue_body.add_argument("path")
@@ -268,6 +271,13 @@ def main(argv: list[str] | None = None) -> int:
                 for item in summary[status]:
                     print(f"  - {item['title']} ({item['path']})")
         return 0
+    if args.action == "session-start":
+        summary = _build_session_start_summary(args.branch or _current_branch())
+        if args.as_json:
+            print(json.dumps(summary, ensure_ascii=True, indent=2, sort_keys=True))
+        else:
+            print(_render_session_start_summary(summary))
+        return 0
     if args.action == "issue-body":
         document = _read_document(Path(args.path))
         print(_render_issue_body(document))
@@ -430,6 +440,80 @@ def _doc_to_dict(document: PMDocument) -> dict[str, object]:
     }
 
 
+def _build_session_start_summary(branch: str) -> dict[str, object]:
+    issue = _parse_issue_from_branch(branch) if branch else None
+    task = _find_task_by_issue(issue) if issue is not None else None
+    issue_state = _load_issue_state(task) if task is not None else None
+    pr_context = _pr_context_for_branch(branch)
+    policies = [
+        "When the user reports a concrete problem, directly diagnose, implement, verify, and close the loop unless blocked or high-risk.",
+        "Prefer repository-local execution paths such as ./scripts/run-pytest.sh and the local .venv before treating missing global tools as blockers.",
+        "Keep the issue, task twin, issue-state, and PR closure state synchronized before considering the work complete.",
+    ]
+    warnings: list[str] = []
+    if issue is not None and task is None:
+        warnings.append(f"No local task twin found for issue #{issue}.")
+    if task is not None and task.metadata.get("status") == "in_progress" and issue_state is None:
+        warnings.append(
+            f"In-progress issue #{issue} has no issue-state document. Run `python3 -m openprecedent.codex_pm issue-state-init {task.path}`."
+        )
+
+    summary: dict[str, object] = {
+        "branch": branch,
+        "issue": issue,
+        "task": _doc_to_dict(task) if task is not None else None,
+        "issue_state": {
+            "path": str(issue_state.path),
+            "status": issue_state.metadata.get("status", ""),
+        }
+        if issue_state is not None
+        else None,
+        "pull_request": pr_context,
+        "default_policies": policies,
+        "warnings": warnings,
+    }
+    return summary
+
+
+def _render_session_start_summary(summary: dict[str, object]) -> str:
+    lines = [
+        "Codex session-start summary",
+        f"Branch: {summary.get('branch') or '(detached)'}",
+    ]
+    issue = summary.get("issue")
+    lines.append(f"Issue: #{issue}" if issue is not None else "Issue: none detected from branch")
+
+    task = summary.get("task")
+    if isinstance(task, dict):
+        lines.append(f"Task: {task.get('title')} ({task.get('path')})")
+        lines.append(f"Task status: {task.get('status')}")
+    else:
+        lines.append("Task: no matching local task twin")
+
+    issue_state = summary.get("issue_state")
+    if isinstance(issue_state, dict):
+        lines.append(f"Issue state: {issue_state.get('path')}")
+    else:
+        lines.append("Issue state: missing or not initialized")
+
+    pull_request = summary.get("pull_request")
+    if isinstance(pull_request, dict):
+        lines.append(f"Pull request: #{pull_request.get('number')} {pull_request.get('title')} ({pull_request.get('url')})")
+    else:
+        lines.append("Pull request: none detected for the current branch")
+
+    lines.extend(["", "Default execution policy:"])
+    for item in summary.get("default_policies", []):
+        lines.append(f"- {item}")
+
+    warnings = summary.get("warnings", [])
+    if warnings:
+        lines.extend(["", "Warnings:"])
+        for warning in warnings:
+            lines.append(f"- {warning}")
+    return "\n".join(lines)
+
+
 def _current_branch() -> str:
     return _git_output(["git", "branch", "--show-current"]) or ""
 
@@ -451,6 +535,61 @@ def _parse_github_remote(remote_url: str) -> tuple[str, str] | None:
     if match is None:
         return None
     return match.group(1), match.group(2)
+
+
+def _repository_for_pr_lookup() -> str | None:
+    for remote_name in ("upstream", "origin"):
+        remote_url = _git_output(["git", "remote", "get-url", remote_name])
+        if remote_url is None:
+            continue
+        parsed = _parse_github_remote(remote_url)
+        if parsed is not None:
+            return f"{parsed[0]}/{parsed[1]}"
+    return None
+
+
+def _pr_context_for_branch(branch: str) -> dict[str, object] | None:
+    if not branch:
+        return None
+    repo = _repository_for_pr_lookup()
+    origin_url = _git_output(["git", "remote", "get-url", "origin"])
+    if repo is None or origin_url is None:
+        return None
+    parsed_origin = _parse_github_remote(origin_url)
+    if parsed_origin is None:
+        return None
+
+    result = subprocess.run(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--head",
+            f"{parsed_origin[0]}:{branch}",
+            "--state",
+            "open",
+            "--json",
+            "number,title,url",
+            "--limit",
+            "1",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    items = json.loads(result.stdout)
+    if not items:
+        return None
+    pr = items[0]
+    return {
+        "number": pr.get("number"),
+        "title": pr.get("title"),
+        "url": pr.get("url"),
+    }
 
 
 def _parse_issue_from_branch(branch: str) -> int | None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1186,6 +1186,23 @@ def test_tooling_setup_mentions_live_validation_skill() -> None:
     assert ".codex/skills/openclaw-live-validation/SKILL.md" in content
 
 
+def test_tooling_setup_mentions_session_start_workflow() -> None:
+    path = Path(__file__).parent.parent / "docs" / "engineering" / "tooling-setup.md"
+
+    content = path.read_text(encoding="utf-8")
+
+    assert "./scripts/run-codex-session-start.sh" in content
+    assert "directly diagnose, implement, verify, and close the loop" in content
+
+
+def test_agents_mentions_default_direct_fix_behavior() -> None:
+    path = Path(__file__).parent.parent / "AGENTS.md"
+
+    content = path.read_text(encoding="utf-8")
+
+    assert "default to directly diagnosing and fixing it through implementation, verification, and workflow closure" in content
+
+
 def test_harness_reuse_guide_exists() -> None:
     path = Path(__file__).parent.parent / "docs" / "engineering" / "harness-reuse-guide.md"
 

--- a/tests/test_codex_pm.py
+++ b/tests/test_codex_pm.py
@@ -802,3 +802,80 @@ def test_codex_pm_issue_state_check_passes_after_state_init(
 
     assert main(["issue-state-check", "--branch", "codex/issue-106-issue-scoped-dev-state"]) == 0
     assert "Issue state check passed" in capsys.readouterr().out
+
+
+def test_codex_pm_session_start_reports_issue_context_and_default_policy(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    assert main(["init"]) == 0
+    capsys.readouterr()
+    assert (
+        main(
+            [
+                "task-new",
+                "real-history-quality",
+                "session-start",
+                "--title",
+                "Add session start workflow",
+                "--issue",
+                "166",
+                "--status",
+                "in_progress",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    task_path = tmp_path / ".codex" / "pm" / "tasks" / "real-history-quality" / "session-start.md"
+    assert main(["issue-state-init", str(task_path)]) == 0
+    capsys.readouterr()
+
+    monkeypatch.setattr("openprecedent.codex_pm._pr_context_for_branch", lambda branch: {"number": 165, "title": "open pr", "url": "https://example.com/pr/165"})
+
+    assert main(["session-start", "--branch", "issue-166-session-start-consistency"]) == 0
+    output = capsys.readouterr().out
+    assert "Branch: issue-166-session-start-consistency" in output
+    assert "Issue: #166" in output
+    assert "Task status: in_progress" in output
+    assert "Pull request: #165 open pr" in output
+    assert "directly diagnose, implement, verify, and close the loop" in output
+
+
+def test_codex_pm_session_start_warns_when_in_progress_issue_lacks_state(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    assert main(["init"]) == 0
+    capsys.readouterr()
+    assert (
+        main(
+            [
+                "task-new",
+                "real-history-quality",
+                "session-start-missing-state",
+                "--title",
+                "Add session start workflow",
+                "--issue",
+                "166",
+                "--status",
+                "in_progress",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    monkeypatch.setattr("openprecedent.codex_pm._pr_context_for_branch", lambda branch: None)
+
+    assert main(["session-start", "--branch", "issue-166-session-start-consistency"]) == 0
+    output = capsys.readouterr().out
+    assert "Warnings:" in output
+    assert "has no issue-state document" in output


### PR DESCRIPTION
Closes #166

Add a standard session-start harness entrypoint that surfaces the active issue/task/PR context and the repository's default direct-fix behavior so later Codex sessions start from the same durable workflow state.

Implementation notes:
- Prefer building on the existing `codex_pm`, task twin, and issue-state mechanisms instead of inventing a second state system.

Validation:
- `PYTHONPATH=src /workspace/02-projects/incubation/openprecedent/.venv/bin/python -m pytest -q tests/test_codex_pm.py tests/test_cli.py -k "session_start or tooling_setup_mentions_session_start_workflow or agents_mentions_default_direct_fix_behavior"`
- `./scripts/run-codex-session-start.sh --branch issue-166-session-start-consistency`
