### PR TITLE
Implement the Rust SQLite store and schema compatibility layer for the public CLI

### DIFF
--- a/.codex/pm/issue-state/176-implement-rust-sqlite-store-and-schema-compatibility-layer-for-public-cli.md
+++ b/.codex/pm/issue-state/176-implement-rust-sqlite-store-and-schema-compatibility-layer-for-public-cli.md
@@ -1,0 +1,33 @@
+---
+type: issue_state
+issue: 176
+task: .codex/pm/tasks/public-cli-foundation/implement-rust-sqlite-store-and-schema-compatibility-layer-for-public-cli.md
+title: Implement the Rust SQLite store and schema compatibility layer for the public CLI
+status: in_progress
+---
+
+## Summary
+
+Port SQLite schema ownership and the reusable persistence layer into Rust so later command migrations can read and write the runtime database without depending on Python.
+
+## Validated Facts
+
+- the Rust contracts crate now includes case, event, decision, and artifact domain types
+- the Rust SQLite store crate now owns schema initialization for cases, events, decisions, and artifacts
+- the Rust SQLite store crate also applies the decisions-table compatibility migration for missing `confidence` and `explanation_json` columns
+- the Rust store exposes reusable methods for creating and listing cases, appending and listing events, replacing and listing decisions, finding a case by OpenClaw session id, and upserting artifacts
+- `cargo test` passes across the full Rust workspace, including store roundtrip and legacy migration tests
+
+## Open Questions
+
+- whether the next command-family slices should move the shared row-mapping helpers into smaller modules as the Rust store grows
+
+## Next Steps
+
+- commit the `#176` implementation, open a child PR against `codex/issue-172-rust-public-cli`, and merge it
+- start `#177` from the refreshed integration branch after the Rust store layer lands
+
+## Artifacts
+
+- `rust/openprecedent-contracts/src/`
+- `rust/openprecedent-store-sqlite/src/lib.rs`

--- a/.codex/pm/tasks/public-cli-foundation/implement-rust-sqlite-store-and-schema-compatibility-layer-for-public-cli.md
+++ b/.codex/pm/tasks/public-cli-foundation/implement-rust-sqlite-store-and-schema-compatibility-layer-for-public-cli.md
@@ -3,32 +3,42 @@ type: task
 epic: public-cli-foundation
 slug: implement-rust-sqlite-store-and-schema-compatibility-layer-for-public-cli
 title: Implement the Rust SQLite store and schema compatibility layer for the public CLI
-status: backlog
+status: done
 task_type: implementation
 labels: cli,rust,interface
 issue: 176
+state_path: .codex/pm/issue-state/176-implement-rust-sqlite-store-and-schema-compatibility-layer-for-public-cli.md
 ---
 
 ## Context
 
-Planned child issue under `#172`. Expand the implementation detail when this issue becomes active.
+The Rust CLI already has a stable config and doctor surface from `#175`, but later command families still need a Rust-native persistence layer.
+This slice ports SQLite schema ownership, initialization, migration, and row-mapping into Rust so later command issues can use one shared store crate instead of reaching back into Python.
 
 ## Deliverable
 
-Implement the scoped GitHub issue on a child branch that merges into `codex/issue-172-rust-public-cli`.
+Implement the Rust SQLite store crate with schema bootstrap, legacy migration handling, and reusable CRUD-style methods for the core case, event, decision, and artifact records.
 
 ## Scope
 
-- follow the scoped work and constraints defined in the linked GitHub issue
+- add Rust domain structs for case, event, decision, and artifact records to the shared contracts crate
+- implement SQLite schema initialization and migration in `openprecedent-store-sqlite`
+- implement reusable store methods for the core persisted objects used by later CLI slices
+- add Rust tests for roundtripping current schema data and upgrading a legacy decisions table missing newer columns
 
 ## Acceptance Criteria
 
-- satisfy the acceptance criteria in the linked GitHub issue before opening a child PR
+- the Rust implementation can open and validate the existing SQLite runtime schema shape
+- schema and migration ownership for the public CLI no longer depend on Python at runtime
+- later CLI command slices can reuse the Rust store layer instead of re-implementing DB access
+- store tests cover both current-schema roundtrips and legacy-column migration behavior
 
 ## Validation
 
-- run issue-appropriate local validation when this task becomes active
+- run `. \"$HOME/.cargo/env\" && cargo test`
+- run `./scripts/run-pytest.sh -q tests/test_rust_cli_workspace.py`
 
 ## Implementation Notes
 
-- This task twin was scaffolded during the Rust CLI issue decomposition and should be elaborated when implementation starts.
+- The store crate now owns the SQLite DDL for cases, events, decisions, and artifacts.
+- The Rust contracts crate now includes the core persisted object types, which later command slices can use directly.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,10 +115,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "cc"
+version = "1.2.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -158,6 +197,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,10 +225,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "float-cmp"
@@ -229,10 +292,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "id-arena"
@@ -265,6 +361,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "js-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,6 +381,17 @@ name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -353,8 +470,11 @@ dependencies = [
 name = "openprecedent-contracts"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "clap",
  "serde",
+ "serde_json",
+ "strum",
 ]
 
 [[package]]
@@ -371,8 +491,19 @@ dependencies = [
 name = "openprecedent-store-sqlite"
 version = "0.1.0"
 dependencies = [
- "openprecedent-core",
+ "chrono",
+ "openprecedent-contracts",
+ "rusqlite",
+ "serde_json",
+ "tempfile",
+ "thiserror",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "predicates"
@@ -468,6 +599,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rusqlite"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,6 +624,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "semver"
@@ -539,10 +690,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "syn"
@@ -654,6 +838,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -678,6 +868,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -715,10 +950,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,13 @@ authors = ["yaoyinnan <35447132+yaoyinnan@users.noreply.github.com>"]
 
 [workspace.dependencies]
 assert_cmd = "2.1.1"
+chrono = { version = "0.4.42", features = ["serde"] }
 clap = { version = "4.5.38", features = ["derive"] }
 predicates = "3.1.3"
+rusqlite = { version = "0.37.0", features = ["bundled"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
+strum = { version = "0.27.2", features = ["derive"] }
 tempfile = "3.20.0"
 thiserror = "2.0.12"
 toml = "0.8.23"

--- a/rust/openprecedent-contracts/Cargo.toml
+++ b/rust/openprecedent-contracts/Cargo.toml
@@ -6,5 +6,8 @@ license.workspace = true
 authors.workspace = true
 
 [dependencies]
+chrono.workspace = true
 clap.workspace = true
 serde.workspace = true
+serde_json.workspace = true
+strum.workspace = true

--- a/rust/openprecedent-contracts/src/artifact.rs
+++ b/rust/openprecedent-contracts/src/artifact.rs
@@ -1,0 +1,22 @@
+use serde::{Deserialize, Serialize};
+use strum::{Display, EnumString};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Display, EnumString)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum ArtifactType {
+    File,
+    CommandOutput,
+    Message,
+    Report,
+    Patch,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Artifact {
+    pub artifact_id: String,
+    pub case_id: String,
+    pub artifact_type: ArtifactType,
+    pub uri_or_path: String,
+    pub summary: Option<String>,
+}

--- a/rust/openprecedent-contracts/src/case.rs
+++ b/rust/openprecedent-contracts/src/case.rs
@@ -1,0 +1,25 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use strum::{Display, EnumString};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Display, EnumString)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum CaseStatus {
+    Started,
+    Completed,
+    Failed,
+    Paused,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Case {
+    pub case_id: String,
+    pub title: String,
+    pub status: CaseStatus,
+    pub user_id: Option<String>,
+    pub agent_id: Option<String>,
+    pub started_at: DateTime<Utc>,
+    pub ended_at: Option<DateTime<Utc>>,
+    pub final_summary: Option<String>,
+}

--- a/rust/openprecedent-contracts/src/decision.rs
+++ b/rust/openprecedent-contracts/src/decision.rs
@@ -1,0 +1,41 @@
+use serde::{Deserialize, Serialize};
+use strum::{Display, EnumString};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Display, EnumString)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum DecisionType {
+    TaskFrameDefined,
+    ConstraintAdopted,
+    SuccessCriteriaSet,
+    ClarificationResolved,
+    OptionRejected,
+    AuthorityConfirmed,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct DecisionExplanation {
+    pub goal: String,
+    pub evidence: Vec<String>,
+    pub constraints: Vec<String>,
+    pub selection_reason: String,
+    pub result: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Decision {
+    pub decision_id: String,
+    pub case_id: String,
+    pub decision_type: DecisionType,
+    pub title: String,
+    pub question: String,
+    pub chosen_action: String,
+    pub alternatives: Vec<String>,
+    pub evidence_event_ids: Vec<String>,
+    pub constraint_summary: Option<String>,
+    pub requires_human_confirmation: bool,
+    pub outcome: Option<String>,
+    pub confidence: f64,
+    pub explanation: DecisionExplanation,
+    pub sequence_no: i64,
+}

--- a/rust/openprecedent-contracts/src/event.rs
+++ b/rust/openprecedent-contracts/src/event.rs
@@ -1,0 +1,61 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use strum::{Display, EnumString};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Display, EnumString)]
+#[serde(rename_all = "kebab-case")]
+pub enum EventType {
+    #[strum(serialize = "case.started")]
+    CaseStarted,
+    #[strum(serialize = "checkpoint.saved")]
+    CheckpointSaved,
+    #[strum(serialize = "message.user")]
+    MessageUser,
+    #[strum(serialize = "message.agent")]
+    MessageAgent,
+    #[strum(serialize = "model.invoked")]
+    ModelInvoked,
+    #[strum(serialize = "model.completed")]
+    ModelCompleted,
+    #[strum(serialize = "tool.called")]
+    ToolCalled,
+    #[strum(serialize = "tool.completed")]
+    ToolCompleted,
+    #[strum(serialize = "command.started")]
+    CommandStarted,
+    #[strum(serialize = "command.completed")]
+    CommandCompleted,
+    #[strum(serialize = "file.read")]
+    FileRead,
+    #[strum(serialize = "file.write")]
+    FileWrite,
+    #[strum(serialize = "user.confirmed")]
+    UserConfirmed,
+    #[strum(serialize = "case.completed")]
+    CaseCompleted,
+    #[strum(serialize = "case.failed")]
+    CaseFailed,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Display, EnumString)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum EventActor {
+    User,
+    Agent,
+    System,
+    Tool,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Event {
+    pub event_id: String,
+    pub case_id: String,
+    pub event_type: EventType,
+    pub actor: EventActor,
+    pub timestamp: DateTime<Utc>,
+    pub sequence_no: i64,
+    pub parent_event_id: Option<String>,
+    pub payload: Value,
+}

--- a/rust/openprecedent-contracts/src/lib.rs
+++ b/rust/openprecedent-contracts/src/lib.rs
@@ -1,7 +1,17 @@
+mod artifact;
+mod case;
+mod decision;
+mod event;
+
 use std::path::PathBuf;
 
 use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
+
+pub use artifact::{Artifact, ArtifactType};
+pub use case::{Case, CaseStatus};
+pub use decision::{Decision, DecisionExplanation, DecisionType};
+pub use event::{Event, EventActor, EventType};
 
 pub const CLI_BINARY_NAME: &str = "openprecedent";
 pub const CONTRACT_PHASE: &str = "bootstrap";

--- a/rust/openprecedent-store-sqlite/Cargo.toml
+++ b/rust/openprecedent-store-sqlite/Cargo.toml
@@ -6,4 +6,11 @@ license.workspace = true
 authors.workspace = true
 
 [dependencies]
-openprecedent-core = { path = "../openprecedent-core" }
+chrono.workspace = true
+openprecedent-contracts = { path = "../openprecedent-contracts" }
+rusqlite.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/rust/openprecedent-store-sqlite/src/lib.rs
+++ b/rust/openprecedent-store-sqlite/src/lib.rs
@@ -1,1 +1,641 @@
-pub const STORE_BACKEND_NAME: &str = "sqlite";
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use chrono::{DateTime, Utc};
+use openprecedent_contracts::{
+    Artifact, Case, CaseStatus, Decision, DecisionExplanation, Event, EventType,
+};
+use rusqlite::{Connection, OptionalExtension, Row};
+use serde_json::Value;
+
+#[derive(Debug, thiserror::Error)]
+pub enum SqliteStoreError {
+    #[error(transparent)]
+    Sqlite(#[from] rusqlite::Error),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+    #[error("invalid RFC3339 timestamp: {0}")]
+    DateTime(String),
+    #[error("invalid enum value for {kind}: {value}")]
+    EnumValue { kind: &'static str, value: String },
+}
+
+pub struct SqliteStore {
+    db_path: PathBuf,
+}
+
+impl SqliteStore {
+    pub fn new(path: impl AsRef<Path>) -> Result<Self, SqliteStoreError> {
+        let db_path = path.as_ref().to_path_buf();
+        if let Some(parent) = db_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        let store = Self { db_path };
+        store.initialize()?;
+        Ok(store)
+    }
+
+    pub fn db_path(&self) -> &Path {
+        &self.db_path
+    }
+
+    pub fn create_case(&self, case: &Case) -> Result<(), SqliteStoreError> {
+        let connection = self.connect()?;
+        connection.execute(
+            "
+            INSERT INTO cases (
+                case_id, title, status, user_id, agent_id, started_at, ended_at, final_summary
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ",
+            (
+                &case.case_id,
+                &case.title,
+                case.status.to_string(),
+                &case.user_id,
+                &case.agent_id,
+                case.started_at.to_rfc3339(),
+                case.ended_at.map(|value| value.to_rfc3339()),
+                &case.final_summary,
+            ),
+        )?;
+        Ok(())
+    }
+
+    pub fn list_cases(&self) -> Result<Vec<Case>, SqliteStoreError> {
+        let connection = self.connect()?;
+        let mut statement =
+            connection.prepare("SELECT * FROM cases ORDER BY started_at DESC, case_id DESC")?;
+        let rows = statement.query_map([], Self::row_to_case)?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    }
+
+    pub fn get_case(&self, case_id: &str) -> Result<Option<Case>, SqliteStoreError> {
+        let connection = self.connect()?;
+        connection
+            .query_row(
+                "SELECT * FROM cases WHERE case_id = ?",
+                [case_id],
+                Self::row_to_case,
+            )
+            .optional()
+            .map_err(Into::into)
+    }
+
+    pub fn find_case_id_by_openclaw_session_id(
+        &self,
+        session_id: &str,
+    ) -> Result<Option<String>, SqliteStoreError> {
+        let connection = self.connect()?;
+        connection
+            .query_row(
+                "
+                SELECT case_id
+                FROM events
+                WHERE event_type = ?
+                  AND json_extract(payload_json, '$.session_id') = ?
+                ORDER BY sequence_no ASC, event_id ASC
+                LIMIT 1
+                ",
+                [EventType::CaseStarted.to_string(), session_id.to_string()],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(Into::into)
+    }
+
+    pub fn append_event(&self, event: &Event) -> Result<(), SqliteStoreError> {
+        let connection = self.connect()?;
+        connection.execute(
+            "
+            INSERT INTO events (
+                event_id, case_id, event_type, actor, timestamp, sequence_no,
+                parent_event_id, payload_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ",
+            (
+                &event.event_id,
+                &event.case_id,
+                event.event_type.to_string(),
+                event.actor.to_string(),
+                event.timestamp.to_rfc3339(),
+                event.sequence_no,
+                &event.parent_event_id,
+                serde_json::to_string(&event.payload)?,
+            ),
+        )?;
+
+        if matches!(
+            event.event_type,
+            EventType::CaseCompleted | EventType::CaseFailed
+        ) {
+            let status = match event.event_type {
+                EventType::CaseCompleted => CaseStatus::Completed,
+                EventType::CaseFailed => CaseStatus::Failed,
+                _ => unreachable!(),
+            };
+            connection.execute(
+                "
+                UPDATE cases
+                SET status = ?, ended_at = ?, final_summary = COALESCE(?, final_summary)
+                WHERE case_id = ?
+                ",
+                (
+                    status.to_string(),
+                    event.timestamp.to_rfc3339(),
+                    payload_summary(&event.payload),
+                    &event.case_id,
+                ),
+            )?;
+        }
+        Ok(())
+    }
+
+    pub fn list_events(&self, case_id: &str) -> Result<Vec<Event>, SqliteStoreError> {
+        let connection = self.connect()?;
+        let mut statement = connection.prepare(
+            "
+            SELECT * FROM events
+            WHERE case_id = ?
+            ORDER BY sequence_no ASC, timestamp ASC, event_id ASC
+            ",
+        )?;
+        let rows = statement.query_map([case_id], Self::row_to_event)?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    }
+
+    pub fn next_event_sequence(&self, case_id: &str) -> Result<i64, SqliteStoreError> {
+        let connection = self.connect()?;
+        let value = connection.query_row(
+            "SELECT COALESCE(MAX(sequence_no), 0) AS max_sequence FROM events WHERE case_id = ?",
+            [case_id],
+            |row| row.get::<_, i64>(0),
+        )?;
+        Ok(value + 1)
+    }
+
+    pub fn replace_decisions(
+        &self,
+        case_id: &str,
+        decisions: &[Decision],
+    ) -> Result<(), SqliteStoreError> {
+        let mut connection = self.connect()?;
+        let transaction = connection.transaction()?;
+        transaction.execute("DELETE FROM decisions WHERE case_id = ?", [case_id])?;
+
+        for decision in decisions {
+            transaction.execute(
+                "
+                INSERT INTO decisions (
+                    decision_id, case_id, decision_type, title, question, chosen_action,
+                    alternatives_json, evidence_event_ids_json, constraint_summary,
+                    requires_human_confirmation, outcome, confidence, explanation_json, sequence_no
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ",
+                (
+                    &decision.decision_id,
+                    &decision.case_id,
+                    decision.decision_type.to_string(),
+                    &decision.title,
+                    &decision.question,
+                    &decision.chosen_action,
+                    serde_json::to_string(&decision.alternatives)?,
+                    serde_json::to_string(&decision.evidence_event_ids)?,
+                    &decision.constraint_summary,
+                    decision.requires_human_confirmation as i64,
+                    &decision.outcome,
+                    decision.confidence,
+                    serde_json::to_string(&decision.explanation)?,
+                    decision.sequence_no,
+                ),
+            )?;
+        }
+
+        transaction.commit()?;
+        Ok(())
+    }
+
+    pub fn list_decisions(&self, case_id: &str) -> Result<Vec<Decision>, SqliteStoreError> {
+        let connection = self.connect()?;
+        let mut statement = connection.prepare(
+            "
+            SELECT * FROM decisions
+            WHERE case_id = ?
+            ORDER BY sequence_no ASC, decision_id ASC
+            ",
+        )?;
+        let rows = statement.query_map([case_id], Self::row_to_decision)?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    }
+
+    pub fn list_artifacts(&self, case_id: &str) -> Result<Vec<Artifact>, SqliteStoreError> {
+        let connection = self.connect()?;
+        let mut statement = connection.prepare(
+            "
+            SELECT * FROM artifacts
+            WHERE case_id = ?
+            ORDER BY artifact_id ASC
+            ",
+        )?;
+        let rows = statement.query_map([case_id], Self::row_to_artifact)?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    }
+
+    pub fn upsert_artifact(&self, artifact: &Artifact) -> Result<(), SqliteStoreError> {
+        let connection = self.connect()?;
+        connection.execute(
+            "
+            INSERT INTO artifacts (artifact_id, case_id, artifact_type, uri_or_path, summary)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(artifact_id) DO UPDATE SET
+                case_id = excluded.case_id,
+                artifact_type = excluded.artifact_type,
+                uri_or_path = excluded.uri_or_path,
+                summary = excluded.summary
+            ",
+            (
+                &artifact.artifact_id,
+                &artifact.case_id,
+                artifact.artifact_type.to_string(),
+                &artifact.uri_or_path,
+                &artifact.summary,
+            ),
+        )?;
+        Ok(())
+    }
+
+    fn connect(&self) -> Result<Connection, SqliteStoreError> {
+        let connection = Connection::open(&self.db_path)?;
+        connection.execute_batch("PRAGMA foreign_keys = ON;")?;
+        Ok(connection)
+    }
+
+    fn initialize(&self) -> Result<(), SqliteStoreError> {
+        let connection = self.connect()?;
+        connection.execute_batch(
+            "
+            CREATE TABLE IF NOT EXISTS cases (
+                case_id TEXT PRIMARY KEY,
+                title TEXT NOT NULL,
+                status TEXT NOT NULL,
+                user_id TEXT,
+                agent_id TEXT,
+                started_at TEXT NOT NULL,
+                ended_at TEXT,
+                final_summary TEXT
+            );
+
+            CREATE TABLE IF NOT EXISTS events (
+                event_id TEXT PRIMARY KEY,
+                case_id TEXT NOT NULL,
+                event_type TEXT NOT NULL,
+                actor TEXT NOT NULL,
+                timestamp TEXT NOT NULL,
+                sequence_no INTEGER NOT NULL,
+                parent_event_id TEXT,
+                payload_json TEXT NOT NULL,
+                FOREIGN KEY(case_id) REFERENCES cases(case_id)
+            );
+
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_events_case_sequence
+            ON events(case_id, sequence_no);
+
+            CREATE TABLE IF NOT EXISTS decisions (
+                decision_id TEXT PRIMARY KEY,
+                case_id TEXT NOT NULL,
+                decision_type TEXT NOT NULL,
+                title TEXT NOT NULL,
+                question TEXT NOT NULL,
+                chosen_action TEXT NOT NULL,
+                alternatives_json TEXT NOT NULL,
+                evidence_event_ids_json TEXT NOT NULL,
+                constraint_summary TEXT,
+                requires_human_confirmation INTEGER NOT NULL,
+                outcome TEXT,
+                confidence REAL NOT NULL,
+                explanation_json TEXT NOT NULL,
+                sequence_no INTEGER NOT NULL,
+                FOREIGN KEY(case_id) REFERENCES cases(case_id)
+            );
+
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_decisions_case_sequence
+            ON decisions(case_id, sequence_no);
+
+            CREATE TABLE IF NOT EXISTS artifacts (
+                artifact_id TEXT PRIMARY KEY,
+                case_id TEXT NOT NULL,
+                artifact_type TEXT NOT NULL,
+                uri_or_path TEXT NOT NULL,
+                summary TEXT,
+                FOREIGN KEY(case_id) REFERENCES cases(case_id)
+            );
+            ",
+        )?;
+        Self::ensure_column(
+            &connection,
+            "decisions",
+            "confidence",
+            "REAL NOT NULL DEFAULT 0.5",
+        )?;
+        Self::ensure_column(
+            &connection,
+            "decisions",
+            "explanation_json",
+            "TEXT NOT NULL DEFAULT '{}'",
+        )?;
+        Ok(())
+    }
+
+    fn ensure_column(
+        connection: &Connection,
+        table: &str,
+        column: &str,
+        ddl: &str,
+    ) -> Result<(), SqliteStoreError> {
+        let mut statement = connection.prepare(&format!("PRAGMA table_info({table})"))?;
+        let rows = statement.query_map([], |row| row.get::<_, String>(1))?;
+        let existing = rows.collect::<Result<Vec<_>, _>>()?;
+        if existing.iter().any(|value| value == column) {
+            return Ok(());
+        }
+        connection.execute(
+            &format!("ALTER TABLE {table} ADD COLUMN {column} {ddl}"),
+            [],
+        )?;
+        Ok(())
+    }
+
+    fn row_to_case(row: &Row<'_>) -> Result<Case, rusqlite::Error> {
+        Ok(Case {
+            case_id: row.get("case_id")?,
+            title: row.get("title")?,
+            status: parse_enum("case status", &row.get::<_, String>("status")?)?,
+            user_id: row.get("user_id")?,
+            agent_id: row.get("agent_id")?,
+            started_at: parse_datetime(&row.get::<_, String>("started_at")?)?,
+            ended_at: row
+                .get::<_, Option<String>>("ended_at")?
+                .map(|value| parse_datetime(&value))
+                .transpose()?,
+            final_summary: row.get("final_summary")?,
+        })
+    }
+
+    fn row_to_event(row: &Row<'_>) -> Result<Event, rusqlite::Error> {
+        Ok(Event {
+            event_id: row.get("event_id")?,
+            case_id: row.get("case_id")?,
+            event_type: parse_enum("event type", &row.get::<_, String>("event_type")?)?,
+            actor: parse_enum("event actor", &row.get::<_, String>("actor")?)?,
+            timestamp: parse_datetime(&row.get::<_, String>("timestamp")?)?,
+            sequence_no: row.get("sequence_no")?,
+            parent_event_id: row.get("parent_event_id")?,
+            payload: serde_json::from_str(&row.get::<_, String>("payload_json")?)
+                .map_err(json_to_sqlite_error)?,
+        })
+    }
+
+    fn row_to_decision(row: &Row<'_>) -> Result<Decision, rusqlite::Error> {
+        Ok(Decision {
+            decision_id: row.get("decision_id")?,
+            case_id: row.get("case_id")?,
+            decision_type: parse_enum("decision type", &row.get::<_, String>("decision_type")?)?,
+            title: row.get("title")?,
+            question: row.get("question")?,
+            chosen_action: row.get("chosen_action")?,
+            alternatives: serde_json::from_str(&row.get::<_, String>("alternatives_json")?)
+                .map_err(json_to_sqlite_error)?,
+            evidence_event_ids: serde_json::from_str(
+                &row.get::<_, String>("evidence_event_ids_json")?,
+            )
+            .map_err(json_to_sqlite_error)?,
+            constraint_summary: row.get("constraint_summary")?,
+            requires_human_confirmation: row.get::<_, i64>("requires_human_confirmation")? != 0,
+            outcome: row.get("outcome")?,
+            confidence: row.get("confidence")?,
+            explanation: serde_json::from_str::<DecisionExplanation>(
+                &row.get::<_, String>("explanation_json")?,
+            )
+            .map_err(json_to_sqlite_error)?,
+            sequence_no: row.get("sequence_no")?,
+        })
+    }
+
+    fn row_to_artifact(row: &Row<'_>) -> Result<Artifact, rusqlite::Error> {
+        Ok(Artifact {
+            artifact_id: row.get("artifact_id")?,
+            case_id: row.get("case_id")?,
+            artifact_type: parse_enum("artifact type", &row.get::<_, String>("artifact_type")?)?,
+            uri_or_path: row.get("uri_or_path")?,
+            summary: row.get("summary")?,
+        })
+    }
+}
+
+fn payload_summary(payload: &Value) -> Option<String> {
+    let summary = payload.get("summary")?.as_str()?;
+    if summary.trim().is_empty() {
+        None
+    } else {
+        Some(summary.to_string())
+    }
+}
+
+fn parse_datetime(value: &str) -> Result<DateTime<Utc>, rusqlite::Error> {
+    DateTime::parse_from_rfc3339(value)
+        .map(|value| value.with_timezone(&Utc))
+        .map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                0,
+                rusqlite::types::Type::Text,
+                Box::new(SqliteStoreError::DateTime(error.to_string())),
+            )
+        })
+}
+
+fn parse_enum<T>(kind: &'static str, value: &str) -> Result<T, rusqlite::Error>
+where
+    T: FromStr,
+{
+    T::from_str(value).map_err(|_| {
+        rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Text,
+            Box::new(SqliteStoreError::EnumValue {
+                kind,
+                value: value.to_string(),
+            }),
+        )
+    })
+}
+
+fn json_to_sqlite_error(error: serde_json::Error) -> rusqlite::Error {
+    rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(error))
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{TimeZone, Utc};
+    use openprecedent_contracts::{
+        Case, CaseStatus, Decision, DecisionExplanation, DecisionType, Event, EventType,
+    };
+    use rusqlite::Connection;
+    use serde_json::json;
+    use tempfile::tempdir;
+
+    use super::SqliteStore;
+
+    #[test]
+    fn initializes_schema_and_roundtrips_core_records() {
+        let tmp = tempdir().expect("tmp");
+        let store =
+            SqliteStore::new(tmp.path().join("runtime").join("openprecedent.db")).expect("store");
+
+        let case = Case {
+            case_id: "case-1".to_string(),
+            title: "Rust store".to_string(),
+            status: CaseStatus::Started,
+            user_id: Some("user-1".to_string()),
+            agent_id: Some("agent-1".to_string()),
+            started_at: Utc.with_ymd_and_hms(2026, 3, 13, 10, 0, 0).unwrap(),
+            ended_at: None,
+            final_summary: None,
+        };
+        store.create_case(&case).expect("create case");
+
+        let started_event = Event {
+            event_id: "event-0".to_string(),
+            case_id: case.case_id.clone(),
+            event_type: EventType::CaseStarted,
+            actor: openprecedent_contracts::EventActor::System,
+            timestamp: Utc.with_ymd_and_hms(2026, 3, 13, 10, 0, 0).unwrap(),
+            sequence_no: 1,
+            parent_event_id: None,
+            payload: json!({"session_id": "session-1"}),
+        };
+        store.append_event(&started_event).expect("append start");
+
+        let event = Event {
+            event_id: "event-1".to_string(),
+            case_id: case.case_id.clone(),
+            event_type: EventType::CaseCompleted,
+            actor: openprecedent_contracts::EventActor::System,
+            timestamp: Utc.with_ymd_and_hms(2026, 3, 13, 10, 5, 0).unwrap(),
+            sequence_no: 2,
+            parent_event_id: None,
+            payload: json!({"summary": "done", "session_id": "session-1"}),
+        };
+        store.append_event(&event).expect("append event");
+
+        let decision = Decision {
+            decision_id: "decision-1".to_string(),
+            case_id: case.case_id.clone(),
+            decision_type: DecisionType::TaskFrameDefined,
+            title: "Frame the task".to_string(),
+            question: "What should be done?".to_string(),
+            chosen_action: "Bootstrap the workspace".to_string(),
+            alternatives: vec!["Do nothing".to_string()],
+            evidence_event_ids: vec![started_event.event_id.clone(), event.event_id.clone()],
+            constraint_summary: Some("Keep the CLI stable".to_string()),
+            requires_human_confirmation: false,
+            outcome: Some("accepted".to_string()),
+            confidence: 0.9,
+            explanation: DecisionExplanation {
+                goal: "create the initial CLI".to_string(),
+                evidence: vec!["issue scope".to_string()],
+                constraints: vec!["long-term contract".to_string()],
+                selection_reason: "best first slice".to_string(),
+                result: Some("workspace created".to_string()),
+            },
+            sequence_no: 1,
+        };
+        store
+            .replace_decisions(&case.case_id, &[decision.clone()])
+            .expect("replace decisions");
+
+        let artifact = openprecedent_contracts::Artifact {
+            artifact_id: "artifact-1".to_string(),
+            case_id: case.case_id.clone(),
+            artifact_type: openprecedent_contracts::ArtifactType::Report,
+            uri_or_path: "docs/report.md".to_string(),
+            summary: Some("bootstrap report".to_string()),
+        };
+        store.upsert_artifact(&artifact).expect("artifact");
+
+        assert_eq!(
+            store
+                .get_case(&case.case_id)
+                .expect("get case")
+                .unwrap()
+                .status,
+            CaseStatus::Completed
+        );
+        assert_eq!(
+            store.list_events(&case.case_id).expect("events"),
+            vec![started_event, event]
+        );
+        assert_eq!(
+            store.list_decisions(&case.case_id).expect("decisions"),
+            vec![decision]
+        );
+        assert_eq!(
+            store.list_artifacts(&case.case_id).expect("artifacts"),
+            vec![artifact]
+        );
+        assert_eq!(
+            store
+                .find_case_id_by_openclaw_session_id("session-1")
+                .expect("session lookup"),
+            Some(case.case_id.clone())
+        );
+        assert_eq!(
+            store.next_event_sequence(&case.case_id).expect("sequence"),
+            3
+        );
+    }
+
+    #[test]
+    fn adds_missing_decision_columns_for_legacy_schema() {
+        let tmp = tempdir().expect("tmp");
+        let db_path = tmp.path().join("legacy.db");
+        let connection = Connection::open(&db_path).expect("legacy db");
+        connection
+            .execute_batch(
+                "
+                CREATE TABLE decisions (
+                    decision_id TEXT PRIMARY KEY,
+                    case_id TEXT NOT NULL,
+                    decision_type TEXT NOT NULL,
+                    title TEXT NOT NULL,
+                    question TEXT NOT NULL,
+                    chosen_action TEXT NOT NULL,
+                    alternatives_json TEXT NOT NULL,
+                    evidence_event_ids_json TEXT NOT NULL,
+                    constraint_summary TEXT,
+                    requires_human_confirmation INTEGER NOT NULL,
+                    outcome TEXT,
+                    sequence_no INTEGER NOT NULL
+                );
+                ",
+            )
+            .expect("legacy schema");
+        drop(connection);
+
+        let _store = SqliteStore::new(&db_path).expect("migrated store");
+        let connection = Connection::open(&db_path).expect("db");
+        let mut statement = connection
+            .prepare("PRAGMA table_info(decisions)")
+            .expect("pragma");
+        let rows = statement
+            .query_map([], |row| row.get::<_, String>(1))
+            .expect("rows")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("columns");
+
+        assert!(rows.contains(&"confidence".to_string()));
+        assert!(rows.contains(&"explanation_json".to_string()));
+    }
+}


### PR DESCRIPTION
Closes #176

Implement the Rust SQLite store crate with schema bootstrap, legacy migration handling, and reusable CRUD-style methods for the core case, event, decision, and artifact records.

Implementation notes:
- The store crate now owns the SQLite DDL for cases, events, decisions, and artifacts.
- The Rust contracts crate now includes the core persisted object types, which later command slices can use directly.

Validation:
- run `. \"$HOME/.cargo/env\" && cargo test`
- run `./scripts/run-pytest.sh -q tests/test_rust_cli_workspace.py`
- `. "$HOME/.cargo/env" && cargo test; ./scripts/run-pytest.sh -q tests/test_rust_cli_workspace.py; ./scripts/run-agent-preflight.sh`