### PR TITLE
Migrate case commands to the Rust CLI

### DIFF
--- a/.codex/pm/issue-state/177-migrate-case-commands-to-rust-cli.md
+++ b/.codex/pm/issue-state/177-migrate-case-commands-to-rust-cli.md
@@ -1,0 +1,32 @@
+---
+type: issue_state
+issue: 177
+task: .codex/pm/tasks/public-cli-foundation/migrate-case-commands-to-rust-cli.md
+title: Migrate case commands to the Rust CLI
+status: in_progress
+---
+
+## Summary
+
+Migrate the public `openprecedent case` command family from the Python CLI into the Rust CLI on top of the Rust config and store layers.
+
+## Validated Facts
+
+- the Rust CLI now implements `case create`, `case list`, and `case show`
+- the Rust case commands persist and read data through the Rust SQLite store crate, not the Python service layer
+- create, list, show, generated case ids, duplicate-case errors, and missing-case errors are covered by Rust integration tests
+- `cargo test -p openprecedent-cli` passes with both the doctor/version tests and the new case contract tests
+
+## Open Questions
+
+- whether the next event-command slice should reuse the same one-file CLI shape or split the command handlers into smaller modules first
+
+## Next Steps
+
+- run repository preflight, commit the `#177` implementation, open a child PR against `codex/issue-172-rust-public-cli`, and merge it
+- start `#178` after the Rust case commands land in the integration branch
+
+## Artifacts
+
+- `rust/openprecedent-cli/src/main.rs`
+- `rust/openprecedent-cli/tests/case_contract.rs`

--- a/.codex/pm/tasks/public-cli-foundation/migrate-case-commands-to-rust-cli.md
+++ b/.codex/pm/tasks/public-cli-foundation/migrate-case-commands-to-rust-cli.md
@@ -3,32 +3,43 @@ type: task
 epic: public-cli-foundation
 slug: migrate-case-commands-to-rust-cli
 title: Migrate case commands to the Rust CLI
-status: backlog
+status: done
 task_type: implementation
 labels: cli,rust,interface
 issue: 177
+state_path: .codex/pm/issue-state/177-migrate-case-commands-to-rust-cli.md
 ---
 
 ## Context
 
-Planned child issue under `#172`. Expand the implementation detail when this issue becomes active.
+The Rust CLI now has global config handling and a reusable SQLite store layer.
+This slice migrates the first public domain command family, `openprecedent case`, off the Python CLI and onto the Rust binary using the new store.
 
 ## Deliverable
 
-Implement the scoped GitHub issue on a child branch that merges into `codex/issue-172-rust-public-cli`.
+Implement `case create`, `case list`, and `case show` directly in the Rust CLI, preserving the expected JSON behavior and key error semantics.
 
 ## Scope
 
-- follow the scoped work and constraints defined in the linked GitHub issue
+- replace the placeholder Rust `case` command tree with real create/list/show handling
+- connect the Rust `case` command family to the Rust SQLite store
+- preserve expected machine-readable JSON output for create, list, and show
+- preserve user-facing error cases for duplicate case ids and missing case ids
+- add Rust integration tests that exercise the `case` surface through the compiled binary
 
 ## Acceptance Criteria
 
-- satisfy the acceptance criteria in the linked GitHub issue before opening a child PR
+- the public `case` command family runs through the Rust binary
+- machine-readable output is stable enough for automation and test fixtures
+- case operations do not call the Python CLI or shell wrappers
+- Rust integration tests cover create, list, show, generated ids, and duplicate or missing-case failures
 
 ## Validation
 
-- run issue-appropriate local validation when this task becomes active
+- run `. \"$HOME/.cargo/env\" && cargo test -p openprecedent-cli`
+- run `./scripts/run-pytest.sh -q tests/test_rust_cli_workspace.py`
 
 ## Implementation Notes
 
-- This task twin was scaffolded during the Rust CLI issue decomposition and should be elaborated when implementation starts.
+- The Rust CLI now generates `case_<12 hex chars>` ids when `--case-id` is omitted, matching the current Python behavior.
+- Text rendering remains human-focused, but JSON output is the contract surface for automation.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,13 +457,16 @@ name = "openprecedent-cli"
 version = "0.1.0"
 dependencies = [
  "assert_cmd",
+ "chrono",
  "clap",
  "openprecedent-contracts",
  "openprecedent-core",
+ "openprecedent-store-sqlite",
  "predicates",
  "serde",
  "serde_json",
  "tempfile",
+ "uuid",
 ]
 
 [[package]]
@@ -836,6 +839,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+dependencies = [
+ "getrandom",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,4 @@ strum = { version = "0.27.2", features = ["derive"] }
 tempfile = "3.20.0"
 thiserror = "2.0.12"
 toml = "0.8.23"
+uuid = { version = "1.18.1", features = ["v4"] }

--- a/rust/openprecedent-cli/Cargo.toml
+++ b/rust/openprecedent-cli/Cargo.toml
@@ -10,11 +10,14 @@ name = "openprecedent"
 path = "src/main.rs"
 
 [dependencies]
+chrono.workspace = true
 clap.workspace = true
 openprecedent-contracts = { path = "../openprecedent-contracts" }
 openprecedent-core = { path = "../openprecedent-core" }
+openprecedent-store-sqlite = { path = "../openprecedent-store-sqlite" }
 serde.workspace = true
 serde_json.workspace = true
+uuid.workspace = true
 
 [dev-dependencies]
 assert_cmd.workspace = true

--- a/rust/openprecedent-cli/src/main.rs
+++ b/rust/openprecedent-cli/src/main.rs
@@ -1,15 +1,18 @@
 use std::ffi::OsString;
 
+use chrono::Utc;
 use clap::{ArgAction, Args, CommandFactory, FromArgMatches, Parser, Subcommand};
 use openprecedent_contracts::{
-    OutputFormat, PathsDoctorReport, StorageDoctorReport, VersionReport, CLI_BINARY_NAME,
-    CONTRACT_PHASE,
+    Case, CaseStatus, OutputFormat, PathsDoctorReport, StorageDoctorReport, VersionReport,
+    CLI_BINARY_NAME, CONTRACT_PHASE,
 };
 use openprecedent_core::{
     build_environment_report, build_paths_report, build_storage_report, build_version_report,
-    not_implemented, resolve_runtime_config, CliConfigOverrides,
+    not_implemented, resolve_runtime_config, CliConfigOverrides, ResolvedRuntimeConfig,
 };
+use openprecedent_store_sqlite::SqliteStore;
 use serde::Serialize;
+use uuid::Uuid;
 
 #[derive(Debug, Parser)]
 #[command(name = CLI_BINARY_NAME)]
@@ -55,9 +58,26 @@ struct CaseCommand {
 
 #[derive(Debug, Subcommand)]
 enum CaseSubcommand {
-    Create(TrailingArgs),
-    List(TrailingArgs),
-    Show(TrailingArgs),
+    Create(CreateCaseArgs),
+    List,
+    Show(ShowCaseArgs),
+}
+
+#[derive(Debug, Args)]
+struct CreateCaseArgs {
+    #[arg(long)]
+    title: String,
+    #[arg(long = "case-id")]
+    case_id: Option<String>,
+    #[arg(long = "user-id")]
+    user_id: Option<String>,
+    #[arg(long = "agent-id")]
+    agent_id: Option<String>,
+}
+
+#[derive(Debug, Args)]
+struct ShowCaseArgs {
+    case_id: String,
 }
 
 #[derive(Debug, Args)]
@@ -246,7 +266,7 @@ where
             &build_version_report(env!("CARGO_PKG_VERSION"), CONTRACT_PHASE),
             config.format.value,
         ),
-        Command::Case(command) => render_not_implemented_path(case_path(command)),
+        Command::Case(command) => handle_case(command, &config),
         Command::Event(command) => render_not_implemented_path(event_path(command)),
         Command::Decision(command) => render_not_implemented_path(decision_path(command)),
         Command::Replay(command) => render_not_implemented_path(replay_path(command)),
@@ -254,6 +274,71 @@ where
         Command::Capture(command) => render_not_implemented_path(capture_path(command)),
         Command::Lineage(command) => render_not_implemented_path(lineage_path(command)),
         Command::Eval(command) => render_not_implemented_path(eval_path(command)),
+    }
+}
+
+fn handle_case(command: CaseCommand, config: &ResolvedRuntimeConfig) -> i32 {
+    let store = match SqliteStore::new(&config.db.path) {
+        Ok(store) => store,
+        Err(error) => {
+            eprintln!("{error}");
+            return 1;
+        }
+    };
+
+    match command.command {
+        CaseSubcommand::Create(args) => {
+            let case_id = args
+                .case_id
+                .unwrap_or_else(|| format!("case_{}", &Uuid::new_v4().simple().to_string()[..12]));
+            match store.get_case(&case_id) {
+                Ok(Some(_)) => {
+                    eprintln!("case already exists: {case_id}");
+                    1
+                }
+                Ok(None) => {
+                    let case = Case {
+                        case_id,
+                        title: args.title,
+                        status: CaseStatus::Started,
+                        user_id: args.user_id,
+                        agent_id: args.agent_id,
+                        started_at: Utc::now(),
+                        ended_at: None,
+                        final_summary: None,
+                    };
+                    match store.create_case(&case) {
+                        Ok(()) => render(&case, config.format.value),
+                        Err(error) => {
+                            eprintln!("{error}");
+                            1
+                        }
+                    }
+                }
+                Err(error) => {
+                    eprintln!("{error}");
+                    1
+                }
+            }
+        }
+        CaseSubcommand::List => match store.list_cases() {
+            Ok(cases) => render_case_list(&cases, config.format.value),
+            Err(error) => {
+                eprintln!("{error}");
+                1
+            }
+        },
+        CaseSubcommand::Show(args) => match store.get_case(&args.case_id) {
+            Ok(Some(case)) => render(&case, config.format.value),
+            Ok(None) => {
+                eprintln!("case not found: {}", args.case_id);
+                1
+            }
+            Err(error) => {
+                eprintln!("{error}");
+                1
+            }
+        },
     }
 }
 
@@ -285,8 +370,53 @@ where
     }
 }
 
+fn render_case_list(cases: &[Case], format: OutputFormat) -> i32 {
+    match format {
+        OutputFormat::Json => match serde_json::to_string_pretty(cases) {
+            Ok(json) => {
+                println!("{json}");
+                0
+            }
+            Err(error) => {
+                eprintln!("{error}");
+                1
+            }
+        },
+        OutputFormat::Text => {
+            for case in cases {
+                println!("{} {} {}", case.case_id, case.status, case.title);
+            }
+            0
+        }
+    }
+}
+
 trait TextRenderable {
     fn render_text(&self) -> String;
+}
+
+impl TextRenderable for Case {
+    fn render_text(&self) -> String {
+        let mut lines = vec![
+            format!("case_id: {}", self.case_id),
+            format!("title: {}", self.title),
+            format!("status: {}", self.status),
+            format!("started_at: {}", self.started_at.to_rfc3339()),
+        ];
+        if let Some(user_id) = &self.user_id {
+            lines.push(format!("user_id: {user_id}"));
+        }
+        if let Some(agent_id) = &self.agent_id {
+            lines.push(format!("agent_id: {agent_id}"));
+        }
+        if let Some(ended_at) = &self.ended_at {
+            lines.push(format!("ended_at: {}", ended_at.to_rfc3339()));
+        }
+        if let Some(summary) = &self.final_summary {
+            lines.push(format!("final_summary: {summary}"));
+        }
+        lines.join("\n")
+    }
 }
 
 impl TextRenderable for VersionReport {
@@ -364,14 +494,6 @@ fn render_storage_line(label: &str, path: &openprecedent_contracts::StoragePathR
         path.exists,
         path.parent_exists
     )
-}
-
-fn case_path(command: CaseCommand) -> Vec<&'static str> {
-    match command.command {
-        CaseSubcommand::Create(_) => vec!["case", "create"],
-        CaseSubcommand::List(_) => vec!["case", "list"],
-        CaseSubcommand::Show(_) => vec!["case", "show"],
-    }
 }
 
 fn event_path(command: EventCommand) -> Vec<&'static str> {

--- a/rust/openprecedent-cli/tests/case_contract.rs
+++ b/rust/openprecedent-cli/tests/case_contract.rs
@@ -1,0 +1,157 @@
+use assert_cmd::Command;
+use serde_json::Value;
+use tempfile::tempdir;
+
+fn cli() -> Command {
+    Command::cargo_bin("openprecedent").expect("cargo bin")
+}
+
+#[test]
+fn case_create_list_and_show_work_in_json_mode() {
+    let runtime = tempdir().expect("runtime");
+    let db_path = runtime.path().join("openprecedent.db");
+
+    let create_output = cli()
+        .args([
+            "--db",
+            db_path.to_str().expect("db path"),
+            "--format",
+            "json",
+            "case",
+            "create",
+            "--case-id",
+            "case_rust_cli",
+            "--title",
+            "Rust case",
+            "--user-id",
+            "user-1",
+            "--agent-id",
+            "agent-1",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let created: Value = serde_json::from_slice(&create_output).expect("created");
+    assert_eq!(created["case_id"], "case_rust_cli");
+    assert_eq!(created["status"], "started");
+
+    let list_output = cli()
+        .args([
+            "--db",
+            db_path.to_str().expect("db path"),
+            "--format",
+            "json",
+            "case",
+            "list",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let listed: Value = serde_json::from_slice(&list_output).expect("list");
+    assert_eq!(listed.as_array().expect("array").len(), 1);
+
+    let show_output = cli()
+        .args([
+            "--db",
+            db_path.to_str().expect("db path"),
+            "--format",
+            "json",
+            "case",
+            "show",
+            "case_rust_cli",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let shown: Value = serde_json::from_slice(&show_output).expect("show");
+    assert_eq!(shown["title"], "Rust case");
+}
+
+#[test]
+fn case_create_generates_case_id_when_omitted() {
+    let runtime = tempdir().expect("runtime");
+    let db_path = runtime.path().join("openprecedent.db");
+
+    let output = cli()
+        .args([
+            "--db",
+            db_path.to_str().expect("db path"),
+            "--format",
+            "json",
+            "case",
+            "create",
+            "--title",
+            "Generated id case",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let created: Value = serde_json::from_slice(&output).expect("created");
+    let case_id = created["case_id"].as_str().expect("case id");
+    assert!(case_id.starts_with("case_"));
+    assert_eq!(case_id.len(), 17);
+}
+
+#[test]
+fn case_show_reports_missing_case() {
+    let runtime = tempdir().expect("runtime");
+    let db_path = runtime.path().join("openprecedent.db");
+
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().expect("db path"),
+            "case",
+            "show",
+            "missing-case",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("case not found: missing-case"));
+}
+
+#[test]
+fn case_create_reports_duplicate_case_id() {
+    let runtime = tempdir().expect("runtime");
+    let db_path = runtime.path().join("openprecedent.db");
+
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().expect("db path"),
+            "case",
+            "create",
+            "--case-id",
+            "duplicate-case",
+            "--title",
+            "first",
+        ])
+        .assert()
+        .success();
+
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().expect("db path"),
+            "case",
+            "create",
+            "--case-id",
+            "duplicate-case",
+            "--title",
+            "second",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "case already exists: duplicate-case",
+        ));
+}


### PR DESCRIPTION
Closes #177

Implement `case create`, `case list`, and `case show` directly in the Rust CLI, preserving the expected JSON behavior and key error semantics.

Implementation notes:
- The Rust CLI now generates `case_<12 hex chars>` ids when `--case-id` is omitted, matching the current Python behavior.
- Text rendering remains human-focused, but JSON output is the contract surface for automation.

Validation:
- run `. \"$HOME/.cargo/env\" && cargo test -p openprecedent-cli`
- run `./scripts/run-pytest.sh -q tests/test_rust_cli_workspace.py`
- `. "$HOME/.cargo/env" && cargo test -p openprecedent-cli; ./scripts/run-pytest.sh -q tests/test_rust_cli_workspace.py; ./scripts/run-agent-preflight.sh`