### PR TITLE
Migrate event commands to the Rust CLI

### DIFF
--- a/.codex/pm/issue-state/178-migrate-event-commands-to-rust-cli.md
+++ b/.codex/pm/issue-state/178-migrate-event-commands-to-rust-cli.md
@@ -1,0 +1,36 @@
+---
+type: issue_state
+issue: 178
+task: .codex/pm/tasks/public-cli-foundation/migrate-event-commands-to-rust-cli.md
+title: Migrate event commands to the Rust CLI
+status: in_progress
+---
+
+## Summary
+
+Migrate the public `openprecedent event` command family from the Python CLI into the Rust CLI on top of the Rust config and SQLite store layers.
+
+## Validated Facts
+
+- the Rust CLI now implements `event append` and `event import-jsonl`
+- the Rust event commands persist and read data through the Rust SQLite store crate, not the Python service layer
+- event append covers generated event ids, case existence checks, payload parsing, and sequence allocation
+- event import ingests canonical event JSONL records, supports `--case-id` fallback, preserves case completion summary/status transitions, and errors when `case_id` is missing
+- the shared Rust event contract now serializes `EventType` with the existing dotted public values such as `message.agent` and `case.completed`
+- `cargo test` and `cargo test -p openprecedent-cli -p openprecedent-contracts` pass with the new event contract tests
+
+## Open Questions
+
+- whether the next replay/decision slices should keep extending `main.rs` directly or extract command handlers into smaller modules as the Rust surface grows
+
+## Next Steps
+
+- run local preflight, commit the `#178` slice, open a child PR against `codex/issue-172-rust-public-cli`, and merge it
+- start `#179` after the Rust event commands land in the integration branch
+
+## Artifacts
+
+- `rust/openprecedent-cli/src/main.rs`
+- `rust/openprecedent-cli/tests/event_contract.rs`
+- `rust/openprecedent-contracts/src/event.rs`
+- `.codex/pm/tasks/public-cli-foundation/migrate-event-commands-to-rust-cli.md`

--- a/.codex/pm/tasks/public-cli-foundation/migrate-event-commands-to-rust-cli.md
+++ b/.codex/pm/tasks/public-cli-foundation/migrate-event-commands-to-rust-cli.md
@@ -3,7 +3,7 @@ type: task
 epic: public-cli-foundation
 slug: migrate-event-commands-to-rust-cli
 title: Migrate event commands to the Rust CLI
-status: backlog
+status: done
 task_type: implementation
 labels: cli,rust,interface
 issue: 178
@@ -11,24 +11,33 @@ issue: 178
 
 ## Context
 
-Planned child issue under `#172`. Expand the implementation detail when this issue becomes active.
+Child issue `#178` under `#172` migrates the public `openprecedent event` command family from Python into the Rust CLI. This slice should land only the event append and structured JSONL import surfaces, preserving the raw-event timeline contract and the existing SQLite persistence layout.
 
 ## Deliverable
 
-Implement the scoped GitHub issue on a child branch that merges into `codex/issue-172-rust-public-cli`.
+Implement `openprecedent event append` and `openprecedent event import-jsonl` in Rust on a dedicated child branch that merges into `codex/issue-172-rust-public-cli`.
 
 ## Scope
 
-- follow the scoped work and constraints defined in the linked GitHub issue
+- replace the placeholder Rust `event` handlers with real append/import implementations
+- preserve event ordering, sequence assignment, timestamps, payload storage, and case status transitions
+- validate imported and appended events against the current CLI contract expectations
 
 ## Acceptance Criteria
 
-- satisfy the acceptance criteria in the linked GitHub issue before opening a child PR
+- `openprecedent event append` writes a new event through the Rust store and returns the created event
+- `openprecedent event import-jsonl` ingests JSONL event records through the Rust CLI without depending on the Python CLI
+- stored events remain compatible with the current persistence model and replay ordering assumptions
+- Rust tests cover append and import success paths plus key error cases
 
 ## Validation
 
-- run issue-appropriate local validation when this task becomes active
+- run `cargo test -p openprecedent-cli`
+- run `./scripts/run-pytest.sh -q tests/test_rust_cli_workspace.py`
+- run `./scripts/run-agent-preflight.sh` before opening the PR
 
 ## Implementation Notes
 
-- This task twin was scaffolded during the Rust CLI issue decomposition and should be elaborated when implementation starts.
+- Keep the public interface contract-first: stable JSON output, domain-shaped errors, and no shell wrapper dependencies.
+- Reuse the Rust SQLite store instead of adding Python interop or shell delegation.
+- Completed on `codex/issue-178-rust-event-commands` with Rust `event append` / `event import-jsonl`, contract tests, and an event-type serialization compatibility fix in the shared Rust contracts crate.

--- a/rust/openprecedent-cli/src/main.rs
+++ b/rust/openprecedent-cli/src/main.rs
@@ -1,17 +1,21 @@
 use std::ffi::OsString;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
 
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use clap::{ArgAction, Args, CommandFactory, FromArgMatches, Parser, Subcommand};
 use openprecedent_contracts::{
-    Case, CaseStatus, OutputFormat, PathsDoctorReport, StorageDoctorReport, VersionReport,
-    CLI_BINARY_NAME, CONTRACT_PHASE,
+    Case, CaseStatus, Event, EventActor, EventType, OutputFormat, PathsDoctorReport,
+    StorageDoctorReport, VersionReport, CLI_BINARY_NAME, CONTRACT_PHASE,
 };
 use openprecedent_core::{
     build_environment_report, build_paths_report, build_storage_report, build_version_report,
     not_implemented, resolve_runtime_config, CliConfigOverrides, ResolvedRuntimeConfig,
 };
 use openprecedent_store_sqlite::SqliteStore;
+use serde::Deserialize;
 use serde::Serialize;
+use serde_json::{Map, Value};
 use uuid::Uuid;
 
 #[derive(Debug, Parser)]
@@ -88,8 +92,26 @@ struct EventCommand {
 
 #[derive(Debug, Subcommand)]
 enum EventSubcommand {
-    Append(TrailingArgs),
-    ImportJsonl(TrailingArgs),
+    Append(AppendEventArgs),
+    ImportJsonl(ImportJsonlArgs),
+}
+
+#[derive(Debug, Args)]
+struct AppendEventArgs {
+    case_id: String,
+    event_type: String,
+    actor: String,
+    #[arg(long, default_value = "{}")]
+    payload: String,
+    #[arg(long = "event-id")]
+    event_id: Option<String>,
+}
+
+#[derive(Debug, Args)]
+struct ImportJsonlArgs {
+    path: std::path::PathBuf,
+    #[arg(long = "case-id")]
+    case_id: Option<String>,
 }
 
 #[derive(Debug, Args)]
@@ -267,7 +289,7 @@ where
             config.format.value,
         ),
         Command::Case(command) => handle_case(command, &config),
-        Command::Event(command) => render_not_implemented_path(event_path(command)),
+        Command::Event(command) => handle_event(command, &config),
         Command::Decision(command) => render_not_implemented_path(decision_path(command)),
         Command::Replay(command) => render_not_implemented_path(replay_path(command)),
         Command::Precedent(command) => render_not_implemented_path(precedent_path(command)),
@@ -342,6 +364,141 @@ fn handle_case(command: CaseCommand, config: &ResolvedRuntimeConfig) -> i32 {
     }
 }
 
+fn handle_event(command: EventCommand, config: &ResolvedRuntimeConfig) -> i32 {
+    let store = match SqliteStore::new(&config.db.path) {
+        Ok(store) => store,
+        Err(error) => {
+            eprintln!("{error}");
+            return 1;
+        }
+    };
+
+    match command.command {
+        EventSubcommand::Append(args) => {
+            let payload = match serde_json::from_str::<Value>(&args.payload) {
+                Ok(Value::Object(payload)) => payload,
+                Ok(_) => {
+                    eprintln!("event payload must be a JSON object");
+                    return 1;
+                }
+                Err(error) => {
+                    eprintln!("{error}");
+                    return 1;
+                }
+            };
+
+            let event_type = match args.event_type.parse::<EventType>() {
+                Ok(value) => value,
+                Err(error) => {
+                    eprintln!("{error}");
+                    return 1;
+                }
+            };
+            let actor = match args.actor.parse::<EventActor>() {
+                Ok(value) => value,
+                Err(error) => {
+                    eprintln!("{error}");
+                    return 1;
+                }
+            };
+
+            if let Some(code) = ensure_case_exists(&store, &args.case_id) {
+                return code;
+            }
+
+            let event = Event {
+                event_id: args.event_id.unwrap_or_else(|| {
+                    format!("evt_{}", &Uuid::new_v4().simple().to_string()[..12])
+                }),
+                case_id: args.case_id.clone(),
+                event_type,
+                actor,
+                timestamp: Utc::now(),
+                sequence_no: match store.next_event_sequence(&args.case_id) {
+                    Ok(sequence_no) => sequence_no,
+                    Err(error) => {
+                        eprintln!("{error}");
+                        return 1;
+                    }
+                },
+                parent_event_id: None,
+                payload: Value::Object(payload),
+            };
+
+            match store.append_event(&event) {
+                Ok(()) => render(&event, config.format.value),
+                Err(error) => {
+                    eprintln!("{error}");
+                    1
+                }
+            }
+        }
+        EventSubcommand::ImportJsonl(args) => {
+            let file = match File::open(&args.path) {
+                Ok(file) => file,
+                Err(error) => {
+                    eprintln!("{error}");
+                    return 1;
+                }
+            };
+
+            let mut imported = Vec::new();
+            for (index, line_result) in BufReader::new(file).lines().enumerate() {
+                let line_number = index + 1;
+                let line = match line_result {
+                    Ok(line) => line,
+                    Err(error) => {
+                        eprintln!("{error}");
+                        return 1;
+                    }
+                };
+                let stripped = line.trim();
+                if stripped.is_empty() {
+                    continue;
+                }
+
+                let input = match serde_json::from_str::<ImportedEventRecord>(stripped) {
+                    Ok(input) => input,
+                    Err(error) => {
+                        eprintln!("{error}");
+                        return 1;
+                    }
+                };
+
+                let case_id = match input.case_id.clone().or_else(|| args.case_id.clone()) {
+                    Some(case_id) if !case_id.is_empty() => case_id,
+                    _ => {
+                        eprintln!("line {line_number}: case_id is required");
+                        return 1;
+                    }
+                };
+
+                if let Some(code) = ensure_case_exists(&store, &case_id) {
+                    return code;
+                }
+
+                let event = match imported_event_to_event(input, &store, &case_id) {
+                    Ok(event) => event,
+                    Err(error) => {
+                        eprintln!("line {line_number}: {error}");
+                        return 1;
+                    }
+                };
+
+                match store.append_event(&event) {
+                    Ok(()) => imported.push(event),
+                    Err(error) => {
+                        eprintln!("{error}");
+                        return 1;
+                    }
+                }
+            }
+
+            render_event_list(&imported, config.format.value)
+        }
+    }
+}
+
 fn render_not_implemented_path(path: Vec<&'static str>) -> i32 {
     let error = not_implemented(&path);
     eprintln!("{error}");
@@ -391,6 +548,30 @@ fn render_case_list(cases: &[Case], format: OutputFormat) -> i32 {
     }
 }
 
+fn render_event_list(events: &[Event], format: OutputFormat) -> i32 {
+    match format {
+        OutputFormat::Json => match serde_json::to_string_pretty(events) {
+            Ok(json) => {
+                println!("{json}");
+                0
+            }
+            Err(error) => {
+                eprintln!("{error}");
+                1
+            }
+        },
+        OutputFormat::Text => {
+            for event in events {
+                println!(
+                    "[{}] {} {} {}",
+                    event.sequence_no, event.event_id, event.event_type, event.actor
+                );
+            }
+            0
+        }
+    }
+}
+
 trait TextRenderable {
     fn render_text(&self) -> String;
 }
@@ -414,6 +595,24 @@ impl TextRenderable for Case {
         }
         if let Some(summary) = &self.final_summary {
             lines.push(format!("final_summary: {summary}"));
+        }
+        lines.join("\n")
+    }
+}
+
+impl TextRenderable for Event {
+    fn render_text(&self) -> String {
+        let mut lines = vec![
+            format!("event_id: {}", self.event_id),
+            format!("case_id: {}", self.case_id),
+            format!("event_type: {}", self.event_type),
+            format!("actor: {}", self.actor),
+            format!("timestamp: {}", self.timestamp.to_rfc3339()),
+            format!("sequence_no: {}", self.sequence_no),
+            format!("payload: {}", self.payload),
+        ];
+        if let Some(parent_event_id) = &self.parent_event_id {
+            lines.push(format!("parent_event_id: {parent_event_id}"));
         }
         lines.join("\n")
     }
@@ -496,18 +695,91 @@ fn render_storage_line(label: &str, path: &openprecedent_contracts::StoragePathR
     )
 }
 
-fn event_path(command: EventCommand) -> Vec<&'static str> {
-    match command.command {
-        EventSubcommand::Append(_) => vec!["event", "append"],
-        EventSubcommand::ImportJsonl(_) => vec!["event", "import-jsonl"],
-    }
-}
-
 fn decision_path(command: DecisionCommand) -> Vec<&'static str> {
     match command.command {
         DecisionSubcommand::Extract(_) => vec!["decision", "extract"],
         DecisionSubcommand::List(_) => vec!["decision", "list"],
     }
+}
+
+fn ensure_case_exists(store: &SqliteStore, case_id: &str) -> Option<i32> {
+    match store.get_case(case_id) {
+        Ok(Some(_)) => None,
+        Ok(None) => {
+            eprintln!("case not found: {case_id}");
+            Some(1)
+        }
+        Err(error) => {
+            eprintln!("{error}");
+            Some(1)
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ImportedEventRecord {
+    case_id: Option<String>,
+    event_id: Option<String>,
+    event_type: String,
+    actor: String,
+    timestamp: Option<String>,
+    parent_event_id: Option<String>,
+    sequence_no: Option<i64>,
+    #[serde(default)]
+    payload: Value,
+}
+
+fn imported_event_to_event(
+    input: ImportedEventRecord,
+    store: &SqliteStore,
+    case_id: &str,
+) -> Result<Event, String> {
+    let ImportedEventRecord {
+        case_id: _,
+        event_id,
+        event_type,
+        actor,
+        timestamp,
+        parent_event_id,
+        sequence_no,
+        payload,
+    } = input;
+
+    let event_type = event_type
+        .parse::<EventType>()
+        .map_err(|error| error.to_string())?;
+    let actor = actor
+        .parse::<EventActor>()
+        .map_err(|error| error.to_string())?;
+    let timestamp = match timestamp {
+        Some(value) => DateTime::parse_from_rfc3339(&value)
+            .map(|value| value.with_timezone(&Utc))
+            .map_err(|error| error.to_string())?,
+        None => Utc::now(),
+    };
+    let payload = match payload {
+        Value::Object(payload) => Value::Object(payload),
+        Value::Null => Value::Object(Map::new()),
+        _ => return Err("payload must be a JSON object".to_string()),
+    };
+    let sequence_no = match sequence_no {
+        Some(sequence_no) => sequence_no,
+        None => store
+            .next_event_sequence(case_id)
+            .map_err(|error| error.to_string())?,
+    };
+
+    Ok(Event {
+        event_id: event_id
+            .unwrap_or_else(|| format!("evt_{}", &Uuid::new_v4().simple().to_string()[..12])),
+        case_id: case_id.to_string(),
+        event_type,
+        actor,
+        timestamp,
+        sequence_no,
+        parent_event_id,
+        payload,
+    })
 }
 
 fn replay_path(command: ReplayCommand) -> Vec<&'static str> {

--- a/rust/openprecedent-cli/tests/event_contract.rs
+++ b/rust/openprecedent-cli/tests/event_contract.rs
@@ -1,0 +1,160 @@
+use std::fs;
+
+use assert_cmd::Command;
+use serde_json::Value;
+use tempfile::tempdir;
+
+fn cli() -> Command {
+    Command::cargo_bin("openprecedent").expect("cargo bin")
+}
+
+fn create_case(db_path: &std::path::Path, case_id: &str, title: &str) {
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().expect("db path"),
+            "case",
+            "create",
+            "--case-id",
+            case_id,
+            "--title",
+            title,
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
+fn event_append_writes_event_and_returns_json() {
+    let runtime = tempdir().expect("runtime");
+    let db_path = runtime.path().join("openprecedent.db");
+    create_case(&db_path, "case_event_append", "Event append");
+
+    let output = cli()
+        .args([
+            "--db",
+            db_path.to_str().expect("db path"),
+            "--format",
+            "json",
+            "event",
+            "append",
+            "case_event_append",
+            "message.agent",
+            "agent",
+            "--payload",
+            "{\"message\":\"inspect files first\"}",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let event: Value = serde_json::from_slice(&output).expect("event");
+    assert_eq!(event["case_id"], "case_event_append");
+    assert_eq!(event["event_type"], "message.agent");
+    assert_eq!(event["actor"], "agent");
+    assert_eq!(event["sequence_no"], 1);
+    assert_eq!(event["payload"]["message"], "inspect files first");
+}
+
+#[test]
+fn event_import_jsonl_ingests_events_and_preserves_case_completion_summary() {
+    let runtime = tempdir().expect("runtime");
+    let db_path = runtime.path().join("openprecedent.db");
+    create_case(&db_path, "case_event_import", "Event import");
+
+    let jsonl_path = runtime.path().join("events.jsonl");
+    fs::write(
+        &jsonl_path,
+        concat!(
+            "{\"case_id\":\"case_event_import\",\"event_type\":\"message.user\",\"actor\":\"user\",\"payload\":{\"message\":\"hello\"}}\n",
+            "{\"case_id\":\"case_event_import\",\"event_type\":\"case.completed\",\"actor\":\"system\",\"payload\":{\"summary\":\"imported summary\"}}\n"
+        ),
+    )
+    .expect("write jsonl");
+
+    let import_output = cli()
+        .args([
+            "--db",
+            db_path.to_str().expect("db path"),
+            "--format",
+            "json",
+            "event",
+            "import-jsonl",
+            jsonl_path.to_str().expect("jsonl path"),
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let imported: Value = serde_json::from_slice(&import_output).expect("import");
+    let imported = imported.as_array().expect("array");
+    assert_eq!(imported.len(), 2);
+    assert_eq!(imported[0]["sequence_no"], 1);
+    assert_eq!(imported[1]["event_type"], "case.completed");
+
+    let case_output = cli()
+        .args([
+            "--db",
+            db_path.to_str().expect("db path"),
+            "--format",
+            "json",
+            "case",
+            "show",
+            "case_event_import",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let case: Value = serde_json::from_slice(&case_output).expect("case");
+    assert_eq!(case["status"], "completed");
+    assert_eq!(case["final_summary"], "imported summary");
+}
+
+#[test]
+fn event_append_reports_missing_case() {
+    let runtime = tempdir().expect("runtime");
+    let db_path = runtime.path().join("openprecedent.db");
+
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().expect("db path"),
+            "event",
+            "append",
+            "missing-case",
+            "message.user",
+            "user",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("case not found: missing-case"));
+}
+
+#[test]
+fn event_import_jsonl_requires_case_id_when_missing_from_record_and_flag() {
+    let runtime = tempdir().expect("runtime");
+    let db_path = runtime.path().join("openprecedent.db");
+    let jsonl_path = runtime.path().join("events.jsonl");
+    fs::write(
+        &jsonl_path,
+        "{\"event_type\":\"message.user\",\"actor\":\"user\",\"payload\":{\"message\":\"hello\"}}\n",
+    )
+    .expect("write jsonl");
+
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().expect("db path"),
+            "event",
+            "import-jsonl",
+            jsonl_path.to_str().expect("jsonl path"),
+        ])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("line 1: case_id is required"));
+}

--- a/rust/openprecedent-contracts/src/event.rs
+++ b/rust/openprecedent-contracts/src/event.rs
@@ -4,36 +4,50 @@ use serde_json::Value;
 use strum::{Display, EnumString};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Display, EnumString)]
-#[serde(rename_all = "kebab-case")]
 pub enum EventType {
+    #[serde(rename = "case.started")]
     #[strum(serialize = "case.started")]
     CaseStarted,
+    #[serde(rename = "checkpoint.saved")]
     #[strum(serialize = "checkpoint.saved")]
     CheckpointSaved,
+    #[serde(rename = "message.user")]
     #[strum(serialize = "message.user")]
     MessageUser,
+    #[serde(rename = "message.agent")]
     #[strum(serialize = "message.agent")]
     MessageAgent,
+    #[serde(rename = "model.invoked")]
     #[strum(serialize = "model.invoked")]
     ModelInvoked,
+    #[serde(rename = "model.completed")]
     #[strum(serialize = "model.completed")]
     ModelCompleted,
+    #[serde(rename = "tool.called")]
     #[strum(serialize = "tool.called")]
     ToolCalled,
+    #[serde(rename = "tool.completed")]
     #[strum(serialize = "tool.completed")]
     ToolCompleted,
+    #[serde(rename = "command.started")]
     #[strum(serialize = "command.started")]
     CommandStarted,
+    #[serde(rename = "command.completed")]
     #[strum(serialize = "command.completed")]
     CommandCompleted,
+    #[serde(rename = "file.read")]
     #[strum(serialize = "file.read")]
     FileRead,
+    #[serde(rename = "file.write")]
     #[strum(serialize = "file.write")]
     FileWrite,
+    #[serde(rename = "user.confirmed")]
     #[strum(serialize = "user.confirmed")]
     UserConfirmed,
+    #[serde(rename = "case.completed")]
     #[strum(serialize = "case.completed")]
     CaseCompleted,
+    #[serde(rename = "case.failed")]
     #[strum(serialize = "case.failed")]
     CaseFailed,
 }


### PR DESCRIPTION
## Summary
- migrate `openprecedent event append` and `openprecedent event import-jsonl` from placeholder Rust handlers to real Rust implementations
- preserve canonical dotted `EventType` JSON serialization in the shared Rust contracts crate
- add Rust CLI contract tests for event append/import success paths and key failure cases

## Testing
- . "$HOME/.cargo/env" && cargo test
- ./scripts/run-pytest.sh -q tests/test_rust_cli_workspace.py
- ./scripts/run-agent-preflight.sh

Closes #178
