### PR TITLE
Migrate Codex capture commands to the Rust CLI

### DIFF
--- a/.codex/pm/issue-state/182-migrate-codex-capture-commands-to-rust-cli.md
+++ b/.codex/pm/issue-state/182-migrate-codex-capture-commands-to-rust-cli.md
@@ -1,0 +1,35 @@
+---
+type: issue_state
+issue: 182
+task: .codex/pm/tasks/public-cli-foundation/migrate-codex-capture-commands-to-rust-cli.md
+title: Migrate Codex capture commands to the Rust CLI
+status: done
+---
+
+## Summary
+
+The Codex rollout import surface now runs through the Rust public CLI, including unsupported-record counting, tool-argument cleanup, and tool-output noise stripping.
+
+## Validated Facts
+
+- issues `#177` through `#181` already moved case, event, decision, replay, precedent, and OpenClaw capture into Rust on the integration branch
+- the Rust CLI now exposes `capture codex import-rollout`
+- Codex rollout normalization now lives in the dedicated `openprecedent-capture-codex` crate instead of the Python CLI
+- Rust import preserves unsupported-record counting, tool-argument cleanup, and tool-output noise stripping semantics from the existing Codex rollout fixtures
+- new Rust contract tests cover normal rollout import, noisy rollout normalization, and downstream precedent ranking using Codex fixtures
+
+## Open Questions
+
+- future lineage-specific capture work may still decide whether any of these Codex normalization helpers should be shared more broadly across runtime ingestion surfaces
+
+## Next Steps
+
+- merge this child issue into `codex/issue-172-rust-public-cli`
+- continue with `#183` for the Rust lineage brief command
+
+## Artifacts
+
+- `rust/openprecedent-capture-codex/`
+- `rust/openprecedent-cli/src/main.rs`
+- `rust/openprecedent-cli/tests/codex_capture_contract.rs`
+- `.codex/pm/tasks/public-cli-foundation/migrate-codex-capture-commands-to-rust-cli.md`

--- a/.codex/pm/tasks/public-cli-foundation/migrate-codex-capture-commands-to-rust-cli.md
+++ b/.codex/pm/tasks/public-cli-foundation/migrate-codex-capture-commands-to-rust-cli.md
@@ -3,7 +3,7 @@ type: task
 epic: public-cli-foundation
 slug: migrate-codex-capture-commands-to-rust-cli
 title: Migrate Codex capture commands to the Rust CLI
-status: backlog
+status: done
 task_type: implementation
 labels: cli,rust,interface
 issue: 182
@@ -11,7 +11,7 @@ issue: 182
 
 ## Context
 
-Planned child issue under `#172`. Expand the implementation detail when this issue becomes active.
+Child issue `#182` under `#172` migrates the public Codex rollout import workflow into Rust. This slice covers the stable `capture codex import-rollout` surface and the normalization behavior that downstream replay, decision extraction, and precedent retrieval depend on.
 
 ## Deliverable
 
@@ -19,16 +19,30 @@ Implement the scoped GitHub issue on a child branch that merges into `codex/issu
 
 ## Scope
 
-- follow the scoped work and constraints defined in the linked GitHub issue
+- implement `capture codex import-rollout` in Rust
+- preserve current rollout normalization semantics, including unsupported-record counting and tool-output noise stripping
+- keep imported events compatible with existing replay, decision extraction, and precedent ranking behavior
+- add Rust contract tests that exercise the current Codex rollout fixtures
 
 ## Acceptance Criteria
 
-- satisfy the acceptance criteria in the linked GitHub issue before opening a child PR
+- Codex rollout capture runs through the Rust CLI without falling back to Python or shell wrappers
+- imported data remains compatible with the shared SQLite schema and downstream Rust replay, decision, and precedent commands
+- Rust tests cover the normal rollout path and noisy rollout normalization path
 
 ## Validation
 
-- run issue-appropriate local validation when this task becomes active
+- run `cargo test`
+- run `./scripts/run-pytest.sh -q tests/test_rust_cli_workspace.py`
+- run `./scripts/run-agent-preflight.sh` before opening the PR
 
 ## Implementation Notes
 
-- This task twin was scaffolded during the Rust CLI issue decomposition and should be elaborated when implementation starts.
+- Prefer moving Codex rollout normalization helpers into the dedicated `openprecedent-capture-codex` crate instead of embedding more runtime-specific parsing directly into the CLI binary.
+- Preserve the JSON output contract because later lineage and skill migrations will invoke this command directly.
+
+## Completion Notes
+
+- implemented `capture codex import-rollout` in the Rust CLI
+- moved Codex rollout normalization and unsupported-record classification into the dedicated `openprecedent-capture-codex` crate
+- added Rust contract tests for the standard rollout path, noisy rollout normalization, and precedent ranking with Codex fixtures

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,11 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 name = "openprecedent-capture-codex"
 version = "0.1.0"
 dependencies = [
- "openprecedent-core",
+ "chrono",
+ "openprecedent-contracts",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -463,6 +467,7 @@ dependencies = [
  "assert_cmd",
  "chrono",
  "clap",
+ "openprecedent-capture-codex",
  "openprecedent-capture-openclaw",
  "openprecedent-contracts",
  "openprecedent-core",

--- a/rust/openprecedent-capture-codex/Cargo.toml
+++ b/rust/openprecedent-capture-codex/Cargo.toml
@@ -6,4 +6,8 @@ license.workspace = true
 authors.workspace = true
 
 [dependencies]
-openprecedent-core = { path = "../openprecedent-core" }
+chrono.workspace = true
+openprecedent-contracts = { path = "../openprecedent-contracts" }
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true

--- a/rust/openprecedent-capture-codex/src/lib.rs
+++ b/rust/openprecedent-capture-codex/src/lib.rs
@@ -1,1 +1,385 @@
+use std::path::Path;
+
+use chrono::{DateTime, Utc};
+use openprecedent_contracts::{Event, EventActor, EventType};
+use serde_json::{Map, Value};
+
 pub const CAPTURE_RUNTIME_NAME: &str = "codex";
+
+#[derive(Debug, thiserror::Error)]
+pub enum CodexCaptureError {
+    #[error("line {line_no}: {message}")]
+    InvalidRecord { line_no: usize, message: String },
+}
+
+pub fn rollout_id_prefix(path: &Path) -> String {
+    let mut slug = String::new();
+    for ch in path
+        .file_stem()
+        .and_then(|item| item.to_str())
+        .unwrap_or_default()
+        .chars()
+    {
+        if ch.is_ascii_alphanumeric() {
+            slug.push(ch.to_ascii_lowercase());
+        } else if !slug.ends_with('-') {
+            slug.push('-');
+        }
+    }
+    let slug = slug.trim_matches('-').to_string();
+    if slug.is_empty() {
+        "codex-rollout".to_string()
+    } else {
+        slug
+    }
+}
+
+pub fn record_type(raw_item: &Map<String, Value>) -> String {
+    let kind = raw_item
+        .get("type")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let subtype = raw_item
+        .get("payload")
+        .and_then(Value::as_object)
+        .and_then(|payload| payload.get("type"))
+        .and_then(Value::as_str);
+    match subtype {
+        Some(subtype) => format!("{kind}:{subtype}"),
+        None => kind.to_string(),
+    }
+}
+
+pub fn normalize_rollout_line(
+    raw_item: Map<String, Value>,
+    line_no: usize,
+    rollout_id_prefix: &str,
+) -> Result<Option<Event>, CodexCaptureError> {
+    let kind = raw_item
+        .get("type")
+        .and_then(Value::as_str)
+        .ok_or_else(|| invalid(line_no, "type is required for codex rollout import"))?;
+    let timestamp = parse_optional_timestamp(raw_item.get("timestamp"), line_no)?;
+    let payload = raw_item
+        .get("payload")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+
+    match kind {
+        "session_meta" => Ok(Some(Event {
+            event_id: payload
+                .get("id")
+                .and_then(value_as_nonempty_string)
+                .unwrap_or_else(|| format!("{rollout_id_prefix}-session-{line_no}")),
+            case_id: String::new(),
+            event_type: EventType::CaseStarted,
+            actor: EventActor::System,
+            timestamp: timestamp.unwrap_or_else(Utc::now),
+            sequence_no: 0,
+            parent_event_id: None,
+            payload: json_object([
+                ("source", Value::String(CAPTURE_RUNTIME_NAME.to_string())),
+                (
+                    "session_id",
+                    payload
+                        .get("id")
+                        .and_then(value_as_nonempty_string)
+                        .map(Value::String)
+                        .unwrap_or(Value::Null),
+                ),
+                (
+                    "cwd",
+                    payload
+                        .get("cwd")
+                        .and_then(value_as_nonempty_string)
+                        .map(Value::String)
+                        .unwrap_or(Value::Null),
+                ),
+                (
+                    "originator",
+                    payload
+                        .get("originator")
+                        .and_then(value_as_nonempty_string)
+                        .map(Value::String)
+                        .unwrap_or(Value::Null),
+                ),
+                (
+                    "cli_version",
+                    payload
+                        .get("cli_version")
+                        .and_then(value_as_nonempty_string)
+                        .map(Value::String)
+                        .unwrap_or(Value::Null),
+                ),
+                (
+                    "model_provider",
+                    payload
+                        .get("model_provider")
+                        .and_then(value_as_nonempty_string)
+                        .map(Value::String)
+                        .unwrap_or(Value::Null),
+                ),
+            ]),
+        })),
+        "event_msg" => match payload
+            .get("type")
+            .and_then(value_as_nonempty_string)
+            .as_deref()
+        {
+            Some("user_message") => Ok(Some(Event {
+                event_id: format!("{rollout_id_prefix}-user-{line_no}"),
+                case_id: String::new(),
+                event_type: EventType::MessageUser,
+                actor: EventActor::User,
+                timestamp: timestamp.unwrap_or_else(Utc::now),
+                sequence_no: 0,
+                parent_event_id: None,
+                payload: json_object([
+                    (
+                        "message",
+                        Value::String(
+                            payload
+                                .get("message")
+                                .and_then(Value::as_str)
+                                .unwrap_or_default()
+                                .to_string(),
+                        ),
+                    ),
+                    ("source", Value::String(CAPTURE_RUNTIME_NAME.to_string())),
+                ]),
+            })),
+            Some("agent_message") => Ok(Some(Event {
+                event_id: format!("{rollout_id_prefix}-agent-{line_no}"),
+                case_id: String::new(),
+                event_type: EventType::MessageAgent,
+                actor: EventActor::Agent,
+                timestamp: timestamp.unwrap_or_else(Utc::now),
+                sequence_no: 0,
+                parent_event_id: None,
+                payload: json_object([
+                    (
+                        "message",
+                        Value::String(
+                            payload
+                                .get("message")
+                                .and_then(Value::as_str)
+                                .unwrap_or_default()
+                                .to_string(),
+                        ),
+                    ),
+                    (
+                        "phase",
+                        payload
+                            .get("phase")
+                            .and_then(value_as_nonempty_string)
+                            .map(Value::String)
+                            .unwrap_or(Value::Null),
+                    ),
+                    ("source", Value::String(CAPTURE_RUNTIME_NAME.to_string())),
+                ]),
+            })),
+            Some("task_complete") => Ok(Some(Event {
+                event_id: format!("{rollout_id_prefix}-complete-{line_no}"),
+                case_id: String::new(),
+                event_type: EventType::CaseCompleted,
+                actor: EventActor::System,
+                timestamp: timestamp.unwrap_or_else(Utc::now),
+                sequence_no: 0,
+                parent_event_id: None,
+                payload: json_object([
+                    (
+                        "summary",
+                        Value::String(
+                            payload
+                                .get("last_agent_message")
+                                .and_then(value_as_nonempty_string)
+                                .unwrap_or_else(|| "Codex task completed".to_string()),
+                        ),
+                    ),
+                    (
+                        "turn_id",
+                        payload
+                            .get("turn_id")
+                            .and_then(value_as_nonempty_string)
+                            .map(Value::String)
+                            .unwrap_or(Value::Null),
+                    ),
+                    ("source", Value::String(CAPTURE_RUNTIME_NAME.to_string())),
+                ]),
+            })),
+            _ => Ok(None),
+        },
+        "response_item" => match payload
+            .get("type")
+            .and_then(value_as_nonempty_string)
+            .as_deref()
+        {
+            Some("function_call") | Some("custom_tool_call") | Some("web_search_call") => {
+                let subtype = payload
+                    .get("type")
+                    .and_then(value_as_nonempty_string)
+                    .unwrap_or_else(|| "function_call".to_string());
+                let tool_name = payload
+                    .get("name")
+                    .and_then(value_as_nonempty_string)
+                    .unwrap_or(subtype);
+                let call_id = payload.get("call_id").and_then(value_as_nonempty_string);
+                Ok(Some(Event {
+                    event_id: call_id
+                        .clone()
+                        .unwrap_or_else(|| format!("{rollout_id_prefix}-tool-call-{line_no}")),
+                    case_id: String::new(),
+                    event_type: EventType::ToolCalled,
+                    actor: EventActor::Agent,
+                    timestamp: timestamp.unwrap_or_else(Utc::now),
+                    sequence_no: 0,
+                    parent_event_id: None,
+                    payload: json_object([
+                        ("tool_name", Value::String(tool_name.clone())),
+                        (
+                            "arguments",
+                            normalize_tool_arguments(
+                                &tool_name,
+                                arguments_to_payload(payload.get("arguments")),
+                            ),
+                        ),
+                        ("call_id", call_id.map(Value::String).unwrap_or(Value::Null)),
+                        ("source", Value::String(CAPTURE_RUNTIME_NAME.to_string())),
+                    ]),
+                }))
+            }
+            Some("function_call_output") | Some("custom_tool_call_output") => {
+                let call_id = payload.get("call_id").and_then(value_as_nonempty_string);
+                Ok(Some(Event {
+                    event_id: format!(
+                        "{}-output",
+                        call_id.clone().unwrap_or_else(|| format!(
+                            "{rollout_id_prefix}-tool-output-{line_no}"
+                        ))
+                    ),
+                    case_id: String::new(),
+                    event_type: EventType::ToolCompleted,
+                    actor: EventActor::Tool,
+                    timestamp: timestamp.unwrap_or_else(Utc::now),
+                    sequence_no: 0,
+                    parent_event_id: None,
+                    payload: json_object([
+                        ("call_id", call_id.map(Value::String).unwrap_or(Value::Null)),
+                        (
+                            "output",
+                            Value::String(strip_tool_output_noise(
+                                payload
+                                    .get("output")
+                                    .and_then(Value::as_str)
+                                    .unwrap_or_default(),
+                            )),
+                        ),
+                        ("source", Value::String(CAPTURE_RUNTIME_NAME.to_string())),
+                    ]),
+                }))
+            }
+            _ => Ok(None),
+        },
+        _ => Ok(None),
+    }
+}
+
+fn invalid(line_no: usize, message: impl Into<String>) -> CodexCaptureError {
+    CodexCaptureError::InvalidRecord {
+        line_no,
+        message: message.into(),
+    }
+}
+
+fn parse_optional_timestamp(
+    value: Option<&Value>,
+    line_no: usize,
+) -> Result<Option<DateTime<Utc>>, CodexCaptureError> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let Some(value) = value.as_str() else {
+        return Err(invalid(line_no, "timestamp must be an ISO-8601 string"));
+    };
+    DateTime::parse_from_rfc3339(value)
+        .map(|value| Some(value.with_timezone(&Utc)))
+        .map_err(|error| invalid(line_no, error.to_string()))
+}
+
+fn arguments_to_payload(value: Option<&Value>) -> Map<String, Value> {
+    match value {
+        Some(Value::Object(value)) => value.clone(),
+        Some(Value::String(value)) if !value.trim().is_empty() => {
+            match serde_json::from_str::<Value>(value) {
+                Ok(Value::Object(parsed)) => parsed,
+                _ => {
+                    let mut map = Map::new();
+                    map.insert("raw".to_string(), Value::String(value.clone()));
+                    map
+                }
+            }
+        }
+        _ => Map::new(),
+    }
+}
+
+fn normalize_tool_arguments(tool_name: &str, arguments: Map<String, Value>) -> Value {
+    if arguments.is_empty() {
+        return Value::Object(Map::new());
+    }
+
+    let mut cleaned = arguments;
+    for key in [
+        "yield_time_ms",
+        "max_output_tokens",
+        "sandbox_permissions",
+        "justification",
+        "prefix_rule",
+        "login",
+        "tty",
+        "shell",
+    ] {
+        cleaned.remove(key);
+    }
+
+    if tool_name == "exec_command" {
+        return Value::Object(cleaned);
+    }
+    Value::Object(cleaned)
+}
+
+fn strip_tool_output_noise(output: &str) -> String {
+    if output.trim().is_empty() {
+        return output.to_string();
+    }
+
+    let mut lines = output.lines().collect::<Vec<_>>();
+    while lines.first().is_some_and(|line| {
+        line.starts_with("Chunk ID:")
+            || line.starts_with("Wall time:")
+            || line.starts_with("Process exited with code")
+            || line.starts_with("Original token count:")
+    }) {
+        lines.remove(0);
+    }
+    if lines.first().is_some_and(|line| *line == "Output:") {
+        lines.remove(0);
+    }
+    lines.join("\n").trim().to_string()
+}
+
+fn value_as_nonempty_string(value: &Value) -> Option<String> {
+    match value {
+        Value::String(value) if !value.trim().is_empty() => Some(value.clone()),
+        _ => None,
+    }
+}
+
+fn json_object<const N: usize>(pairs: [(&str, Value); N]) -> Value {
+    let mut map = Map::new();
+    for (key, value) in pairs {
+        map.insert(key.to_string(), value);
+    }
+    Value::Object(map)
+}

--- a/rust/openprecedent-cli/Cargo.toml
+++ b/rust/openprecedent-cli/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 [dependencies]
 chrono.workspace = true
 clap.workspace = true
+openprecedent-capture-codex = { path = "../openprecedent-capture-codex" }
 openprecedent-contracts = { path = "../openprecedent-contracts" }
 openprecedent-core = { path = "../openprecedent-core" }
 openprecedent-capture-openclaw = { path = "../openprecedent-capture-openclaw" }

--- a/rust/openprecedent-cli/src/main.rs
+++ b/rust/openprecedent-cli/src/main.rs
@@ -1,10 +1,11 @@
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::ffi::OsString;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 
 use chrono::{DateTime, Utc};
 use clap::{ArgAction, Args, CommandFactory, FromArgMatches, Parser, Subcommand};
+use openprecedent_capture_codex as capture_codex;
 use openprecedent_capture_openclaw as capture_openclaw;
 use openprecedent_contracts::{
     Artifact, ArtifactType, Case, CaseStatus, Decision, DecisionExplanation, DecisionType, Event,
@@ -25,6 +26,8 @@ use uuid::Uuid;
 struct CaptureImportOutput {
     case: Case,
     imported_event_count: usize,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    unsupported_record_type_counts: BTreeMap<String, usize>,
     events: Vec<Event>,
 }
 
@@ -273,7 +276,20 @@ struct CodexCaptureCommand {
 
 #[derive(Debug, Subcommand)]
 enum CodexCaptureSubcommand {
-    ImportRollout(TrailingArgs),
+    ImportRollout(CodexImportRolloutArgs),
+}
+
+#[derive(Debug, Args)]
+struct CodexImportRolloutArgs {
+    path: std::path::PathBuf,
+    #[arg(long = "case-id")]
+    case_id: String,
+    #[arg(long)]
+    title: String,
+    #[arg(long = "user-id")]
+    user_id: Option<String>,
+    #[arg(long = "agent-id", default_value = "codex")]
+    agent_id: String,
 }
 
 #[derive(Debug, Args)]
@@ -1060,6 +1076,7 @@ fn handle_capture(command: CaptureCommand, config: &ResolvedRuntimeConfig) -> i3
                 let output = CaptureImportOutput {
                     case,
                     imported_event_count: imported.len(),
+                    unsupported_record_type_counts: BTreeMap::new(),
                     events: imported,
                 };
                 match serde_json::to_string_pretty(&output) {
@@ -1074,11 +1091,118 @@ fn handle_capture(command: CaptureCommand, config: &ResolvedRuntimeConfig) -> i3
                 }
             }
         },
-        CaptureRuntime::Codex(command) => {
-            render_not_implemented_path(capture_path(CaptureCommand {
-                runtime: CaptureRuntime::Codex(command),
-            }))
-        }
+        CaptureRuntime::Codex(command) => match command.command {
+            CodexCaptureSubcommand::ImportRollout(args) => {
+                let store = match SqliteStore::new(&config.db.path) {
+                    Ok(store) => store,
+                    Err(error) => {
+                        eprintln!("{error}");
+                        return 1;
+                    }
+                };
+
+                let case = match ensure_case(
+                    &store,
+                    &args.case_id,
+                    &args.title,
+                    args.user_id.as_deref(),
+                    Some(args.agent_id.as_str()),
+                ) {
+                    Ok(case) => case,
+                    Err(error) => {
+                        eprintln!("{error}");
+                        return 1;
+                    }
+                };
+
+                let file = match File::open(&args.path) {
+                    Ok(file) => file,
+                    Err(error) => {
+                        eprintln!("{error}");
+                        return 1;
+                    }
+                };
+                let rollout_id_prefix = capture_codex::rollout_id_prefix(&args.path);
+                let mut imported = Vec::new();
+                let mut unsupported = BTreeMap::new();
+                for (index, line_result) in BufReader::new(file).lines().enumerate() {
+                    let line_number = index + 1;
+                    let line = match line_result {
+                        Ok(line) => line,
+                        Err(error) => {
+                            eprintln!("{error}");
+                            return 1;
+                        }
+                    };
+                    let stripped = line.trim();
+                    if stripped.is_empty() {
+                        continue;
+                    }
+                    let raw_item = match serde_json::from_str::<Value>(stripped) {
+                        Ok(Value::Object(item)) => item,
+                        Ok(_) => {
+                            eprintln!(
+                                "line {line_number}: codex rollout line must be a JSON object"
+                            );
+                            return 1;
+                        }
+                        Err(error) => {
+                            eprintln!("{error}");
+                            return 1;
+                        }
+                    };
+
+                    let event = match capture_codex::normalize_rollout_line(
+                        raw_item.clone(),
+                        line_number,
+                        &rollout_id_prefix,
+                    ) {
+                        Ok(event) => event,
+                        Err(error) => {
+                            eprintln!("{error}");
+                            return 1;
+                        }
+                    };
+                    let Some(mut event) = event else {
+                        *unsupported
+                            .entry(capture_codex::record_type(&raw_item))
+                            .or_insert(0) += 1;
+                        continue;
+                    };
+
+                    event.case_id = args.case_id.clone();
+                    event.sequence_no = match store.next_event_sequence(&args.case_id) {
+                        Ok(sequence) => sequence,
+                        Err(error) => {
+                            eprintln!("{error}");
+                            return 1;
+                        }
+                    };
+                    if let Err(error) = store.append_event(&event) {
+                        eprintln!("{error}");
+                        return 1;
+                    }
+                    imported.push(event);
+                }
+
+                let output = CaptureImportOutput {
+                    case,
+                    imported_event_count: imported.len(),
+                    unsupported_record_type_counts: unsupported,
+                    events: imported,
+                };
+                match serde_json::to_string_pretty(&output) {
+                    Ok(json) => {
+                        println!("{json}");
+                        0
+                    }
+                    Err(error) => {
+                        eprintln!("{error}");
+                        1
+                    }
+                }
+            }
+        },
     }
 }
 
@@ -3464,28 +3588,6 @@ const STOP_WORDS: [&str; 18] = [
     "the", "and", "for", "with", "that", "this", "from", "into", "will", "then", "case",
     "openclaw", "session", "docs", "file", "tool", "command", "agent",
 ];
-
-fn capture_path(command: CaptureCommand) -> Vec<&'static str> {
-    match command.runtime {
-        CaptureRuntime::Openclaw(command) => match command.command {
-            OpenclawCaptureSubcommand::ListSessions(_) => {
-                vec!["capture", "openclaw", "list-sessions"]
-            }
-            OpenclawCaptureSubcommand::ImportSession(_) => {
-                vec!["capture", "openclaw", "import-session"]
-            }
-            OpenclawCaptureSubcommand::CollectSessions(_) => {
-                vec!["capture", "openclaw", "collect-sessions"]
-            }
-            OpenclawCaptureSubcommand::ImportJsonl(_) => {
-                vec!["capture", "openclaw", "import-jsonl"]
-            }
-        },
-        CaptureRuntime::Codex(command) => match command.command {
-            CodexCaptureSubcommand::ImportRollout(_) => vec!["capture", "codex", "import-rollout"],
-        },
-    }
-}
 
 fn lineage_path(command: LineageCommand) -> Vec<&'static str> {
     match command.command {

--- a/rust/openprecedent-cli/tests/codex_capture_contract.rs
+++ b/rust/openprecedent-cli/tests/codex_capture_contract.rs
@@ -1,0 +1,250 @@
+use std::path::Path;
+
+use assert_cmd::Command;
+use serde_json::Value;
+use tempfile::tempdir;
+
+fn cli() -> Command {
+    Command::cargo_bin("openprecedent").expect("cargo bin")
+}
+
+fn fixture(name: &str) -> String {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../tests/fixtures")
+        .join(name)
+        .display()
+        .to_string()
+}
+
+#[test]
+fn capture_codex_import_rollout_imports_trace_and_replay_reads_it() {
+    let runtime = tempdir().expect("runtime");
+    let db_path = runtime.path().join("openprecedent.db");
+
+    let output = cli()
+        .args([
+            "--db",
+            db_path.to_str().expect("db path"),
+            "--format",
+            "json",
+            "capture",
+            "codex",
+            "import-rollout",
+            &fixture("codex_rollout.jsonl"),
+            "--case-id",
+            "case_codex_rollout_rust",
+            "--title",
+            "Codex imported rollout",
+            "--user-id",
+            "u1",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let imported: Value = serde_json::from_slice(&output).expect("imported");
+    assert_eq!(imported["case"]["case_id"], "case_codex_rollout_rust");
+    assert_eq!(imported["imported_event_count"], 6);
+    assert_eq!(
+        imported["unsupported_record_type_counts"],
+        serde_json::json!({"event_msg:task_started": 1})
+    );
+
+    let replay_output = cli()
+        .args([
+            "--db",
+            db_path.to_str().expect("db path"),
+            "--format",
+            "json",
+            "replay",
+            "case",
+            "case_codex_rollout_rust",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let replay: Value = serde_json::from_slice(&replay_output).expect("replay");
+    assert_eq!(replay["case"]["status"], "completed");
+    assert_eq!(
+        replay["summary"],
+        "Codex runtime research should stay Codex-specific and avoid generic multi-runtime abstraction for now."
+    );
+}
+
+#[test]
+fn capture_codex_import_rollout_strips_noise_and_preserves_semantic_tool_payloads() {
+    let runtime = tempdir().expect("runtime");
+    let db_path = runtime.path().join("openprecedent.db");
+
+    let output = cli()
+        .args([
+            "--db",
+            db_path.to_str().expect("db path"),
+            "--format",
+            "json",
+            "capture",
+            "codex",
+            "import-rollout",
+            &fixture("codex_rollout_noisy.jsonl"),
+            "--case-id",
+            "case_codex_noise_rust",
+            "--title",
+            "Codex noisy rollout",
+            "--user-id",
+            "u1",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let imported: Value = serde_json::from_slice(&output).expect("imported");
+    assert_eq!(imported["imported_event_count"], 6);
+    assert_eq!(
+        imported["unsupported_record_type_counts"],
+        serde_json::json!({
+            "event_msg:task_started": 1,
+            "event_msg:token_count": 1,
+            "response_item:message": 2,
+            "response_item:reasoning": 1,
+            "turn_context": 1
+        })
+    );
+
+    let replay_output = cli()
+        .args([
+            "--db",
+            db_path.to_str().expect("db path"),
+            "--format",
+            "json",
+            "replay",
+            "case",
+            "case_codex_noise_rust",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let replay: Value = serde_json::from_slice(&replay_output).expect("replay");
+    assert_eq!(
+        replay["summary"],
+        "Codex replay should show semantic evidence without transport wrappers."
+    );
+
+    let tool_called = replay["events"]
+        .as_array()
+        .expect("events")
+        .iter()
+        .find(|event| event["event_type"] == "tool.called")
+        .expect("tool called");
+    let tool_completed = replay["events"]
+        .as_array()
+        .expect("events")
+        .iter()
+        .find(|event| event["event_type"] == "tool.completed")
+        .expect("tool completed");
+
+    assert_eq!(
+        tool_called["payload"]["arguments"],
+        serde_json::json!({
+            "cmd": "sed -n '1,40p' docs/engineering/codex-runtime-boundary.md",
+            "workdir": "/workspace/02-projects/incubation/openprecedent"
+        })
+    );
+    assert_eq!(
+        tool_completed["payload"]["output"],
+        "# Codex Runtime Boundary For Research\nThe goal is not to make OpenPrecedent generic."
+    );
+}
+
+#[test]
+fn capture_codex_import_rollout_feeds_precedent_ranking() {
+    let runtime = tempdir().expect("runtime");
+    let db_path = runtime.path().join("openprecedent.db");
+
+    let imports = [
+        (
+            "case_codex_precedent_current_rust",
+            "Current Codex docs-only recommendation",
+            "codex_rollout_precedent_current.jsonl",
+        ),
+        (
+            "case_codex_precedent_semantic_rust",
+            "Semantic Codex docs-only precedent",
+            "codex_rollout_precedent_semantic_match.jsonl",
+        ),
+        (
+            "case_codex_precedent_operational_rust",
+            "Operationally similar Codex summary",
+            "codex_rollout_precedent_operational_overlap.jsonl",
+        ),
+    ];
+
+    for (case_id, title, filename) in imports {
+        cli()
+            .args([
+                "--db",
+                db_path.to_str().expect("db path"),
+                "capture",
+                "codex",
+                "import-rollout",
+                &fixture(filename),
+                "--case-id",
+                case_id,
+                "--title",
+                title,
+                "--user-id",
+                "u1",
+            ])
+            .assert()
+            .success();
+        cli()
+            .args([
+                "--db",
+                db_path.to_str().expect("db path"),
+                "--format",
+                "json",
+                "decision",
+                "extract",
+                case_id,
+            ])
+            .assert()
+            .success();
+    }
+
+    let output = cli()
+        .args([
+            "--db",
+            db_path.to_str().expect("db path"),
+            "--format",
+            "json",
+            "precedent",
+            "find",
+            "case_codex_precedent_current_rust",
+            "--limit",
+            "2",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let precedents: Value = serde_json::from_slice(&output).expect("precedents");
+    let precedents = precedents.as_array().expect("precedents array");
+    assert_eq!(precedents.len(), 2);
+    assert_eq!(
+        precedents[0]["case_id"],
+        "case_codex_precedent_semantic_rust"
+    );
+    assert_eq!(
+        precedents[1]["case_id"],
+        "case_codex_precedent_operational_rust"
+    );
+}


### PR DESCRIPTION
Closes #182

Implement the scoped GitHub issue on a child branch that merges into `codex/issue-172-rust-public-cli`.

Implementation notes:
- Prefer moving Codex rollout normalization helpers into the dedicated `openprecedent-capture-codex` crate instead of embedding more runtime-specific parsing directly into the CLI binary.
- Preserve the JSON output contract because later lineage and skill migrations will invoke this command directly.

Validation:
- run `cargo test`
- run `./scripts/run-pytest.sh -q tests/test_rust_cli_workspace.py`
- run `./scripts/run-agent-preflight.sh` before opening the PR
- `cargo test; ./scripts/run-pytest.sh -q tests/test_rust_cli_workspace.py; ./scripts/run-agent-preflight.sh`