### PR TITLE
Migrate the lineage brief command to the Rust CLI

### DIFF
--- a/.codex/pm/issue-state/183-migrate-lineage-brief-command-to-rust-cli.md
+++ b/.codex/pm/issue-state/183-migrate-lineage-brief-command-to-rust-cli.md
@@ -1,0 +1,34 @@
+---
+type: issue_state
+issue: 183
+task: .codex/pm/tasks/public-cli-foundation/migrate-lineage-brief-command-to-rust-cli.md
+title: Migrate the lineage brief command to the Rust CLI
+status: done
+---
+
+## Summary
+
+The runtime decision-lineage brief now runs through the Rust public CLI and records stable runtime invocation entries for successful brief requests.
+
+## Validated Facts
+
+- issues `#177` through `#182` already moved the core CRUD, replay, precedent, and capture surfaces into Rust on the integration branch
+- the Rust CLI now exposes `lineage brief`
+- lineage brief now returns stable Rust contract types and appends runtime invocation records to the resolved invocation-log path
+- Rust contract tests cover brief generation from extracted decisions and invocation-log recording with `case_id`, `session_id`, `current_plan`, `candidate_action`, and `known_files`
+
+## Open Questions
+
+- the ranking and brief-shaping helpers currently live in the CLI crate and may still move into shared core helpers if more lineage surfaces converge on the same logic
+
+## Next Steps
+
+- merge this child issue into `codex/issue-172-rust-public-cli`
+- continue with `#184` for lineage invocation list and inspect commands
+
+## Artifacts
+
+- `rust/openprecedent-contracts/`
+- `rust/openprecedent-cli/src/main.rs`
+- `rust/openprecedent-cli/tests/lineage_brief_contract.rs`
+- `.codex/pm/tasks/public-cli-foundation/migrate-lineage-brief-command-to-rust-cli.md`

--- a/.codex/pm/tasks/public-cli-foundation/migrate-lineage-brief-command-to-rust-cli.md
+++ b/.codex/pm/tasks/public-cli-foundation/migrate-lineage-brief-command-to-rust-cli.md
@@ -3,7 +3,7 @@ type: task
 epic: public-cli-foundation
 slug: migrate-lineage-brief-command-to-rust-cli
 title: Migrate the lineage brief command to the Rust CLI
-status: backlog
+status: done
 task_type: implementation
 labels: cli,rust,interface
 issue: 183
@@ -11,7 +11,7 @@ issue: 183
 
 ## Context
 
-Planned child issue under `#172`. Expand the implementation detail when this issue becomes active.
+Child issue `#183` under `#172` migrates the runtime decision-lineage brief into Rust. This slice defines the first stable machine-facing lineage retrieval surface that skills will call directly.
 
 ## Deliverable
 
@@ -19,16 +19,30 @@ Implement the scoped GitHub issue on a child branch that merges into `codex/issu
 
 ## Scope
 
-- follow the scoped work and constraints defined in the linked GitHub issue
+- implement `lineage brief` in Rust
+- preserve the current semantic retrieval and brief-shaping behavior closely enough for existing research fixtures
+- append runtime invocation records to the resolved invocation log path
+- define stable Rust JSON contracts for the lineage brief and recorded invocation shape
 
 ## Acceptance Criteria
 
-- satisfy the acceptance criteria in the linked GitHub issue before opening a child PR
+- skills can call `openprecedent lineage brief --format json` without shell wrapper indirection
+- successful brief requests append runtime invocation records compatible with the existing log file contract
+- Rust tests cover brief generation and invocation-log recording
 
 ## Validation
 
-- run issue-appropriate local validation when this task becomes active
+- run `cargo test`
+- run `./scripts/run-pytest.sh -q tests/test_rust_cli_workspace.py`
+- run `./scripts/run-agent-preflight.sh` before opening the PR
 
 ## Implementation Notes
 
-- This task twin was scaffolded during the Rust CLI issue decomposition and should be elaborated when implementation starts.
+- Treat the lineage brief JSON shape as a long-lived skill contract, not as an internal debug payload.
+- Keep invocation logging explicit in the Rust CLI so later `lineage invocation` commands can build on the same stored contract.
+
+## Completion Notes
+
+- implemented `lineage brief` in the Rust CLI with stable JSON and text rendering
+- added lineage contract types to `openprecedent-contracts`, including the runtime invocation record shape
+- preserved invocation-log recording for successful brief requests and added Rust contract tests for brief generation and log recording

--- a/rust/openprecedent-cli/src/main.rs
+++ b/rust/openprecedent-cli/src/main.rs
@@ -1,16 +1,18 @@
 use std::collections::{BTreeMap, HashSet};
 use std::ffi::OsString;
-use std::fs::File;
-use std::io::{BufRead, BufReader};
+use std::fs::{File, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
 
 use chrono::{DateTime, Utc};
 use clap::{ArgAction, Args, CommandFactory, FromArgMatches, Parser, Subcommand};
 use openprecedent_capture_codex as capture_codex;
 use openprecedent_capture_openclaw as capture_openclaw;
 use openprecedent_contracts::{
-    Artifact, ArtifactType, Case, CaseStatus, Decision, DecisionExplanation, DecisionType, Event,
-    EventActor, EventType, OutputFormat, PathsDoctorReport, Precedent, ReplayResponse,
-    StorageDoctorReport, VersionReport, CLI_BINARY_NAME, CONTRACT_PHASE,
+    Artifact, ArtifactType, Case, CaseStatus, Decision, DecisionExplanation, DecisionLineageBrief,
+    DecisionLineageMatchedCase, DecisionLineageQueryReason, DecisionType, Event, EventActor,
+    EventType, OutputFormat, PathsDoctorReport, Precedent, ReplayResponse,
+    RuntimeDecisionLineageInvocation, StorageDoctorReport, VersionReport, CLI_BINARY_NAME,
+    CONTRACT_PHASE,
 };
 use openprecedent_core::{
     build_environment_report, build_paths_report, build_storage_report, build_version_report,
@@ -300,8 +302,28 @@ struct LineageCommand {
 
 #[derive(Debug, Subcommand)]
 enum LineageSubcommand {
-    Brief(TrailingArgs),
+    Brief(LineageBriefArgs),
     Invocation(LineageInvocationCommand),
+}
+
+#[derive(Debug, Args)]
+struct LineageBriefArgs {
+    #[arg(long = "query-reason", value_enum)]
+    query_reason: DecisionLineageQueryReason,
+    #[arg(long = "task-summary")]
+    task_summary: String,
+    #[arg(long = "current-plan")]
+    current_plan: Option<String>,
+    #[arg(long = "candidate-action")]
+    candidate_action: Option<String>,
+    #[arg(long = "known-file")]
+    known_files: Vec<String>,
+    #[arg(long = "case-id")]
+    case_id: Option<String>,
+    #[arg(long = "session-id")]
+    session_id: Option<String>,
+    #[arg(long, default_value_t = 3)]
+    limit: usize,
 }
 
 #[derive(Debug, Args)]
@@ -401,7 +423,7 @@ where
         Command::Replay(command) => handle_replay(command, &config),
         Command::Precedent(command) => handle_precedent(command, &config),
         Command::Capture(command) => handle_capture(command, &config),
-        Command::Lineage(command) => render_not_implemented_path(lineage_path(command)),
+        Command::Lineage(command) => handle_lineage(command, &config),
         Command::Eval(command) => render_not_implemented_path(eval_path(command)),
     }
 }
@@ -1206,6 +1228,44 @@ fn handle_capture(command: CaptureCommand, config: &ResolvedRuntimeConfig) -> i3
     }
 }
 
+fn handle_lineage(command: LineageCommand, config: &ResolvedRuntimeConfig) -> i32 {
+    match command.command {
+        LineageSubcommand::Brief(args) => {
+            let store = match SqliteStore::new(&config.db.path) {
+                Ok(store) => store,
+                Err(error) => {
+                    eprintln!("{error}");
+                    return 1;
+                }
+            };
+
+            let brief = match build_decision_lineage_brief(&store, &args) {
+                Ok(brief) => brief,
+                Err(error) => {
+                    eprintln!("{error}");
+                    return 1;
+                }
+            };
+
+            if let Err(error) = record_runtime_decision_lineage_invocation(
+                &args,
+                &brief,
+                &config.invocation_log.path,
+            ) {
+                eprintln!("{error}");
+                return 1;
+            }
+
+            render(&brief, config.format.value)
+        }
+        LineageSubcommand::Invocation(command) => {
+            render_not_implemented_path(lineage_path(LineageCommand {
+                command: LineageSubcommand::Invocation(command),
+            }))
+        }
+    }
+}
+
 fn render_not_implemented_path(path: Vec<&'static str>) -> i32 {
     let error = not_implemented(&path);
     eprintln!("{error}");
@@ -1495,6 +1555,56 @@ impl TextRenderable for Precedent {
         }
         if let Some(outcome) = &self.historical_outcome {
             lines.push(format!("  historical_outcome: {outcome}"));
+        }
+        lines.join("\n")
+    }
+}
+
+impl TextRenderable for DecisionLineageBrief {
+    fn render_text(&self) -> String {
+        let mut lines = vec![
+            format!("query_reason: {}", self.query_reason),
+            format!("task_summary: {}", self.task_summary),
+        ];
+        if let Some(task_frame) = &self.task_frame {
+            lines.push(format!("task_frame: {task_frame}"));
+        }
+        if let Some(suggested_focus) = &self.suggested_focus {
+            lines.push(format!("suggested_focus: {suggested_focus}"));
+        }
+        lines.push("matched_cases:".to_string());
+        for matched in &self.matched_cases {
+            lines.push(format!(
+                "  - {} (score={}): {}",
+                matched.case_id, matched.similarity_score, matched.title
+            ));
+        }
+        if !self.accepted_constraints.is_empty() {
+            lines.push(format!(
+                "accepted_constraints: {}",
+                self.accepted_constraints.join(" | ")
+            ));
+        }
+        if !self.success_criteria.is_empty() {
+            lines.push(format!(
+                "success_criteria: {}",
+                self.success_criteria.join(" | ")
+            ));
+        }
+        if !self.rejected_options.is_empty() {
+            lines.push(format!(
+                "rejected_options: {}",
+                self.rejected_options.join(" | ")
+            ));
+        }
+        if !self.authority_signals.is_empty() {
+            lines.push(format!(
+                "authority_signals: {}",
+                self.authority_signals.join(" | ")
+            ));
+        }
+        if !self.cautions.is_empty() {
+            lines.push(format!("cautions: {}", self.cautions.join(" | ")));
         }
         lines.join("\n")
     }
@@ -3501,6 +3611,193 @@ fn decision_keywords(decisions: &[Decision]) -> HashSet<String> {
         }
     }
     keywords
+}
+
+fn build_decision_lineage_brief(
+    store: &SqliteStore,
+    args: &LineageBriefArgs,
+) -> Result<DecisionLineageBrief, String> {
+    let query_tokens = decision_lineage_query_tokens(args);
+    if query_tokens.is_empty() {
+        return Err("decision-lineage brief requires non-empty task context".to_string());
+    }
+
+    let mut ranked_cases: Vec<(i64, Case, Vec<Event>, Vec<Decision>)> = Vec::new();
+    for case in store.list_cases().map_err(|error| error.to_string())? {
+        let events = store
+            .list_events(&case.case_id)
+            .map_err(|error| error.to_string())?;
+        let decisions = store
+            .list_decisions(&case.case_id)
+            .map_err(|error| error.to_string())?;
+        if decisions.is_empty() {
+            continue;
+        }
+
+        let case_keywords = case_keywords(&case, &events, &decisions);
+        let decision_keywords = decision_keywords(&decisions);
+        let semantic_overlap = query_tokens.intersection(&decision_keywords).count() as i64;
+        let contextual_overlap = query_tokens.intersection(&case_keywords).count() as i64;
+        let score = semantic_overlap * 3 + contextual_overlap;
+        if score <= 0 {
+            continue;
+        }
+        ranked_cases.push((score, case, events, decisions));
+    }
+
+    ranked_cases.sort_by(|left, right| {
+        right
+            .0
+            .cmp(&left.0)
+            .then_with(|| left.1.case_id.cmp(&right.1.case_id))
+    });
+
+    let mut matched_cases = Vec::new();
+    let mut relevant_decisions = Vec::new();
+    for (score, case, events, decisions) in ranked_cases.into_iter().take(args.limit.max(1)) {
+        matched_cases.push(DecisionLineageMatchedCase {
+            case_id: case.case_id.clone(),
+            title: case.title.clone(),
+            similarity_score: score,
+            summary: build_case_summary(&case, &events, &decisions),
+        });
+        relevant_decisions.extend(decisions);
+    }
+
+    let task_frame = first_decision_text(&relevant_decisions, DecisionType::TaskFrameDefined);
+    let accepted_constraints =
+        decision_texts(&relevant_decisions, DecisionType::ConstraintAdopted, 5);
+    let success_criteria = decision_texts(&relevant_decisions, DecisionType::SuccessCriteriaSet, 5);
+    let rejected_options = decision_texts(&relevant_decisions, DecisionType::OptionRejected, 5);
+    let authority_signals =
+        decision_texts(&relevant_decisions, DecisionType::AuthorityConfirmed, 5);
+
+    let suggested_focus = task_frame
+        .clone()
+        .or_else(|| accepted_constraints.first().cloned())
+        .or_else(|| success_criteria.first().cloned());
+    let cautions = rejected_options
+        .iter()
+        .chain(accepted_constraints.iter())
+        .filter(|text| {
+            let normalized = normalize_message_intent(text);
+            normalized.contains("do not")
+                || normalized.contains("don't")
+                || normalized.contains("instead of")
+        })
+        .take(3)
+        .cloned()
+        .collect::<Vec<_>>();
+
+    Ok(DecisionLineageBrief {
+        query_reason: args.query_reason,
+        task_summary: args.task_summary.clone(),
+        suggested_focus,
+        matched_cases,
+        task_frame,
+        accepted_constraints,
+        success_criteria,
+        rejected_options,
+        authority_signals,
+        cautions,
+    })
+}
+
+fn decision_lineage_query_tokens(args: &LineageBriefArgs) -> HashSet<String> {
+    let mut texts = vec![args.task_summary.clone()];
+    if let Some(current_plan) = &args.current_plan {
+        texts.push(current_plan.clone());
+    }
+    if let Some(candidate_action) = &args.candidate_action {
+        texts.push(candidate_action.clone());
+    }
+    texts.extend(args.known_files.clone());
+
+    let mut tokens = HashSet::new();
+    for text in texts {
+        tokens.extend(tokenize_keywords(&text));
+    }
+    tokens
+}
+
+fn decision_texts(
+    decisions: &[Decision],
+    decision_type: DecisionType,
+    limit: usize,
+) -> Vec<String> {
+    let mut values = Vec::new();
+    let mut seen = HashSet::new();
+    for decision in decisions {
+        if decision.decision_type != decision_type {
+            continue;
+        }
+        let text = decision
+            .outcome
+            .clone()
+            .unwrap_or_else(|| decision.chosen_action.clone());
+        let normalized = normalize_message_intent(&text);
+        if normalized.is_empty() || !seen.insert(normalized) {
+            continue;
+        }
+        values.push(text);
+        if values.len() >= limit {
+            break;
+        }
+    }
+    values
+}
+
+fn first_decision_text(decisions: &[Decision], decision_type: DecisionType) -> Option<String> {
+    decision_texts(decisions, decision_type, 1)
+        .into_iter()
+        .next()
+}
+
+fn record_runtime_decision_lineage_invocation(
+    args: &LineageBriefArgs,
+    brief: &DecisionLineageBrief,
+    log_path: &std::path::Path,
+) -> Result<RuntimeDecisionLineageInvocation, String> {
+    let invocation = RuntimeDecisionLineageInvocation {
+        invocation_id: format!("rtinv_{}", &Uuid::new_v4().simple().to_string()[..12]),
+        recorded_at: Utc::now(),
+        query_reason: args.query_reason,
+        task_summary: args.task_summary.clone(),
+        current_plan: args.current_plan.clone(),
+        candidate_action: args.candidate_action.clone(),
+        known_files: args.known_files.clone(),
+        case_id: args.case_id.clone(),
+        session_id: args.session_id.clone(),
+        matched_case_ids: brief
+            .matched_cases
+            .iter()
+            .map(|item| item.case_id.clone())
+            .collect(),
+        task_frame: brief.task_frame.clone(),
+        accepted_constraints: brief.accepted_constraints.clone(),
+        success_criteria: brief.success_criteria.clone(),
+        rejected_options: brief.rejected_options.clone(),
+        authority_signals: brief.authority_signals.clone(),
+        cautions: brief.cautions.clone(),
+        suggested_focus: brief.suggested_focus.clone(),
+    };
+
+    if let Some(parent) = log_path.parent() {
+        std::fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+    }
+    let mut handle = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_path)
+        .map_err(|error| error.to_string())?;
+    writeln!(
+        handle,
+        "{}",
+        serde_json::to_string(&invocation).map_err(|error| error.to_string())?
+    )
+    .map_err(|error| error.to_string())?;
+
+    Ok(invocation)
 }
 
 fn build_reusable_takeaway(case: &Case, decisions: &[Decision]) -> Option<String> {

--- a/rust/openprecedent-cli/tests/lineage_brief_contract.rs
+++ b/rust/openprecedent-cli/tests/lineage_brief_contract.rs
@@ -1,0 +1,256 @@
+use std::fs;
+use std::path::Path;
+
+use assert_cmd::Command;
+use serde_json::Value;
+use tempfile::tempdir;
+
+fn cli() -> Command {
+    Command::cargo_bin("openprecedent").expect("cargo bin")
+}
+
+fn seed_guidance_case(db_path: &std::path::Path, case_id: &str, title: &str) {
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().expect("db path"),
+            "case",
+            "create",
+            "--case-id",
+            case_id,
+            "--title",
+            title,
+        ])
+        .assert()
+        .success();
+
+    for payload in [
+        (
+            "message.user",
+            "user",
+            "{\"message\":\"Do not edit code. Provide a short written recommendation only.\"}",
+        ),
+        (
+            "message.agent",
+            "agent",
+            "{\"message\":\"I will stay within docs-only scope and provide a short recommendation.\"}",
+        ),
+        (
+            "user.confirmed",
+            "user",
+            "{\"message\":\"Approved. Stay within docs-only scope.\"}",
+        ),
+    ] {
+        cli()
+            .args([
+                "--db",
+                db_path.to_str().expect("db path"),
+                "event",
+                "append",
+                case_id,
+                payload.0,
+                payload.1,
+                "--payload",
+                payload.2,
+            ])
+            .assert()
+            .success();
+    }
+
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().expect("db path"),
+            "--format",
+            "json",
+            "decision",
+            "extract",
+            case_id,
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
+fn lineage_brief_returns_json_and_records_runtime_invocation() {
+    let runtime = tempdir().expect("runtime");
+    let db_path = runtime.path().join("openprecedent.db");
+    let log_path = runtime.path().join("runtime-invocations.jsonl");
+
+    seed_guidance_case(
+        &db_path,
+        "case_cli_brief_guidance",
+        "Docs-only recommendation",
+    );
+
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().expect("db path"),
+            "case",
+            "create",
+            "--case-id",
+            "case_runtime_scope",
+            "--title",
+            "Runtime scope case",
+        ])
+        .assert()
+        .success();
+
+    let output = cli()
+        .args([
+            "--db",
+            db_path.to_str().expect("db path"),
+            "--invocation-log",
+            log_path.to_str().expect("log path"),
+            "--format",
+            "json",
+            "lineage",
+            "brief",
+            "--query-reason",
+            "initial_planning",
+            "--task-summary",
+            "Do not edit code. Provide a short written recommendation only.",
+            "--case-id",
+            "case_runtime_scope",
+            "--session-id",
+            "session_runtime_scope",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let brief: Value = serde_json::from_slice(&output).expect("brief");
+    assert_eq!(brief["query_reason"], "initial_planning");
+    assert_eq!(
+        brief["matched_cases"][0]["case_id"],
+        "case_cli_brief_guidance"
+    );
+    assert!(
+        brief["authority_signals"]
+            .as_array()
+            .expect("authority")
+            .len()
+            >= 1
+    );
+
+    let logged = fs::read_to_string(&log_path).expect("log file");
+    let rows = logged
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str::<Value>(line).expect("json line"))
+        .collect::<Vec<_>>();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["query_reason"], "initial_planning");
+    assert_eq!(rows[0]["case_id"], "case_runtime_scope");
+    assert_eq!(rows[0]["session_id"], "session_runtime_scope");
+    assert_eq!(
+        rows[0]["matched_case_ids"],
+        serde_json::json!(["case_cli_brief_guidance"])
+    );
+}
+
+#[test]
+fn lineage_brief_uses_plan_action_and_known_file_context() {
+    let runtime = tempdir().expect("runtime");
+    let db_path = runtime.path().join("openprecedent.db");
+    let log_path = runtime.path().join("runtime-invocations.jsonl");
+    let fixture_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/fixtures");
+
+    for (case_id, title, filename) in [
+        (
+            "case_codex_precedent_current_rust",
+            "Current Codex docs-only recommendation",
+            "codex_rollout_precedent_current.jsonl",
+        ),
+        (
+            "case_codex_precedent_semantic_rust",
+            "Semantic Codex docs-only precedent",
+            "codex_rollout_precedent_semantic_match.jsonl",
+        ),
+    ] {
+        cli()
+            .args([
+                "--db",
+                db_path.to_str().expect("db path"),
+                "capture",
+                "codex",
+                "import-rollout",
+                fixture_root.join(filename).to_str().expect("fixture"),
+                "--case-id",
+                case_id,
+                "--title",
+                title,
+            ])
+            .assert()
+            .success();
+        cli()
+            .args([
+                "--db",
+                db_path.to_str().expect("db path"),
+                "--format",
+                "json",
+                "decision",
+                "extract",
+                case_id,
+            ])
+            .assert()
+            .success();
+    }
+
+    let output = cli()
+        .args([
+            "--db",
+            db_path.to_str().expect("db path"),
+            "--invocation-log",
+            log_path.to_str().expect("log path"),
+            "--format",
+            "json",
+            "lineage",
+            "brief",
+            "--query-reason",
+            "before_file_write",
+            "--task-summary",
+            "Do not edit code. Give me a brief recommendation about the Codex runtime boundary docs only.",
+            "--current-plan",
+            "Prepare a brief docs-only recommendation about the Codex runtime boundary docs.",
+            "--candidate-action",
+            "Edit docs/engineering/codex-runtime-boundary.md",
+            "--known-file",
+            "docs/engineering/codex-runtime-boundary.md",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let brief: Value = serde_json::from_slice(&output).expect("brief");
+    assert_eq!(brief["query_reason"], "before_file_write");
+    assert_eq!(
+        brief["matched_cases"][0]["case_id"],
+        "case_codex_precedent_semantic_rust"
+    );
+
+    let logged = fs::read_to_string(&log_path).expect("log file");
+    let row = logged
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str::<Value>(line).expect("json line"))
+        .last()
+        .expect("logged row");
+    assert_eq!(
+        row["current_plan"],
+        "Prepare a brief docs-only recommendation about the Codex runtime boundary docs."
+    );
+    assert_eq!(
+        row["candidate_action"],
+        "Edit docs/engineering/codex-runtime-boundary.md"
+    );
+    assert_eq!(
+        row["known_files"],
+        serde_json::json!(["docs/engineering/codex-runtime-boundary.md"])
+    );
+}

--- a/rust/openprecedent-contracts/src/lib.rs
+++ b/rust/openprecedent-contracts/src/lib.rs
@@ -2,6 +2,7 @@ mod artifact;
 mod case;
 mod decision;
 mod event;
+mod lineage;
 mod precedent;
 mod replay;
 
@@ -14,6 +15,10 @@ pub use artifact::{Artifact, ArtifactType};
 pub use case::{Case, CaseStatus};
 pub use decision::{Decision, DecisionExplanation, DecisionType};
 pub use event::{Event, EventActor, EventType};
+pub use lineage::{
+    DecisionLineageBrief, DecisionLineageMatchedCase, DecisionLineageQueryReason,
+    RuntimeDecisionLineageInvocation,
+};
 pub use precedent::Precedent;
 pub use replay::ReplayResponse;
 

--- a/rust/openprecedent-contracts/src/lineage.rs
+++ b/rust/openprecedent-contracts/src/lineage.rs
@@ -1,0 +1,82 @@
+use chrono::{DateTime, Utc};
+use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, ValueEnum)]
+#[serde(rename_all = "snake_case")]
+pub enum DecisionLineageQueryReason {
+    #[value(name = "initial_planning")]
+    InitialPlanning,
+    #[value(name = "before_file_write")]
+    BeforeFileWrite,
+    #[value(name = "after_failure")]
+    AfterFailure,
+    #[value(name = "manual")]
+    Manual,
+}
+
+impl std::fmt::Display for DecisionLineageQueryReason {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::InitialPlanning => "initial_planning",
+            Self::BeforeFileWrite => "before_file_write",
+            Self::AfterFailure => "after_failure",
+            Self::Manual => "manual",
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct DecisionLineageMatchedCase {
+    pub case_id: String,
+    pub title: String,
+    pub similarity_score: i64,
+    pub summary: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct DecisionLineageBrief {
+    pub query_reason: DecisionLineageQueryReason,
+    pub task_summary: String,
+    pub suggested_focus: Option<String>,
+    pub matched_cases: Vec<DecisionLineageMatchedCase>,
+    pub task_frame: Option<String>,
+    #[serde(default)]
+    pub accepted_constraints: Vec<String>,
+    #[serde(default)]
+    pub success_criteria: Vec<String>,
+    #[serde(default)]
+    pub rejected_options: Vec<String>,
+    #[serde(default)]
+    pub authority_signals: Vec<String>,
+    #[serde(default)]
+    pub cautions: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct RuntimeDecisionLineageInvocation {
+    pub invocation_id: String,
+    pub recorded_at: DateTime<Utc>,
+    pub query_reason: DecisionLineageQueryReason,
+    pub task_summary: String,
+    pub current_plan: Option<String>,
+    pub candidate_action: Option<String>,
+    #[serde(default)]
+    pub known_files: Vec<String>,
+    pub case_id: Option<String>,
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub matched_case_ids: Vec<String>,
+    pub task_frame: Option<String>,
+    #[serde(default)]
+    pub accepted_constraints: Vec<String>,
+    #[serde(default)]
+    pub success_criteria: Vec<String>,
+    #[serde(default)]
+    pub rejected_options: Vec<String>,
+    #[serde(default)]
+    pub authority_signals: Vec<String>,
+    #[serde(default)]
+    pub cautions: Vec<String>,
+    pub suggested_focus: Option<String>,
+}


### PR DESCRIPTION
Closes #183

Implement the scoped GitHub issue on a child branch that merges into `codex/issue-172-rust-public-cli`.

Implementation notes:
- Treat the lineage brief JSON shape as a long-lived skill contract, not as an internal debug payload.
- Keep invocation logging explicit in the Rust CLI so later `lineage invocation` commands can build on the same stored contract.

Validation:
- run `cargo test`
- run `./scripts/run-pytest.sh -q tests/test_rust_cli_workspace.py`
- run `./scripts/run-agent-preflight.sh` before opening the PR
- `cargo test; ./scripts/run-pytest.sh -q tests/test_rust_cli_workspace.py; ./scripts/run-agent-preflight.sh`