### PR TITLE
Migrate lineage invocation inspection commands to the Rust CLI

### DIFF
--- a/.codex/pm/issue-state/184-migrate-lineage-invocation-inspection-commands-to-rust-cli.md
+++ b/.codex/pm/issue-state/184-migrate-lineage-invocation-inspection-commands-to-rust-cli.md
@@ -1,0 +1,34 @@
+---
+type: issue_state
+issue: 184
+task: .codex/pm/tasks/public-cli-foundation/migrate-lineage-invocation-inspection-commands-to-rust-cli.md
+title: Migrate lineage invocation inspection commands to the Rust CLI
+status: done
+---
+
+## Summary
+
+Lineage invocation history can now be listed and inspected through the Rust public CLI without falling back to the Python CLI.
+
+## Validated Facts
+
+- issue `#183` already writes runtime lineage invocation records from the Rust CLI
+- the Rust CLI now exposes `lineage invocation list` and `lineage invocation inspect`
+- Rust inspection preserves the current behavior of returning downstream events and decisions that occurred after the recorded invocation time for the referenced case
+- Rust contract tests cover invocation list readability and inspection fidelity against the current JSONL log contract
+
+## Open Questions
+
+- later research tooling may still want higher-level filtering or summary commands beyond the raw list and inspect surfaces
+
+## Next Steps
+
+- merge this child issue into `codex/issue-172-rust-public-cli`
+- continue with `#185` for eval command migration
+
+## Artifacts
+
+- `rust/openprecedent-contracts/`
+- `rust/openprecedent-cli/src/main.rs`
+- `rust/openprecedent-cli/tests/lineage_invocation_contract.rs`
+- `.codex/pm/tasks/public-cli-foundation/migrate-lineage-invocation-inspection-commands-to-rust-cli.md`

--- a/.codex/pm/tasks/public-cli-foundation/migrate-lineage-invocation-inspection-commands-to-rust-cli.md
+++ b/.codex/pm/tasks/public-cli-foundation/migrate-lineage-invocation-inspection-commands-to-rust-cli.md
@@ -3,7 +3,7 @@ type: task
 epic: public-cli-foundation
 slug: migrate-lineage-invocation-inspection-commands-to-rust-cli
 title: Migrate lineage invocation inspection commands to the Rust CLI
-status: backlog
+status: done
 task_type: implementation
 labels: cli,rust,interface
 issue: 184
@@ -11,7 +11,7 @@ issue: 184
 
 ## Context
 
-Planned child issue under `#172`. Expand the implementation detail when this issue becomes active.
+Child issue `#184` under `#172` migrates lineage invocation observability into Rust. This slice covers listing recorded invocation entries and inspecting one invocation together with downstream case signals.
 
 ## Deliverable
 
@@ -19,16 +19,29 @@ Implement the scoped GitHub issue on a child branch that merges into `codex/issu
 
 ## Scope
 
-- follow the scoped work and constraints defined in the linked GitHub issue
+- implement `lineage invocation list` in Rust
+- implement `lineage invocation inspect` in Rust
+- preserve invocation-log readability and downstream inspection fidelity against the current JSONL log contract
 
 ## Acceptance Criteria
 
-- satisfy the acceptance criteria in the linked GitHub issue before opening a child PR
+- invocation history is readable through the Rust CLI
+- a recorded invocation can be inspected together with downstream events and decisions when the referenced case exists
+- Rust tests cover invocation listing and inspection behavior
 
 ## Validation
 
-- run issue-appropriate local validation when this task becomes active
+- run `cargo test`
+- run `./scripts/run-pytest.sh -q tests/test_rust_cli_workspace.py`
+- run `./scripts/run-agent-preflight.sh` before opening the PR
 
 ## Implementation Notes
 
-- This task twin was scaffolded during the Rust CLI issue decomposition and should be elaborated when implementation starts.
+- Reuse the lineage invocation contract introduced by `#183` instead of inventing a second log shape.
+- Keep log-path resolution on the global `--invocation-log` flag and resolved runtime config so skills and harnesses can keep using one path.
+
+## Completion Notes
+
+- implemented `lineage invocation list` and `lineage invocation inspect` in the Rust CLI
+- added a Rust inspection contract that combines one invocation with downstream events and decisions
+- added Rust contract tests for invocation listing and downstream inspection behavior

--- a/rust/openprecedent-cli/src/main.rs
+++ b/rust/openprecedent-cli/src/main.rs
@@ -11,8 +11,8 @@ use openprecedent_contracts::{
     Artifact, ArtifactType, Case, CaseStatus, Decision, DecisionExplanation, DecisionLineageBrief,
     DecisionLineageMatchedCase, DecisionLineageQueryReason, DecisionType, Event, EventActor,
     EventType, OutputFormat, PathsDoctorReport, Precedent, ReplayResponse,
-    RuntimeDecisionLineageInvocation, StorageDoctorReport, VersionReport, CLI_BINARY_NAME,
-    CONTRACT_PHASE,
+    RuntimeDecisionLineageInspection, RuntimeDecisionLineageInvocation, StorageDoctorReport,
+    VersionReport, CLI_BINARY_NAME, CONTRACT_PHASE,
 };
 use openprecedent_core::{
     build_environment_report, build_paths_report, build_storage_report, build_version_report,
@@ -334,8 +334,17 @@ struct LineageInvocationCommand {
 
 #[derive(Debug, Subcommand)]
 enum LineageInvocationSubcommand {
-    List(TrailingArgs),
-    Inspect(TrailingArgs),
+    List(LineageInvocationListArgs),
+    Inspect(LineageInvocationInspectArgs),
+}
+
+#[derive(Debug, Args)]
+struct LineageInvocationListArgs {}
+
+#[derive(Debug, Args)]
+struct LineageInvocationInspectArgs {
+    #[arg(long = "invocation-id")]
+    invocation_id: String,
 }
 
 #[derive(Debug, Args)]
@@ -1258,11 +1267,40 @@ fn handle_lineage(command: LineageCommand, config: &ResolvedRuntimeConfig) -> i3
 
             render(&brief, config.format.value)
         }
-        LineageSubcommand::Invocation(command) => {
-            render_not_implemented_path(lineage_path(LineageCommand {
-                command: LineageSubcommand::Invocation(command),
-            }))
-        }
+        LineageSubcommand::Invocation(command) => match command.command {
+            LineageInvocationSubcommand::List(_) => {
+                let invocations =
+                    match list_runtime_decision_lineage_invocations(&config.invocation_log.path) {
+                        Ok(invocations) => invocations,
+                        Err(error) => {
+                            eprintln!("{error}");
+                            return 1;
+                        }
+                    };
+                render(&invocations, config.format.value)
+            }
+            LineageInvocationSubcommand::Inspect(args) => {
+                let store = match SqliteStore::new(&config.db.path) {
+                    Ok(store) => store,
+                    Err(error) => {
+                        eprintln!("{error}");
+                        return 1;
+                    }
+                };
+                let inspection = match inspect_runtime_decision_lineage_invocation(
+                    &store,
+                    &args.invocation_id,
+                    &config.invocation_log.path,
+                ) {
+                    Ok(inspection) => inspection,
+                    Err(error) => {
+                        eprintln!("{error}");
+                        return 1;
+                    }
+                };
+                render(&inspection, config.format.value)
+            }
+        },
     }
 }
 
@@ -1607,6 +1645,50 @@ impl TextRenderable for DecisionLineageBrief {
             lines.push(format!("cautions: {}", self.cautions.join(" | ")));
         }
         lines.join("\n")
+    }
+}
+
+impl TextRenderable for RuntimeDecisionLineageInvocation {
+    fn render_text(&self) -> String {
+        let mut lines = vec![
+            format!("invocation_id: {}", self.invocation_id),
+            format!("recorded_at: {}", self.recorded_at.to_rfc3339()),
+            format!("query_reason: {}", self.query_reason),
+            format!("task_summary: {}", self.task_summary),
+        ];
+        if let Some(case_id) = &self.case_id {
+            lines.push(format!("case_id: {case_id}"));
+        }
+        if let Some(session_id) = &self.session_id {
+            lines.push(format!("session_id: {session_id}"));
+        }
+        if !self.matched_case_ids.is_empty() {
+            lines.push(format!(
+                "matched_case_ids: {}",
+                self.matched_case_ids.join(", ")
+            ));
+        }
+        lines.join("\n")
+    }
+}
+
+impl TextRenderable for Vec<RuntimeDecisionLineageInvocation> {
+    fn render_text(&self) -> String {
+        self.iter()
+            .map(TextRenderable::render_text)
+            .collect::<Vec<_>>()
+            .join("\n\n")
+    }
+}
+
+impl TextRenderable for RuntimeDecisionLineageInspection {
+    fn render_text(&self) -> String {
+        [
+            self.invocation.render_text(),
+            format!("downstream_events: {}", self.downstream_events.len()),
+            format!("downstream_decisions: {}", self.downstream_decisions.len()),
+        ]
+        .join("\n")
     }
 }
 
@@ -3800,6 +3882,89 @@ fn record_runtime_decision_lineage_invocation(
     Ok(invocation)
 }
 
+fn list_runtime_decision_lineage_invocations(
+    log_path: &std::path::Path,
+) -> Result<Vec<RuntimeDecisionLineageInvocation>, String> {
+    if !log_path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let file = File::open(log_path).map_err(|error| error.to_string())?;
+    let mut invocations = Vec::new();
+    for (index, line_result) in BufReader::new(file).lines().enumerate() {
+        let line_no = index + 1;
+        let line = line_result.map_err(|error| error.to_string())?;
+        let stripped = line.trim();
+        if stripped.is_empty() {
+            continue;
+        }
+        let invocation = serde_json::from_str::<RuntimeDecisionLineageInvocation>(stripped)
+            .map_err(|_| {
+                format!("invalid runtime decision-lineage invocation log at line {line_no}")
+            })?;
+        invocations.push(invocation);
+    }
+    Ok(invocations)
+}
+
+fn inspect_runtime_decision_lineage_invocation(
+    store: &SqliteStore,
+    invocation_id: &str,
+    log_path: &std::path::Path,
+) -> Result<RuntimeDecisionLineageInspection, String> {
+    let invocation = list_runtime_decision_lineage_invocations(log_path)?
+        .into_iter()
+        .find(|item| item.invocation_id == invocation_id)
+        .ok_or_else(|| format!("invocation not found: {invocation_id}"))?;
+
+    let Some(case_id) = invocation.case_id.clone() else {
+        return Ok(RuntimeDecisionLineageInspection {
+            invocation,
+            downstream_events: Vec::new(),
+            downstream_decisions: Vec::new(),
+        });
+    };
+
+    let Some(_case) = store
+        .get_case(&case_id)
+        .map_err(|error| error.to_string())?
+    else {
+        return Ok(RuntimeDecisionLineageInspection {
+            invocation,
+            downstream_events: Vec::new(),
+            downstream_decisions: Vec::new(),
+        });
+    };
+
+    let downstream_events = store
+        .list_events(&case_id)
+        .map_err(|error| error.to_string())?
+        .into_iter()
+        .filter(|event| event.timestamp > invocation.recorded_at)
+        .collect::<Vec<_>>();
+    let downstream_event_ids = downstream_events
+        .iter()
+        .map(|event| event.event_id.clone())
+        .collect::<HashSet<_>>();
+    let downstream_decisions = store
+        .list_decisions(&case_id)
+        .map_err(|error| error.to_string())?
+        .into_iter()
+        .filter(|decision| {
+            decision
+                .evidence_event_ids
+                .iter()
+                .any(|event_id| downstream_event_ids.contains(event_id))
+        })
+        .collect::<Vec<_>>();
+
+    Ok(RuntimeDecisionLineageInspection {
+        invocation,
+        downstream_events,
+        downstream_decisions,
+    })
+}
+
 fn build_reusable_takeaway(case: &Case, decisions: &[Decision]) -> Option<String> {
     decisions
         .last()
@@ -3885,16 +4050,6 @@ const STOP_WORDS: [&str; 18] = [
     "the", "and", "for", "with", "that", "this", "from", "into", "will", "then", "case",
     "openclaw", "session", "docs", "file", "tool", "command", "agent",
 ];
-
-fn lineage_path(command: LineageCommand) -> Vec<&'static str> {
-    match command.command {
-        LineageSubcommand::Brief(_) => vec!["lineage", "brief"],
-        LineageSubcommand::Invocation(command) => match command.command {
-            LineageInvocationSubcommand::List(_) => vec!["lineage", "invocation", "list"],
-            LineageInvocationSubcommand::Inspect(_) => vec!["lineage", "invocation", "inspect"],
-        },
-    }
-}
 
 fn eval_path(command: EvalCommand) -> Vec<&'static str> {
     match command.command {

--- a/rust/openprecedent-cli/tests/lineage_invocation_contract.rs
+++ b/rust/openprecedent-cli/tests/lineage_invocation_contract.rs
@@ -1,0 +1,253 @@
+use std::fs;
+
+use assert_cmd::Command;
+use serde_json::Value;
+use tempfile::tempdir;
+
+fn cli() -> Command {
+    Command::cargo_bin("openprecedent").expect("cargo bin")
+}
+
+fn seed_guidance_case(db_path: &std::path::Path, case_id: &str, title: &str) {
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().expect("db path"),
+            "case",
+            "create",
+            "--case-id",
+            case_id,
+            "--title",
+            title,
+        ])
+        .assert()
+        .success();
+
+    for payload in [
+        (
+            "message.user",
+            "user",
+            "{\"message\":\"Do not edit code. Provide a short written recommendation only.\"}",
+        ),
+        (
+            "message.agent",
+            "agent",
+            "{\"message\":\"I will stay within docs-only scope and provide a short recommendation.\"}",
+        ),
+        (
+            "user.confirmed",
+            "user",
+            "{\"message\":\"Approved. Stay within docs-only scope.\"}",
+        ),
+    ] {
+        cli()
+            .args([
+                "--db",
+                db_path.to_str().expect("db path"),
+                "event",
+                "append",
+                case_id,
+                payload.0,
+                payload.1,
+                "--payload",
+                payload.2,
+            ])
+            .assert()
+            .success();
+    }
+
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().expect("db path"),
+            "--format",
+            "json",
+            "decision",
+            "extract",
+            case_id,
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
+fn lineage_invocation_list_reads_logged_entries() {
+    let runtime = tempdir().expect("runtime");
+    let db_path = runtime.path().join("openprecedent.db");
+    let log_path = runtime.path().join("runtime-invocations.jsonl");
+
+    seed_guidance_case(
+        &db_path,
+        "case_cli_brief_guidance",
+        "Docs-only recommendation",
+    );
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().expect("db path"),
+            "--invocation-log",
+            log_path.to_str().expect("log path"),
+            "--format",
+            "json",
+            "lineage",
+            "brief",
+            "--query-reason",
+            "initial_planning",
+            "--task-summary",
+            "Do not edit code. Provide a short written recommendation only.",
+            "--case-id",
+            "case_runtime_scope",
+            "--session-id",
+            "session_runtime_scope",
+        ])
+        .assert()
+        .success();
+
+    let output = cli()
+        .args([
+            "--invocation-log",
+            log_path.to_str().expect("log path"),
+            "--format",
+            "json",
+            "lineage",
+            "invocation",
+            "list",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let invocations: Value = serde_json::from_slice(&output).expect("invocations");
+    let invocations = invocations.as_array().expect("array");
+    assert_eq!(invocations.len(), 1);
+    assert_eq!(invocations[0]["query_reason"], "initial_planning");
+    assert_eq!(invocations[0]["session_id"], "session_runtime_scope");
+    assert_eq!(
+        invocations[0]["matched_case_ids"],
+        serde_json::json!(["case_cli_brief_guidance"])
+    );
+}
+
+#[test]
+fn lineage_invocation_inspect_returns_downstream_events_and_decisions() {
+    let runtime = tempdir().expect("runtime");
+    let db_path = runtime.path().join("openprecedent.db");
+    let log_path = runtime.path().join("runtime-invocations.jsonl");
+
+    seed_guidance_case(
+        &db_path,
+        "case_cli_brief_guidance",
+        "Docs-only recommendation",
+    );
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().expect("db path"),
+            "case",
+            "create",
+            "--case-id",
+            "case_runtime_scope",
+            "--title",
+            "Runtime scope case",
+        ])
+        .assert()
+        .success();
+
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().expect("db path"),
+            "--invocation-log",
+            log_path.to_str().expect("log path"),
+            "--format",
+            "json",
+            "lineage",
+            "brief",
+            "--query-reason",
+            "initial_planning",
+            "--task-summary",
+            "Do not edit code. Provide a short written recommendation only.",
+            "--case-id",
+            "case_runtime_scope",
+        ])
+        .assert()
+        .success();
+
+    let logged = fs::read_to_string(&log_path).expect("log file");
+    let invocation_id = logged
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str::<Value>(line).expect("json line"))
+        .last()
+        .and_then(|row| row["invocation_id"].as_str().map(ToString::to_string))
+        .expect("invocation id");
+
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().expect("db path"),
+            "event",
+            "append",
+            "case_runtime_scope",
+            "message.agent",
+            "agent",
+            "--payload",
+            "{\"message\":\"I will keep this docs-only and avoid code edits.\"}",
+        ])
+        .assert()
+        .success();
+    cli()
+        .args([
+            "--db",
+            db_path.to_str().expect("db path"),
+            "--format",
+            "json",
+            "decision",
+            "extract",
+            "case_runtime_scope",
+        ])
+        .assert()
+        .success();
+
+    let output = cli()
+        .args([
+            "--db",
+            db_path.to_str().expect("db path"),
+            "--invocation-log",
+            log_path.to_str().expect("log path"),
+            "--format",
+            "json",
+            "lineage",
+            "invocation",
+            "inspect",
+            "--invocation-id",
+            &invocation_id,
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let inspection: Value = serde_json::from_slice(&output).expect("inspection");
+    assert_eq!(
+        inspection["invocation"]["matched_case_ids"],
+        serde_json::json!(["case_cli_brief_guidance"])
+    );
+    assert!(
+        inspection["downstream_events"]
+            .as_array()
+            .expect("events")
+            .len()
+            >= 1
+    );
+    assert!(
+        inspection["downstream_decisions"]
+            .as_array()
+            .expect("decisions")
+            .len()
+            >= 1
+    );
+}

--- a/rust/openprecedent-contracts/src/lib.rs
+++ b/rust/openprecedent-contracts/src/lib.rs
@@ -17,7 +17,7 @@ pub use decision::{Decision, DecisionExplanation, DecisionType};
 pub use event::{Event, EventActor, EventType};
 pub use lineage::{
     DecisionLineageBrief, DecisionLineageMatchedCase, DecisionLineageQueryReason,
-    RuntimeDecisionLineageInvocation,
+    RuntimeDecisionLineageInspection, RuntimeDecisionLineageInvocation,
 };
 pub use precedent::Precedent;
 pub use replay::ReplayResponse;

--- a/rust/openprecedent-contracts/src/lineage.rs
+++ b/rust/openprecedent-contracts/src/lineage.rs
@@ -2,6 +2,8 @@ use chrono::{DateTime, Utc};
 use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 
+use crate::{Decision, Event};
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, ValueEnum)]
 #[serde(rename_all = "snake_case")]
 pub enum DecisionLineageQueryReason {
@@ -79,4 +81,13 @@ pub struct RuntimeDecisionLineageInvocation {
     #[serde(default)]
     pub cautions: Vec<String>,
     pub suggested_focus: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct RuntimeDecisionLineageInspection {
+    pub invocation: RuntimeDecisionLineageInvocation,
+    #[serde(default)]
+    pub downstream_events: Vec<Event>,
+    #[serde(default)]
+    pub downstream_decisions: Vec<Decision>,
 }


### PR DESCRIPTION
Closes #184

Implement the scoped GitHub issue on a child branch that merges into `codex/issue-172-rust-public-cli`.

Implementation notes:
- Reuse the lineage invocation contract introduced by `#183` instead of inventing a second log shape.
- Keep log-path resolution on the global `--invocation-log` flag and resolved runtime config so skills and harnesses can keep using one path.

Validation:
- run `cargo test`
- run `./scripts/run-pytest.sh -q tests/test_rust_cli_workspace.py`
- run `./scripts/run-agent-preflight.sh` before opening the PR
- `cargo test; ./scripts/run-pytest.sh -q tests/test_rust_cli_workspace.py; ./scripts/run-agent-preflight.sh`