### PR TITLE
Migrate eval commands to the Rust CLI

### DIFF
--- a/.codex/pm/issue-state/185-migrate-eval-commands-to-rust-cli.md
+++ b/.codex/pm/issue-state/185-migrate-eval-commands-to-rust-cli.md
@@ -1,0 +1,34 @@
+---
+type: issue_state
+issue: 185
+task: .codex/pm/tasks/public-cli-foundation/migrate-eval-commands-to-rust-cli.md
+title: Migrate eval commands to the Rust CLI
+status: done
+---
+
+## Summary
+
+The public evaluation command family now runs through the Rust CLI, including fixture-suite evaluation and collected OpenClaw session evaluation.
+
+## Validated Facts
+
+- issues `#177` through `#184` already moved the CRUD, replay, precedent, capture, and lineage observability surfaces into Rust on the integration branch
+- the Rust CLI now exposes `eval fixtures` and `eval captured-openclaw-sessions`
+- fixture evaluation preserves isolated-database enforcement, decision-type checks, and precedent expectations from the current evaluation suites
+- collected OpenClaw session evaluation preserves aggregated counters, unsupported-record summaries, and optional report-file emission
+
+## Open Questions
+
+- later validation flows may still want additional filtering or benchmark-specific summaries on top of these raw evaluation reports
+
+## Next Steps
+
+- merge this child issue into `codex/issue-172-rust-public-cli`
+- continue with `#186` for skill and validation workflow migration away from scripts
+
+## Artifacts
+
+- `rust/openprecedent-contracts/src/eval.rs`
+- `rust/openprecedent-cli/src/main.rs`
+- `rust/openprecedent-cli/tests/eval_contract.rs`
+- `.codex/pm/tasks/public-cli-foundation/migrate-eval-commands-to-rust-cli.md`

--- a/.codex/pm/tasks/public-cli-foundation/migrate-eval-commands-to-rust-cli.md
+++ b/.codex/pm/tasks/public-cli-foundation/migrate-eval-commands-to-rust-cli.md
@@ -3,7 +3,7 @@ type: task
 epic: public-cli-foundation
 slug: migrate-eval-commands-to-rust-cli
 title: Migrate eval commands to the Rust CLI
-status: backlog
+status: done
 task_type: implementation
 labels: cli,rust,interface
 issue: 185
@@ -11,7 +11,7 @@ issue: 185
 
 ## Context
 
-Planned child issue under `#172`. Expand the implementation detail when this issue becomes active.
+Child issue `#185` under `#172` migrates the public evaluation command family into Rust. This slice covers fixture-suite evaluation and collected OpenClaw session evaluation.
 
 ## Deliverable
 
@@ -19,16 +19,29 @@ Implement the scoped GitHub issue on a child branch that merges into `codex/issu
 
 ## Scope
 
-- follow the scoped work and constraints defined in the linked GitHub issue
+- implement `eval fixtures` in Rust
+- implement `eval captured-openclaw-sessions` in Rust
+- preserve expected evaluation report formats where they are part of the public contract
 
 ## Acceptance Criteria
 
-- satisfy the acceptance criteria in the linked GitHub issue before opening a child PR
+- evaluation flows run through the Rust CLI
+- evaluation outputs are stable enough for automated validation
+- the public eval surface no longer depends on Python CLI execution
 
 ## Validation
 
-- run issue-appropriate local validation when this task becomes active
+- run `cargo test`
+- run `./scripts/run-pytest.sh -q tests/test_rust_cli_workspace.py`
+- run `./scripts/run-agent-preflight.sh` before opening the PR
 
 ## Implementation Notes
 
-- This task twin was scaffolded during the Rust CLI issue decomposition and should be elaborated when implementation starts.
+- Reuse the Rust capture, decision extraction, and precedent helpers instead of routing eval through the Python service.
+- Keep the JSON report shapes stable because validation harnesses can depend on them directly once the Rust CLI becomes the public surface.
+
+## Completion Notes
+
+- implemented `eval fixtures` and `eval captured-openclaw-sessions` in the Rust CLI
+- added Rust evaluation report contracts under `openprecedent-contracts`
+- added Rust contract tests for fixture-suite evaluation and collected OpenClaw session evaluation

--- a/rust/openprecedent-cli/src/main.rs
+++ b/rust/openprecedent-cli/src/main.rs
@@ -8,15 +8,16 @@ use clap::{ArgAction, Args, CommandFactory, FromArgMatches, Parser, Subcommand};
 use openprecedent_capture_codex as capture_codex;
 use openprecedent_capture_openclaw as capture_openclaw;
 use openprecedent_contracts::{
-    Artifact, ArtifactType, Case, CaseStatus, Decision, DecisionExplanation, DecisionLineageBrief,
-    DecisionLineageMatchedCase, DecisionLineageQueryReason, DecisionType, Event, EventActor,
-    EventType, OutputFormat, PathsDoctorReport, Precedent, ReplayResponse,
-    RuntimeDecisionLineageInspection, RuntimeDecisionLineageInvocation, StorageDoctorReport,
-    VersionReport, CLI_BINARY_NAME, CONTRACT_PHASE,
+    Artifact, ArtifactType, Case, CaseStatus, CollectedSessionEvaluationReport,
+    CollectedSessionEvaluationResult, Decision, DecisionExplanation, DecisionLineageBrief,
+    DecisionLineageMatchedCase, DecisionLineageQueryReason, DecisionType, EvaluationCaseResult,
+    EvaluationReport, Event, EventActor, EventType, OutputFormat, PathsDoctorReport, Precedent,
+    ReplayResponse, RuntimeDecisionLineageInspection, RuntimeDecisionLineageInvocation,
+    StorageDoctorReport, VersionReport, CLI_BINARY_NAME, CONTRACT_PHASE,
 };
 use openprecedent_core::{
     build_environment_report, build_paths_report, build_storage_report, build_version_report,
-    not_implemented, resolve_runtime_config, CliConfigOverrides, ResolvedRuntimeConfig,
+    resolve_runtime_config, CliConfigOverrides, ResolvedRuntimeConfig,
 };
 use openprecedent_store_sqlite::SqliteStore;
 use serde::Deserialize;
@@ -355,8 +356,30 @@ struct EvalCommand {
 
 #[derive(Debug, Subcommand)]
 enum EvalSubcommand {
-    Fixtures(TrailingArgs),
-    CapturedOpenclawSessions(TrailingArgs),
+    Fixtures(EvalFixturesArgs),
+    #[command(visible_alias = "collected-openclaw-sessions")]
+    CapturedOpenclawSessions(EvalCapturedOpenclawSessionsArgs),
+}
+
+#[derive(Debug, Args)]
+struct EvalFixturesArgs {
+    path: std::path::PathBuf,
+}
+
+#[derive(Debug, Args)]
+struct EvalCapturedOpenclawSessionsArgs {
+    #[arg(long = "sessions-root")]
+    sessions_root: Option<std::path::PathBuf>,
+    #[arg(long = "state-file")]
+    state_file: Option<std::path::PathBuf>,
+    #[arg(long)]
+    limit: Option<usize>,
+    #[arg(long = "user-id")]
+    user_id: Option<String>,
+    #[arg(long = "agent-id", default_value = "openclaw")]
+    agent_id: String,
+    #[arg(long = "report-file")]
+    report_file: Option<std::path::PathBuf>,
 }
 
 #[derive(Debug, Args)]
@@ -433,7 +456,7 @@ where
         Command::Precedent(command) => handle_precedent(command, &config),
         Command::Capture(command) => handle_capture(command, &config),
         Command::Lineage(command) => handle_lineage(command, &config),
-        Command::Eval(command) => render_not_implemented_path(eval_path(command)),
+        Command::Eval(command) => handle_eval(command, &config),
     }
 }
 
@@ -1304,10 +1327,69 @@ fn handle_lineage(command: LineageCommand, config: &ResolvedRuntimeConfig) -> i3
     }
 }
 
-fn render_not_implemented_path(path: Vec<&'static str>) -> i32 {
-    let error = not_implemented(&path);
-    eprintln!("{error}");
-    1
+fn handle_eval(command: EvalCommand, config: &ResolvedRuntimeConfig) -> i32 {
+    let store = match SqliteStore::new(&config.db.path) {
+        Ok(store) => store,
+        Err(error) => {
+            eprintln!("{error}");
+            return 1;
+        }
+    };
+
+    match command.command {
+        EvalSubcommand::Fixtures(args) => {
+            let report = match evaluate_openclaw_fixture_suite(&store, &args.path) {
+                Ok(report) => report,
+                Err(error) => {
+                    eprintln!("{error}");
+                    return 1;
+                }
+            };
+            render(&report, config.format.value)
+        }
+        EvalSubcommand::CapturedOpenclawSessions(args) => {
+            let sessions_root = args
+                .sessions_root
+                .unwrap_or_else(capture_openclaw::default_sessions_root);
+            let state_path = args
+                .state_file
+                .unwrap_or_else(|| config.state_file.path.clone());
+            let report = match evaluate_captured_openclaw_sessions(
+                &store,
+                &sessions_root,
+                &state_path,
+                args.limit,
+                args.user_id.as_deref(),
+                Some(args.agent_id.as_str()),
+            ) {
+                Ok(report) => report,
+                Err(error) => {
+                    eprintln!("{error}");
+                    return 1;
+                }
+            };
+            if let Some(report_path) = args.report_file {
+                if let Some(parent) = report_path.parent() {
+                    if let Err(error) = std::fs::create_dir_all(parent) {
+                        eprintln!("{error}");
+                        return 1;
+                    }
+                }
+                let payload = match serde_json::to_string_pretty(&report) {
+                    Ok(payload) => payload,
+                    Err(error) => {
+                        eprintln!("{error}");
+                        return 1;
+                    }
+                };
+                if let Err(error) = std::fs::write(&report_path, payload) {
+                    eprintln!("{error}");
+                    return 1;
+                }
+            }
+            render(&report, config.format.value)
+        }
+    }
 }
 
 fn render<T>(payload: &T, format: OutputFormat) -> i32
@@ -1689,6 +1771,129 @@ impl TextRenderable for RuntimeDecisionLineageInspection {
             format!("downstream_decisions: {}", self.downstream_decisions.len()),
         ]
         .join("\n")
+    }
+}
+
+impl TextRenderable for EvaluationReport {
+    fn render_text(&self) -> String {
+        let mut lines = vec![format!(
+            "Evaluation: {}/{} passed, {} failed",
+            self.passed_cases, self.total_cases, self.failed_cases
+        )];
+        for result in &self.results {
+            let status = if result.passed { "PASS" } else { "FAIL" };
+            lines.push(format!("- {status} {}", result.case_id));
+            lines.push(format!(
+                "  decisions: expected={} actual={}",
+                result
+                    .expected_decision_types
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
+                    .join(","),
+                result
+                    .actual_decision_types
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
+                    .join(",")
+            ));
+            if !result.expected_precedent_case_ids.is_empty() {
+                lines.push(format!(
+                    "  precedents: expected={} actual={}",
+                    result.expected_precedent_case_ids.join(","),
+                    result.actual_precedent_case_ids.join(",")
+                ));
+            }
+            if !result.missing_decision_types.is_empty() {
+                lines.push(format!(
+                    "  missing decisions: {}",
+                    result
+                        .missing_decision_types
+                        .iter()
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>()
+                        .join(",")
+                ));
+            }
+            if !result.missing_precedent_case_ids.is_empty() {
+                lines.push(format!(
+                    "  missing precedents: {}",
+                    result.missing_precedent_case_ids.join(",")
+                ));
+            }
+        }
+        lines.join("\n")
+    }
+}
+
+impl TextRenderable for CollectedSessionEvaluationReport {
+    fn render_text(&self) -> String {
+        let mut lines = vec![
+            format!(
+                "Collected evaluation: {} cases, {} completed, {} failed",
+                self.evaluated_cases, self.completed_cases, self.failed_cases
+            ),
+            format!(
+                "Average events={:.2}, average decisions={:.2}",
+                self.average_event_count, self.average_decision_count
+            ),
+        ];
+        if !self.decision_type_counts.is_empty() {
+            lines.push(format!(
+                "Decision types: {}",
+                self.decision_type_counts
+                    .iter()
+                    .map(|(decision_type, count)| format!("{decision_type}={count}"))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
+        }
+        if !self.unsupported_record_type_counts.is_empty() {
+            lines.push(format!(
+                "Unsupported record types: {}",
+                self.unsupported_record_type_counts
+                    .iter()
+                    .map(|(record_type, count)| format!("{record_type}={count}"))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
+        }
+        if !self.missing_session_ids.is_empty() {
+            lines.push(format!(
+                "Missing sessions: {}",
+                self.missing_session_ids.join(",")
+            ));
+        }
+        for result in &self.results {
+            lines.push(format!(
+                "- {} status={} events={} decisions={} precedents={}",
+                result.case_id,
+                result.status,
+                result.event_count,
+                result.decision_count,
+                result.precedent_count
+            ));
+            if !result.unsupported_record_type_counts.is_empty() {
+                lines.push(format!(
+                    "  unsupported record types: {}",
+                    result
+                        .unsupported_record_type_counts
+                        .iter()
+                        .map(|(record_type, count)| format!("{record_type}={count}"))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ));
+            }
+            if let Some(top_precedent_case_id) = &result.top_precedent_case_id {
+                lines.push(format!(
+                    "  top precedent: {} (score={})",
+                    top_precedent_case_id,
+                    result.top_precedent_score.unwrap_or_default()
+                ));
+            }
+        }
+        lines.join("\n")
     }
 }
 
@@ -3965,6 +4170,438 @@ fn inspect_runtime_decision_lineage_invocation(
     })
 }
 
+#[derive(Debug, Deserialize)]
+struct EvaluationCaseSpec {
+    case_id: String,
+    title: String,
+    trace_path: String,
+    #[serde(default = "default_evaluation_source_format")]
+    source_format: String,
+    expected_decision_types: Vec<DecisionType>,
+    #[serde(default)]
+    expected_precedent_case_ids: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct EvaluationSuiteSpec {
+    cases: Vec<EvaluationCaseSpec>,
+}
+
+fn default_evaluation_source_format() -> String {
+    "openclaw_trace".to_string()
+}
+
+fn evaluate_openclaw_fixture_suite(
+    store: &SqliteStore,
+    suite_path: &std::path::Path,
+) -> Result<EvaluationReport, String> {
+    let suite: EvaluationSuiteSpec = serde_json::from_str(
+        &std::fs::read_to_string(suite_path).map_err(|error| error.to_string())?,
+    )
+    .map_err(|error| error.to_string())?;
+    let base_dir = suite_path
+        .parent()
+        .ok_or_else(|| format!("suite path has no parent: {}", suite_path.display()))?;
+
+    let existing_case_ids = suite
+        .cases
+        .iter()
+        .filter_map(|case_spec| match store.get_case(&case_spec.case_id) {
+            Ok(Some(_)) => Some(Ok(case_spec.case_id.clone())),
+            Ok(None) => None,
+            Err(error) => Some(Err(error.to_string())),
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    if !existing_case_ids.is_empty() {
+        let mut duplicated = existing_case_ids;
+        duplicated.sort();
+        return Err(format!(
+            "fixture evaluation requires an isolated database; existing evaluation case ids found: {}",
+            duplicated.join(", ")
+        ));
+    }
+
+    for case_spec in &suite.cases {
+        let trace_path = base_dir.join(&case_spec.trace_path);
+        match case_spec.source_format.as_str() {
+            "openclaw_trace" => {
+                import_openclaw_trace_fixture(
+                    store,
+                    &trace_path,
+                    &case_spec.case_id,
+                    &case_spec.title,
+                )?;
+            }
+            "openclaw_session" => {
+                import_openclaw_session(
+                    store,
+                    &trace_path,
+                    &case_spec.case_id,
+                    &case_spec.title,
+                    None,
+                    None,
+                )?;
+            }
+            other => return Err(format!("unsupported evaluation source_format '{}'", other)),
+        }
+        extract_and_store_decisions(store, &case_spec.case_id)?;
+    }
+
+    let mut results = Vec::new();
+    for case_spec in &suite.cases {
+        let actual_decisions = store
+            .list_decisions(&case_spec.case_id)
+            .map_err(|error| error.to_string())?;
+        let actual_decision_types = actual_decisions
+            .iter()
+            .map(|decision| decision.decision_type)
+            .collect::<Vec<_>>();
+        let missing_decision_types = case_spec
+            .expected_decision_types
+            .iter()
+            .copied()
+            .filter(|item| !actual_decision_types.contains(item))
+            .collect::<Vec<_>>();
+        let extra_decision_types = actual_decision_types
+            .iter()
+            .copied()
+            .filter(|item| !case_spec.expected_decision_types.contains(item))
+            .collect::<Vec<_>>();
+        let precedents = find_precedents_for_case(store, &case_spec.case_id, 5)?;
+        let actual_precedent_case_ids = precedents
+            .iter()
+            .map(|precedent| precedent.case_id.clone())
+            .collect::<Vec<_>>();
+        let missing_precedent_case_ids = case_spec
+            .expected_precedent_case_ids
+            .iter()
+            .filter(|item| !actual_precedent_case_ids.contains(item))
+            .cloned()
+            .collect::<Vec<_>>();
+        let passed = missing_decision_types.is_empty() && missing_precedent_case_ids.is_empty();
+
+        results.push(EvaluationCaseResult {
+            case_id: case_spec.case_id.clone(),
+            expected_decision_types: case_spec.expected_decision_types.clone(),
+            actual_decision_types,
+            missing_decision_types,
+            extra_decision_types,
+            expected_precedent_case_ids: case_spec.expected_precedent_case_ids.clone(),
+            actual_precedent_case_ids,
+            missing_precedent_case_ids,
+            passed,
+        });
+    }
+
+    let passed_cases = results.iter().filter(|result| result.passed).count();
+    Ok(EvaluationReport {
+        total_cases: results.len(),
+        passed_cases,
+        failed_cases: results.len() - passed_cases,
+        results,
+    })
+}
+
+fn evaluate_captured_openclaw_sessions(
+    store: &SqliteStore,
+    sessions_root: &std::path::Path,
+    state_path: &std::path::Path,
+    limit: Option<usize>,
+    user_id: Option<&str>,
+    agent_id: Option<&str>,
+) -> Result<CollectedSessionEvaluationReport, String> {
+    let state =
+        capture_openclaw::load_collection_state(state_path).map_err(|error| error.to_string())?;
+    let imported_session_ids = state
+        .imported_session_ids
+        .iter()
+        .cloned()
+        .collect::<HashSet<_>>();
+    let references = capture_openclaw::list_sessions(
+        sessions_root,
+        std::cmp::max(imported_session_ids.len(), 1000),
+    )
+    .map_err(|error| error.to_string())?;
+    let mut selected_references = references
+        .into_iter()
+        .filter(|item| imported_session_ids.contains(&item.session_id))
+        .collect::<Vec<_>>();
+    if let Some(limit) = limit {
+        selected_references.truncate(limit);
+    }
+
+    let mut decision_type_counts = BTreeMap::new();
+    let mut unsupported_record_type_counts = BTreeMap::new();
+    let mut results = Vec::new();
+    let mut missing_session_ids = Vec::new();
+
+    for reference in &selected_references {
+        let case_id = capture_openclaw::case_id_for_session(&reference.session_id);
+        let case = match store
+            .get_case(&case_id)
+            .map_err(|error| error.to_string())?
+        {
+            Some(case) => case,
+            None => {
+                import_openclaw_session(
+                    store,
+                    std::path::Path::new(&reference.transcript_path),
+                    &case_id,
+                    reference
+                        .label
+                        .as_deref()
+                        .unwrap_or(&format!("OpenClaw session {}", reference.session_id)),
+                    user_id,
+                    agent_id,
+                )?
+                .case
+            }
+        };
+        let unsupported = summarize_unsupported_openclaw_session_record_types(
+            std::path::Path::new(&reference.transcript_path),
+        )?;
+        for (record_type, count) in &unsupported {
+            *unsupported_record_type_counts
+                .entry(record_type.clone())
+                .or_insert(0) += *count;
+        }
+
+        let events = store
+            .list_events(&case_id)
+            .map_err(|error| error.to_string())?;
+        let decisions = extract_and_store_decisions(store, &case_id)?;
+        let precedents = find_precedents_for_case(store, &case_id, 3)?;
+        for decision in &decisions {
+            *decision_type_counts
+                .entry(decision.decision_type.to_string())
+                .or_insert(0) += 1;
+        }
+
+        results.push(CollectedSessionEvaluationResult {
+            session_id: reference.session_id.clone(),
+            case_id: case_id.clone(),
+            title: case.title.clone(),
+            transcript_path: reference.transcript_path.clone(),
+            status: case.status.to_string(),
+            event_count: events.len(),
+            decision_count: decisions.len(),
+            precedent_count: precedents.len(),
+            top_precedent_case_id: precedents.first().map(|item| item.case_id.clone()),
+            top_precedent_score: precedents.first().map(|item| item.similarity_score),
+            has_file_write: events
+                .iter()
+                .any(|event| event.event_type == EventType::FileWrite),
+            has_recovery: events.iter().any(|event| {
+                event.event_type == EventType::CommandCompleted
+                    && event
+                        .payload
+                        .as_object()
+                        .and_then(|payload| payload.get("exit_code"))
+                        .and_then(|value| value.as_i64())
+                        .is_some_and(|exit_code| exit_code != 0)
+            }),
+            final_summary: case.final_summary.clone(),
+            unsupported_record_type_counts: unsupported,
+        });
+    }
+
+    let selected_session_ids = selected_references
+        .iter()
+        .map(|item| item.session_id.clone())
+        .collect::<HashSet<_>>();
+    for session_id in &state.imported_session_ids {
+        if !selected_session_ids.contains(session_id) {
+            missing_session_ids.push(session_id.clone());
+        }
+    }
+
+    let event_total = results.iter().map(|item| item.event_count).sum::<usize>();
+    let decision_total = results
+        .iter()
+        .map(|item| item.decision_count)
+        .sum::<usize>();
+    let result_count = results.len();
+
+    Ok(CollectedSessionEvaluationReport {
+        generated_at: Utc::now(),
+        sessions_root: sessions_root.display().to_string(),
+        state_path: state_path.display().to_string(),
+        total_sessions: if limit.is_none() {
+            state.imported_session_ids.len()
+        } else {
+            selected_references.len()
+        },
+        evaluated_cases: results.len(),
+        completed_cases: results
+            .iter()
+            .filter(|item| item.status == CaseStatus::Completed.to_string())
+            .count(),
+        failed_cases: results
+            .iter()
+            .filter(|item| item.status == CaseStatus::Failed.to_string())
+            .count(),
+        cases_with_precedents: results
+            .iter()
+            .filter(|item| item.precedent_count > 0)
+            .count(),
+        cases_with_file_writes: results.iter().filter(|item| item.has_file_write).count(),
+        cases_with_recovery: results.iter().filter(|item| item.has_recovery).count(),
+        average_event_count: if result_count == 0 {
+            0.0
+        } else {
+            event_total as f64 / result_count as f64
+        },
+        average_decision_count: if result_count == 0 {
+            0.0
+        } else {
+            decision_total as f64 / result_count as f64
+        },
+        decision_type_counts,
+        unsupported_record_type_counts,
+        missing_session_ids,
+        results,
+    })
+}
+
+fn import_openclaw_trace_fixture(
+    store: &SqliteStore,
+    path: &std::path::Path,
+    case_id: &str,
+    title: &str,
+) -> Result<(), String> {
+    ensure_case(store, case_id, title, None, Some("openclaw"))?;
+    let file = File::open(path).map_err(|error| error.to_string())?;
+    for (index, line_result) in BufReader::new(file).lines().enumerate() {
+        let line_no = index + 1;
+        let line = line_result.map_err(|error| error.to_string())?;
+        let stripped = line.trim();
+        if stripped.is_empty() {
+            continue;
+        }
+        let raw_item = match serde_json::from_str::<Value>(stripped) {
+            Ok(Value::Object(item)) => item,
+            Ok(_) => {
+                return Err(format!(
+                    "line {line_no}: openclaw trace line must be a JSON object"
+                ))
+            }
+            Err(error) => return Err(error.to_string()),
+        };
+        let event = normalize_openclaw_trace_line(raw_item, line_no, store, case_id)?;
+        store
+            .append_event(&event)
+            .map_err(|error| error.to_string())?;
+    }
+    Ok(())
+}
+
+fn extract_and_store_decisions(
+    store: &SqliteStore,
+    case_id: &str,
+) -> Result<Vec<Decision>, String> {
+    let events = store
+        .list_events(case_id)
+        .map_err(|error| error.to_string())?;
+    let decisions = extract_decisions(case_id, &events);
+    store
+        .replace_decisions(case_id, &decisions)
+        .map_err(|error| error.to_string())?;
+    Ok(decisions)
+}
+
+fn find_precedents_for_case(
+    store: &SqliteStore,
+    case_id: &str,
+    limit: usize,
+) -> Result<Vec<Precedent>, String> {
+    let current_case = store
+        .get_case(case_id)
+        .map_err(|error| error.to_string())?
+        .ok_or_else(|| format!("case not found: {case_id}"))?;
+    let current_events = store
+        .list_events(case_id)
+        .map_err(|error| error.to_string())?;
+    let current_decisions = store
+        .list_decisions(case_id)
+        .map_err(|error| error.to_string())?;
+    let current_fingerprint =
+        build_case_fingerprint(&current_case, &current_events, &current_decisions);
+
+    let mut candidates: Vec<(i64, Precedent)> = Vec::new();
+    for other_case in store.list_cases().map_err(|error| error.to_string())? {
+        if other_case.case_id == case_id {
+            continue;
+        }
+        let other_events = store
+            .list_events(&other_case.case_id)
+            .map_err(|error| error.to_string())?;
+        let other_decisions = store
+            .list_decisions(&other_case.case_id)
+            .map_err(|error| error.to_string())?;
+        let other_fingerprint =
+            build_case_fingerprint(&other_case, &other_events, &other_decisions);
+        let (score, similarities, differences) =
+            compare_fingerprints(&current_fingerprint, &other_fingerprint);
+        if score <= 0 {
+            continue;
+        }
+        candidates.push((
+            score,
+            Precedent {
+                case_id: other_case.case_id.clone(),
+                title: other_case.title.clone(),
+                summary: build_case_summary(&other_case, &other_events, &other_decisions),
+                similarity_score: score,
+                similarities,
+                differences,
+                reusable_takeaway: build_reusable_takeaway(&other_case, &other_decisions),
+                historical_outcome: other_case.final_summary.clone(),
+            },
+        ));
+    }
+    candidates.sort_by(|left, right| {
+        right
+            .0
+            .cmp(&left.0)
+            .then_with(|| left.1.case_id.cmp(&right.1.case_id))
+    });
+    Ok(candidates
+        .into_iter()
+        .take(limit)
+        .map(|(_, precedent)| precedent)
+        .collect())
+}
+
+fn summarize_unsupported_openclaw_session_record_types(
+    transcript_path: &std::path::Path,
+) -> Result<BTreeMap<String, usize>, String> {
+    let file = File::open(transcript_path).map_err(|error| error.to_string())?;
+    let mut counts = BTreeMap::new();
+    for (index, line_result) in BufReader::new(file).lines().enumerate() {
+        let line_no = index + 1;
+        let line = line_result.map_err(|error| error.to_string())?;
+        let stripped = line.trim();
+        if stripped.is_empty() {
+            continue;
+        }
+        let raw_item = match serde_json::from_str::<Value>(stripped) {
+            Ok(Value::Object(item)) => item,
+            Ok(_) => {
+                return Err(format!(
+                    "line {line_no}: openclaw session line must be a JSON object"
+                ))
+            }
+            Err(error) => return Err(error.to_string()),
+        };
+        let (_, unsupported_record_type) =
+            normalize_openclaw_session_line(raw_item, line_no, transcript_path)?;
+        if let Some(unsupported_record_type) = unsupported_record_type {
+            *counts.entry(unsupported_record_type).or_insert(0) += 1;
+        }
+    }
+    Ok(counts)
+}
+
 fn build_reusable_takeaway(case: &Case, decisions: &[Decision]) -> Option<String> {
     decisions
         .last()
@@ -4050,10 +4687,3 @@ const STOP_WORDS: [&str; 18] = [
     "the", "and", "for", "with", "that", "this", "from", "into", "will", "then", "case",
     "openclaw", "session", "docs", "file", "tool", "command", "agent",
 ];
-
-fn eval_path(command: EvalCommand) -> Vec<&'static str> {
-    match command.command {
-        EvalSubcommand::Fixtures(_) => vec!["eval", "fixtures"],
-        EvalSubcommand::CapturedOpenclawSessions(_) => vec!["eval", "captured-openclaw-sessions"],
-    }
-}

--- a/rust/openprecedent-cli/tests/eval_contract.rs
+++ b/rust/openprecedent-cli/tests/eval_contract.rs
@@ -1,0 +1,141 @@
+use std::fs;
+use std::path::Path;
+
+use assert_cmd::Command;
+use tempfile::tempdir;
+
+fn cli() -> Command {
+    Command::cargo_bin("openprecedent").expect("cargo bin")
+}
+
+#[test]
+fn eval_fixtures_reports_expected_case_results() {
+    let runtime = tempdir().expect("runtime");
+    let db_path = runtime.path().join("openprecedent.db");
+    let suite_path =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/fixtures/evaluation/suite.json");
+
+    let output = cli()
+        .args([
+            "--db",
+            db_path.to_str().expect("db path"),
+            "--format",
+            "json",
+            "eval",
+            "fixtures",
+            suite_path.to_str().expect("suite path"),
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let report: serde_json::Value = serde_json::from_slice(&output).expect("report");
+    assert_eq!(report["total_cases"], 5);
+    assert_eq!(report["failed_cases"], 0);
+    assert_eq!(report["passed_cases"], 5);
+
+    let authority_result = report["results"]
+        .as_array()
+        .expect("results")
+        .iter()
+        .find(|item| item["case_id"] == "eval_authority_scope")
+        .expect("authority result");
+    assert_eq!(
+        authority_result["actual_decision_types"],
+        serde_json::json!([
+            "constraint_adopted",
+            "success_criteria_set",
+            "option_rejected",
+            "task_frame_defined",
+            "authority_confirmed"
+        ])
+    );
+}
+
+#[test]
+fn eval_captured_openclaw_sessions_writes_report_and_renders_counts() {
+    let runtime = tempdir().expect("runtime");
+    let db_path = runtime.path().join("openprecedent.db");
+    let fixture_dir =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/fixtures/openclaw_sessions");
+    let sessions_dir = runtime.path().join("sessions");
+    fs::create_dir_all(&sessions_dir).expect("sessions dir");
+    for name in [
+        "sample-session.jsonl",
+        "failing-command-session.jsonl",
+        "unsupported-record-session.jsonl",
+    ] {
+        fs::copy(fixture_dir.join(name), sessions_dir.join(name)).expect("copy fixture");
+    }
+    fs::write(
+        sessions_dir.join("sessions.json"),
+        serde_json::to_string_pretty(&serde_json::json!([
+            {
+                "sessionId": "sample-session",
+                "sessionFile": sessions_dir.join("sample-session.jsonl").display().to_string(),
+                "updatedAt": 1741497000000_i64,
+                "label": "User session: summarize context graph"
+            },
+            {
+                "sessionId": "failing-command-session",
+                "sessionFile": sessions_dir.join("failing-command-session.jsonl").display().to_string(),
+                "updatedAt": 1741498000000_i64,
+                "label": "User session: failing command"
+            },
+            {
+                "sessionId": "unsupported-record-session",
+                "sessionFile": sessions_dir.join("unsupported-record-session.jsonl").display().to_string(),
+                "updatedAt": 1741499000000_i64,
+                "label": "User session: unsupported record"
+            }
+        ]))
+        .expect("sessions json"),
+    )
+    .expect("write sessions index");
+    let state_path = runtime.path().join("collector-state.json");
+    fs::write(
+        &state_path,
+        serde_json::to_string_pretty(&serde_json::json!({
+            "imported_session_ids": [
+                "failing-command-session",
+                "sample-session",
+                "unsupported-record-session"
+            ]
+        }))
+        .expect("state json"),
+    )
+    .expect("write state");
+    let report_path = runtime.path().join("collected-report.json");
+
+    let output = cli()
+        .args([
+            "--db",
+            db_path.to_str().expect("db path"),
+            "--format",
+            "json",
+            "eval",
+            "captured-openclaw-sessions",
+            "--sessions-root",
+            sessions_dir.to_str().expect("sessions dir"),
+            "--state-file",
+            state_path.to_str().expect("state path"),
+            "--report-file",
+            report_path.to_str().expect("report path"),
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let report: serde_json::Value = serde_json::from_slice(&output).expect("report");
+    assert_eq!(report["total_sessions"], 3);
+    assert_eq!(report["evaluated_cases"], 3);
+    assert_eq!(
+        report["unsupported_record_type_counts"],
+        serde_json::json!({"audit_marker": 1})
+    );
+    assert!(report_path.exists());
+}

--- a/rust/openprecedent-contracts/src/eval.rs
+++ b/rust/openprecedent-contracts/src/eval.rs
@@ -1,0 +1,66 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::DecisionType;
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct EvaluationCaseResult {
+    pub case_id: String,
+    pub expected_decision_types: Vec<DecisionType>,
+    pub actual_decision_types: Vec<DecisionType>,
+    pub missing_decision_types: Vec<DecisionType>,
+    pub extra_decision_types: Vec<DecisionType>,
+    pub expected_precedent_case_ids: Vec<String>,
+    pub actual_precedent_case_ids: Vec<String>,
+    pub missing_precedent_case_ids: Vec<String>,
+    pub passed: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct EvaluationReport {
+    pub total_cases: usize,
+    pub passed_cases: usize,
+    pub failed_cases: usize,
+    pub results: Vec<EvaluationCaseResult>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct CollectedSessionEvaluationResult {
+    pub session_id: String,
+    pub case_id: String,
+    pub title: String,
+    pub transcript_path: String,
+    pub status: String,
+    pub event_count: usize,
+    pub decision_count: usize,
+    pub precedent_count: usize,
+    pub top_precedent_case_id: Option<String>,
+    pub top_precedent_score: Option<i64>,
+    pub has_file_write: bool,
+    pub has_recovery: bool,
+    pub final_summary: Option<String>,
+    #[serde(default)]
+    pub unsupported_record_type_counts: std::collections::BTreeMap<String, usize>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct CollectedSessionEvaluationReport {
+    pub generated_at: DateTime<Utc>,
+    pub sessions_root: String,
+    pub state_path: String,
+    pub total_sessions: usize,
+    pub evaluated_cases: usize,
+    pub completed_cases: usize,
+    pub failed_cases: usize,
+    pub cases_with_precedents: usize,
+    pub cases_with_file_writes: usize,
+    pub cases_with_recovery: usize,
+    pub average_event_count: f64,
+    pub average_decision_count: f64,
+    pub decision_type_counts: std::collections::BTreeMap<String, usize>,
+    #[serde(default)]
+    pub unsupported_record_type_counts: std::collections::BTreeMap<String, usize>,
+    #[serde(default)]
+    pub missing_session_ids: Vec<String>,
+    pub results: Vec<CollectedSessionEvaluationResult>,
+}

--- a/rust/openprecedent-contracts/src/lib.rs
+++ b/rust/openprecedent-contracts/src/lib.rs
@@ -1,6 +1,7 @@
 mod artifact;
 mod case;
 mod decision;
+mod eval;
 mod event;
 mod lineage;
 mod precedent;
@@ -14,6 +15,10 @@ use serde::{Deserialize, Serialize};
 pub use artifact::{Artifact, ArtifactType};
 pub use case::{Case, CaseStatus};
 pub use decision::{Decision, DecisionExplanation, DecisionType};
+pub use eval::{
+    CollectedSessionEvaluationReport, CollectedSessionEvaluationResult, EvaluationCaseResult,
+    EvaluationReport,
+};
 pub use event::{Event, EventActor, EventType};
 pub use lineage::{
     DecisionLineageBrief, DecisionLineageMatchedCase, DecisionLineageQueryReason,


### PR DESCRIPTION
Closes #185

Implement the scoped GitHub issue on a child branch that merges into `codex/issue-172-rust-public-cli`.

Implementation notes:
- Reuse the Rust capture, decision extraction, and precedent helpers instead of routing eval through the Python service.
- Keep the JSON report shapes stable because validation harnesses can depend on them directly once the Rust CLI becomes the public surface.

Validation:
- run `cargo test`
- run `./scripts/run-pytest.sh -q tests/test_rust_cli_workspace.py`
- run `./scripts/run-agent-preflight.sh` before opening the PR
- `cargo test; ./scripts/run-pytest.sh -q tests/test_rust_cli_workspace.py; ./scripts/run-agent-preflight.sh`