### PR TITLE
Document the shipped Rust CLI implementation

### DIFF
--- a/.codex/pm/issue-state/172-design-and-adopt-rust-cli-as-stable-public-interface.md
+++ b/.codex/pm/issue-state/172-design-and-adopt-rust-cli-as-stable-public-interface.md
@@ -9,7 +9,7 @@ delivery_stage: done
 
 ## Summary
 
-Issue `#172` served as the long-lived parent for the full Rust CLI migration train on `codex/issue-172-rust-public-cli`, and that integration branch now contains the completed public cutover needed for the final merge back to `main`.
+Issue `#172` started as the Rust public CLI design issue, later served as the parent integration issue for the migration train, and is now in final closeout with a repository-local implementation summary that documents what the shipped Rust CLI actually provides on `main`.
 
 ## Validated Facts
 
@@ -17,10 +17,12 @@ Issue `#172` served as the long-lived parent for the full Rust CLI migration tra
 - multiple skill and validation workflows still rely on repository-local shell scripts, which makes the effective external interface unstable
 - the current command surface already includes more than decision-lineage: case, event, replay, extraction, precedent, runtime capture, and evaluation
 - PR `#173` merged the contract-first Rust CLI design baseline into `main`
-- issue `#172` has been reopened so the migration can proceed under one explicit parent issue instead of spawning disconnected implementation tracks
+- issue `#172` was reopened so the migration could proceed under one explicit parent issue instead of spawning disconnected implementation tracks
 - child issues `#174` through `#187` now cover the Rust workspace, config, store, command families, skill migration, and final cutover in reviewable slices
 - child issues `#174` through `#187` have merged into `codex/issue-172-rust-public-cli`
 - the integration branch now exposes the Rust `openprecedent` CLI as the supported public command surface and removes the public Python CLI and public shell-script entrypoints
+- PR `#202` merged the completed migration train back into `main`
+- the repository now contains a dedicated engineering implementation summary for the shipped Rust CLI
 - integrated validation passed through `cargo test`, targeted Python regression coverage, and `./scripts/run-agent-preflight.sh`
 
 ## Open Questions
@@ -29,7 +31,7 @@ Issue `#172` served as the long-lived parent for the full Rust CLI migration tra
 
 ## Next Steps
 
-- merge `codex/issue-172-rust-public-cli` back to `main` through the final parent PR that closes issue `#172`
+- merge the closeout documentation PR that closes issue `#172`
 
 ## Artifacts
 

--- a/.codex/pm/tasks/public-cli-foundation/design-and-adopt-rust-cli-as-stable-public-interface.md
+++ b/.codex/pm/tasks/public-cli-foundation/design-and-adopt-rust-cli-as-stable-public-interface.md
@@ -4,7 +4,7 @@ epic: public-cli-foundation
 slug: design-and-adopt-rust-cli-as-stable-public-interface
 title: Design and adopt a Rust CLI as the stable public interface for OpenPrecedent
 status: done
-task_type: umbrella
+task_type: docs
 labels: cli,rust,interface
 issue: 172
 state_path: .codex/pm/issue-state/172-design-and-adopt-rust-cli-as-stable-public-interface.md
@@ -13,38 +13,37 @@ state_path: .codex/pm/issue-state/172-design-and-adopt-rust-cli-as-stable-public
 ## Context
 
 OpenPrecedent needs a durable public executable surface.
-This issue started as the design baseline for the Rust-based `openprecedent` CLI and is now the long-lived parent issue for the full public CLI migration train.
-The design baseline landed through PR `#173`, but the issue remains open as the integration parent for all later Rust CLI child issues that merge into the dedicated branch `codex/issue-172-rust-public-cli` before the final cutover back to `main`.
+This issue started as the design baseline for the Rust-based `openprecedent` CLI and later served as the long-lived parent issue for the full public CLI migration train.
+The design baseline landed through PR `#173`, the implementation train landed through PR `#202`, and the remaining closeout work is to leave one durable in-repo implementation summary that explains what the Rust CLI actually ships on `main`.
 
 ## Deliverable
 
-Keep the Rust public CLI design baseline authoritative, define the branch integration policy for the migration train, and carry the full Rust CLI child-issue chain through integration until the completed train is ready for one final merge from `codex/issue-172-rust-public-cli` back to `main`.
+Document the shipped Rust CLI implementation in one systematic engineering overview and close out issue `#172` now that the design baseline and implementation train have both landed on `main`.
 
 ## Scope
 
-- keep the long-term public command tree and interface rules fixed as the parent contract
-- require child implementation PRs under this workstream to merge into `codex/issue-172-rust-public-cli` instead of `main`
-- maintain the child-issue breakdown for the Rust workspace, store layer, domain commands, capture surfaces, lineage surfaces, skill migration, and final cutover
-- hold the integration branch open until the Rust CLI chain is fully integrated and ready for one final merge back to `main`
+- add one comprehensive implementation summary for the shipped Rust CLI
+- explain the actual public command surface, workspace layout, compatibility model, workflow cutover, and verification layers
+- link the implementation summary from the existing usage and design docs
+- close issue `#172` after the in-repo closeout documentation lands
 
 ## Acceptance Criteria
 
-- the repository contains a decision-complete CLI design doc for Rust public interface evolution
-- the design makes Rust CLI the sole intended public interface after cutover
-- local PM and GitHub issue artifacts make `#172` the explicit parent of the Rust CLI implementation chain
-- the parent issue states that child issue PRs merge into `codex/issue-172-rust-public-cli` before the final cutover PR back to `main`
-- the child issue breakdown is fine-grained enough for independent review and implementation slices
+- the repository contains a durable engineering document describing the shipped Rust CLI implementation
+- the closeout doc distinguishes design intent from implemented behavior
+- the implementation doc explains the command surface, crate layout, data compatibility model, and cutover away from the Python CLI and public shell wrappers
+- the usage and design docs link to the implementation summary
+- the resulting PR can close issue `#172`
 
 ## Validation
 
-- review the design against the current Python CLI surface, public docs, and script-based runtime workflows
-- verify the child issue chain covers all currently shipped public capabilities that are exposed through `openprecedent` or through public shell wrappers
-- confirm the parent issue and integration-branch policy are explicit in both local PM state and the GitHub issue body
-- run the integrated Rust CLI branch through `cargo test`, targeted Python regression tests, and `./scripts/run-agent-preflight.sh` before opening the final merge-back PR
+- review the implementation summary against the Rust workspace, current public docs, and shipped command surface on `main`
+- verify the closeout doc matches the actual cutover state for Python CLI removal and public script deprecation
+- run `./scripts/run-agent-preflight.sh` before opening the closing PR
 
 ## Implementation Notes
 
 - PR `#173` merged the design baseline into `main`.
-- Issue `#172` was reopened as the parent umbrella for the dedicated Rust CLI integration branch.
-- Child issues `#174` through `#187` implemented the migration in independently reviewable slices and merged into `codex/issue-172-rust-public-cli`.
-- The integration branch now contains the full Rust workspace, Rust command families, skill migration, and public cutover away from the Python CLI and public shell-script entrypoints.
+- PR `#202` merged the dedicated Rust CLI integration branch back into `main`.
+- Child issues `#174` through `#187` implemented the migration in independently reviewable slices before the final integration merge.
+- This closeout PR leaves one stable implementation summary in the repository and closes issue `#172`.

--- a/docs/engineering/rust-public-cli-design.md
+++ b/docs/engineering/rust-public-cli-design.md
@@ -4,6 +4,10 @@
 
 This document defines the long-term public command interface for OpenPrecedent.
 
+For the shipped implementation summary, see:
+
+- [rust-public-cli-implementation.md](/workspace/02-projects/incubation/openprecedent/docs/engineering/rust-public-cli-implementation.md)
+
 The goal is not to port the current Python `argparse` tree one command at a time.
 The goal is to establish a stable, extensible, product-facing `openprecedent` CLI implemented in Rust and treated as the sole supported external executable surface.
 

--- a/docs/engineering/rust-public-cli-implementation.md
+++ b/docs/engineering/rust-public-cli-implementation.md
@@ -1,0 +1,253 @@
+# Rust Public CLI Implementation
+
+## Purpose
+
+This document describes the Rust CLI that is now actually shipped on `main`.
+
+It is the implementation companion to:
+
+- [rust-public-cli-design.md](/workspace/02-projects/incubation/openprecedent/docs/engineering/rust-public-cli-design.md)
+
+The design document defines the long-term public contract.
+This document explains what was implemented, how the code is organized today, what was cut over from the earlier Python and shell entrypoints, and what remains intentionally internal.
+
+## Outcome
+
+The repository now exposes Rust `openprecedent` as the stable public executable surface.
+
+That cutover includes:
+
+- Rust-native command parsing and output rendering
+- Rust-native config and path resolution
+- Rust-native SQLite access and schema initialization
+- Rust-native implementations of case, event, decision, replay, precedent, capture, lineage, and eval commands
+- skill and validation workflow migration to direct Rust CLI invocation
+- removal of the public Python `openprecedent` console script
+- removal of repository-local shell wrappers as the supported public interface
+
+The Python codebase remains in the repository for internal service logic, PM tooling, and repository-local harness scripts, but it no longer defines the supported product-facing CLI contract.
+
+## Implemented Command Surface
+
+The shipped Rust CLI command tree is:
+
+```text
+openprecedent case
+openprecedent event
+openprecedent decision
+openprecedent replay
+openprecedent precedent
+openprecedent capture
+openprecedent lineage
+openprecedent eval
+openprecedent doctor
+openprecedent version
+```
+
+The implemented command families are:
+
+- `case create|list|show`
+- `event append|import-jsonl`
+- `decision extract|list`
+- `replay case`
+- `precedent find`
+- `capture openclaw list-sessions|import-session|collect-sessions|import-jsonl`
+- `capture codex import-rollout`
+- `lineage brief`
+- `lineage invocation list|inspect`
+- `eval fixtures|captured-openclaw-sessions`
+- `doctor paths|storage|environment`
+- `version`
+
+Global flags implemented across the public surface include:
+
+- `--format`
+- `--home`
+- `--db`
+- `--invocation-log`
+- `--state-file`
+- `--config`
+- `--no-color`
+
+These are resolved through the documented precedence order of CLI flag, environment variable, config file, and default.
+
+## Workspace Layout
+
+The Rust implementation is organized as a workspace rooted at:
+
+- [Cargo.toml](/workspace/02-projects/incubation/openprecedent/Cargo.toml)
+
+The crates are:
+
+- `rust/openprecedent-cli`
+  The public binary crate. It owns command parsing, public command topology, text and JSON rendering, and CLI-level error handling.
+- `rust/openprecedent-contracts`
+  Shared public data shapes used by the CLI, including cases, events, decisions, replay responses, precedent matches, lineage payloads, evaluation reports, and doctor responses.
+- `rust/openprecedent-core`
+  Runtime configuration resolution and higher-level shared CLI logic.
+- `rust/openprecedent-store-sqlite`
+  SQLite-backed persistence, schema initialization, schema compatibility handling, and record round-tripping.
+- `rust/openprecedent-capture-openclaw`
+  OpenClaw-specific transcript discovery, list, import, and collection logic.
+- `rust/openprecedent-capture-codex`
+  Codex rollout import logic.
+
+This layout keeps the command surface, shared contracts, persistence layer, and runtime-specific capture logic separate without turning the public CLI into a thin wrapper over the Python implementation.
+
+## Data and Compatibility Model
+
+The Rust CLI was implemented against the existing local-first runtime layout rather than introducing a second storage system.
+
+The current behavior is:
+
+- runtime home still defaults to `~/.openprecedent/runtime`
+- SQLite remains the persistent store
+- invocation logs remain file-backed and compatible with lineage inspection
+- schema initialization and compatibility upgrades are handled in Rust
+- earlier persisted runtime data remains readable after the cutover
+
+That compatibility layer lives primarily in:
+
+- [lib.rs](/workspace/02-projects/incubation/openprecedent/rust/openprecedent-store-sqlite/src/lib.rs)
+
+The implementation preserves the MVP data model of:
+
+- raw cases
+- raw events
+- derived decisions
+- replay artifacts
+- precedent retrieval over stored case history
+
+## Public Contract Implementation
+
+The Rust CLI directly implements the public contract instead of delegating command execution to the old Python CLI.
+
+Key contract choices now enforced in code are:
+
+- `openprecedent` is the stable binary name
+- JSON output is the machine-facing contract
+- human-readable text output remains available for local use
+- `capture` is the stable namespace for runtime-specific ingest
+- `lineage` is the stable namespace for decision-lineage retrieval and inspection
+- `doctor` is the stable availability and environment diagnosis surface for skills and automation
+
+The main public command tree and argument parsing live in:
+
+- [main.rs](/workspace/02-projects/incubation/openprecedent/rust/openprecedent-cli/src/main.rs)
+
+## Capture and Lineage Surfaces
+
+Two product-facing areas were especially important in this migration.
+
+### Capture
+
+The Rust CLI now owns the supported capture surfaces for:
+
+- OpenClaw transcript listing and import
+- OpenClaw collected-session ingestion
+- Codex rollout import
+
+This replaced public reliance on older repository-local wrappers and gave capture flows a stable command identity under `openprecedent capture ...`.
+
+### Lineage
+
+The Rust CLI now owns:
+
+- `openprecedent lineage brief`
+- `openprecedent lineage invocation list`
+- `openprecedent lineage invocation inspect`
+
+These commands are the intended machine-facing surface for skill-driven precedent retrieval and runtime invocation inspection.
+
+## Skill and Workflow Cutover
+
+The migration was not complete until the repository's own runtime-facing skills and validation workflows stopped depending on the earlier script-shaped public interface.
+
+After the cutover:
+
+- skills are expected to call the Rust CLI directly
+- availability probing should use `openprecedent doctor ...`
+- lineage retrieval should use `openprecedent lineage ... --format json`
+- validation harnesses and remaining helper scripts resolve or build the Rust binary, then call it directly
+
+To support repo-local tooling and tests without reintroducing the old public shell interface, the repository now includes internal Rust-binary resolution helpers:
+
+- [openprecedent-rust-cli.sh](/workspace/02-projects/incubation/openprecedent/scripts/lib/openprecedent-rust-cli.sh)
+- [openprecedent_rust_cli.py](/workspace/02-projects/incubation/openprecedent/scripts/lib/openprecedent_rust_cli.py)
+
+These helpers are internal developer tooling.
+They are not the public product interface.
+
+## What Was Removed from the Public Surface
+
+The cutover intentionally removed two earlier public surfaces.
+
+### Python public CLI
+
+The packaged Python `openprecedent` console script is no longer exposed as the product-facing command entrypoint.
+
+The Python codebase still exists in the repository, but the supported public executable interface is now Rust `openprecedent`.
+
+### Public shell-script entrypoints
+
+Repository-local shell scripts are no longer treated as the supported product-facing command surface.
+
+Some scripts remain in `scripts/` for repository-local operations, validation, installation, and development harnessing, but they are internal helpers around the CLI rather than the CLI itself.
+
+## Verification and Regression Coverage
+
+The implementation was validated through a mix of Rust contract tests, Python regression tests, and repository preflight checks.
+
+The important verification layers are:
+
+- Rust CLI contract tests under [rust/openprecedent-cli/tests](/workspace/02-projects/incubation/openprecedent/rust/openprecedent-cli/tests)
+- repository Python regressions covering wrappers, harnesses, imports, and workspace assumptions under [tests](/workspace/02-projects/incubation/openprecedent/tests)
+- repository preflight and review gates under [run-agent-preflight.sh](/workspace/02-projects/incubation/openprecedent/scripts/run-agent-preflight.sh)
+
+The migration train was validated with:
+
+- `cargo test`
+- targeted Python regression runs for Rust CLI integration surfaces
+- full agent preflight before final merge-back
+
+## Migration Scope Covered by the Train
+
+The Rust CLI migration was delivered through issue `#172` and child issues `#174` through `#187`.
+
+That train covered:
+
+- workspace bootstrap
+- config, doctor, and version contracts
+- SQLite store and schema compatibility
+- case commands
+- event commands
+- decision commands
+- replay and precedent commands
+- OpenClaw capture
+- Codex capture
+- lineage brief
+- lineage invocation inspection
+- eval commands
+- skill and validation workflow migration
+- public cutover away from Python CLI and public shell entrypoints
+
+## What Remains Internal
+
+The following remain intentionally internal or repository-local:
+
+- `openprecedent-pm` and Codex PM workflow tooling
+- repository maintenance scripts
+- Python modules used for repo-local harnessing and support logic
+- historical research artifacts and older command examples kept only as evidence context
+
+These are not part of the supported public CLI contract.
+
+## Practical Reading Order
+
+If you are trying to understand the system now, use this order:
+
+1. [using-openprecedent.md](/workspace/02-projects/incubation/openprecedent/docs/engineering/using-openprecedent.md)
+2. this implementation document
+3. [rust-public-cli-design.md](/workspace/02-projects/incubation/openprecedent/docs/engineering/rust-public-cli-design.md)
+
+That sequence moves from current usage, to actual implementation, to long-term contract intent.

--- a/docs/engineering/using-openprecedent.md
+++ b/docs/engineering/using-openprecedent.md
@@ -7,6 +7,7 @@ This guide explains how to use the current OpenPrecedent MVP in practice.
 For the planned long-term public-interface replacement, see:
 
 - [rust-public-cli-design.md](/workspace/02-projects/incubation/openprecedent/docs/engineering/rust-public-cli-design.md)
+- [rust-public-cli-implementation.md](/workspace/02-projects/incubation/openprecedent/docs/engineering/rust-public-cli-implementation.md)
 
 It is written for two audiences:
 


### PR DESCRIPTION
Closes #172

Document the shipped Rust CLI implementation in one systematic engineering overview and close out issue `#172` now that the design baseline and implementation train have both landed on `main`.

Implementation notes:
- PR `#173` merged the design baseline into `main`.
- PR `#202` merged the dedicated Rust CLI integration branch back into `main`.
- Child issues `#174` through `#187` implemented the migration in independently reviewable slices before the final integration merge.
- This closeout PR leaves one stable implementation summary in the repository and closes issue `#172`.

Validation:
- review the implementation summary against the Rust workspace, current public docs, and shipped command surface on `main`
- verify the closeout doc matches the actual cutover state for Python CLI removal and public script deprecation
- run `./scripts/run-agent-preflight.sh` before opening the closing PR
- `./scripts/run-agent-preflight.sh`