### PR TITLE
Establish repository-wide documentation chronology and canonical entrypoint conventions

### DIFF
--- a/.codex/pm/issue-state/265-establish-repository-wide-doc-chronology-and-entrypoints.md
+++ b/.codex/pm/issue-state/265-establish-repository-wide-doc-chronology-and-entrypoints.md
@@ -1,0 +1,39 @@
+---
+type: issue_state
+issue: 265
+task: .codex/pm/tasks/real-history-quality/establish-repository-wide-doc-chronology-and-entrypoints.md
+title: Establish repository-wide documentation chronology and canonical entrypoint conventions
+status: in_progress
+---
+
+## Summary
+
+Define a lightweight repository-wide convention for documentation chronology and canonical entrypoints, then demonstrate it with minimal `README` and governance updates across the current `docs/` tree.
+
+## Validated Facts
+
+- `docs/README.md` already worked as the top-level English entrypoint, but `docs/product/` and `docs/architecture/` had no local directory index.
+- `docs/research/README.md` and `docs/zh/research/README.md` already used dated directory indexes, so the repository already had one strong chronology pattern worth generalizing.
+- `docs/zh/README.md` described the top-level Chinese tree, but `docs/zh/product/` and `docs/zh/architecture/` had no local entrypoint or explicit canonical-versus-historical guidance.
+- Date and status metadata already existed in parts of the tree, but not yet as a documented repository-wide convention.
+
+## Open Questions
+
+- Whether `docs/engineering/` also needs a dedicated chronology rule beyond the existing concern-based split.
+- Whether more legacy documents should be explicitly reclassified as historical drafts in follow-up issues instead of this minimal entrypoint pass.
+
+## Next Steps
+
+- Verify the new governance doc and directory indexes are sufficient as a first repository-wide convention.
+- Stage the new task twin, issue-state, governance doc, and directory `README` files together in one docs-only commit.
+- Run lightweight validation (`git diff --check` and direct README review) before commit.
+
+## Artifacts
+
+- `docs/README.md`
+- `docs/engineering/governance/documentation-governance.md`
+- `docs/product/README.md`
+- `docs/architecture/README.md`
+- `docs/zh/README.md`
+- `docs/zh/product/README.md`
+- `docs/zh/architecture/README.md`

--- a/.codex/pm/issue-state/265-establish-repository-wide-doc-chronology-and-entrypoints.md
+++ b/.codex/pm/issue-state/265-establish-repository-wide-doc-chronology-and-entrypoints.md
@@ -3,7 +3,7 @@ type: issue_state
 issue: 265
 task: .codex/pm/tasks/real-history-quality/establish-repository-wide-doc-chronology-and-entrypoints.md
 title: Establish repository-wide documentation chronology and canonical entrypoint conventions
-status: in_progress
+status: done
 ---
 
 ## Summary
@@ -17,16 +17,16 @@ Define a lightweight repository-wide convention for documentation chronology and
 - `docs/zh/README.md` described the top-level Chinese tree, but `docs/zh/product/` and `docs/zh/architecture/` had no local entrypoint or explicit canonical-versus-historical guidance.
 - Date and status metadata already existed in parts of the tree, but not yet as a documented repository-wide convention.
 
-## Open Questions
+## Follow-Up Questions
 
 - Whether `docs/engineering/` also needs a dedicated chronology rule beyond the existing concern-based split.
 - Whether more legacy documents should be explicitly reclassified as historical drafts in follow-up issues instead of this minimal entrypoint pass.
 
-## Next Steps
+## Completed Work
 
-- Verify the new governance doc and directory indexes are sufficient as a first repository-wide convention.
-- Stage the new task twin, issue-state, governance doc, and directory `README` files together in one docs-only commit.
-- Run lightweight validation (`git diff --check` and direct README review) before commit.
+- Verified the new governance doc and directory indexes as a first repository-wide convention.
+- Staged the task twin, issue-state, governance doc, and directory `README` files in one docs-only commit.
+- Ran lightweight validation with `git diff --check` and direct README review before commit.
 
 ## Artifacts
 

--- a/.codex/pm/tasks/real-history-quality/establish-repository-wide-doc-chronology-and-entrypoints.md
+++ b/.codex/pm/tasks/real-history-quality/establish-repository-wide-doc-chronology-and-entrypoints.md
@@ -3,7 +3,7 @@ type: task
 epic: real-history-quality
 slug: establish-repository-wide-doc-chronology-and-entrypoints
 title: Establish repository-wide documentation chronology and canonical entrypoint conventions
-status: in_progress
+status: done
 task_type: docs
 labels: documentation
 issue: 265

--- a/.codex/pm/tasks/real-history-quality/establish-repository-wide-doc-chronology-and-entrypoints.md
+++ b/.codex/pm/tasks/real-history-quality/establish-repository-wide-doc-chronology-and-entrypoints.md
@@ -1,0 +1,67 @@
+---
+type: task
+epic: real-history-quality
+slug: establish-repository-wide-doc-chronology-and-entrypoints
+title: Establish repository-wide documentation chronology and canonical entrypoint conventions
+status: in_progress
+task_type: docs
+labels: documentation
+issue: 265
+state_path: .codex/pm/issue-state/265-establish-repository-wide-doc-chronology-and-entrypoints.md
+---
+
+## Context
+
+The repository already has meaningful documentation categories under `docs/`, including architecture, engineering, product, research, and Chinese companion trees.
+However, the current documentation surface still has a navigation and chronology problem:
+
+- readers often cannot tell the creation or revision order of related documents from names alone
+- long-lived discussion notes can grow by accretion and become harder to scan as "current canonical view" versus "historical discussion trail"
+- some directories have a clear local entrypoint while others rely on file browsing and implicit naming
+- date metadata and chronology cues exist in some note sets but not as a repository-wide convention
+
+The goal is not to force every document into date-prefixed filenames.
+The stronger goal is to make the `docs/` tree easier to navigate by giving readers explicit entrypoints, chronology cues, and lifecycle boundaries.
+
+Recent review of Kubernetes documentation practices suggests a useful direction:
+
+- organize primarily by topic tree rather than by time-stamped filename alone
+- use explicit metadata and directory-level entrypoints to signal order and canonical reading paths
+- separate "current canonical documentation" from historical or versioned material instead of letting one file silently absorb every discussion round
+
+OpenPrecedent should adopt a repository-scaled version of that idea for the full `docs/` tree rather than treating this only as a product-doc issue.
+
+## Deliverable
+
+Define and document a repository-wide documentation convention for chronology, canonical entrypoints, and lifecycle boundaries across `docs/` and `docs/zh/`, then apply the minimal structural updates needed so readers can tell where to start and how to interpret document age and status.
+
+## Scope
+
+- audit the top-level documentation categories under `docs/` and `docs/zh/` for missing entrypoints, chronology cues, and inconsistent date or status metadata
+- define a repository convention for directory-level indexes or README entrypoints where chronology or reading order matters
+- define how evolving discussion docs should distinguish current canonical notes from archived rounds, drafts, or superseded material
+- define the minimum metadata expected for documents that need chronology tracking, such as date, status, and document type
+- update the relevant repository documentation rules so later contributors can follow one consistent pattern
+- make only the smallest structural doc edits needed to demonstrate the convention on the current tree
+- keep the work focused on documentation governance and information architecture rather than broader product or implementation planning
+
+## Acceptance Criteria
+
+- the repository has an explicit documented convention for chronology and canonical entrypoints across the `docs/` tree
+- readers can tell from repository docs how canonical documents differ from archived, draft, or round-based discussion material
+- directories that need chronology tracking or a recommended reading path have a clear local entrypoint
+- the convention applies to both English and Chinese documentation trees where parallel materials exist
+- the resulting approach improves `docs/` discoverability without forcing every file into date-prefixed naming
+
+## Validation
+
+- read the updated documentation-governance guidance and confirm it explains chronology, canonical entrypoints, and lifecycle boundaries clearly
+- inspect the affected `docs/` and `docs/zh/` directories and confirm a reader can tell where to start and how to interpret document order or status
+- verify the chosen convention does not conflict with existing repository documentation rules about naming, Chinese translation, and research-note date metadata
+
+## Implementation Notes
+
+- Prefer a topic-tree plus explicit metadata approach over a filename-only chronology scheme.
+- Reuse existing directory `README.md` entrypoints where that pattern already exists or fits naturally.
+- Keep the convention lightweight enough that future issue-scoped documentation updates can follow it without large mechanical overhead.
+- Consider Kubernetes documentation organization as a reference pattern for topic-first structure, explicit entrypoints, and metadata-driven ordering, but adapt it pragmatically to this repository rather than copying its full site-generation model.

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,9 +7,32 @@ Repository documentation is organized by function:
 - `research/`: market and competitive analysis
 - `engineering/`: implementation and operational documentation
 
+Directory entrypoints:
+
+- [Product docs](/root/.config/superpowers/worktrees/openprecedent/codex-issue-265-doc-chronology/docs/product/README.md)
+- [Architecture docs](/root/.config/superpowers/worktrees/openprecedent/codex-issue-265-doc-chronology/docs/architecture/README.md)
+- [Research notes](/root/.config/superpowers/worktrees/openprecedent/codex-issue-265-doc-chronology/docs/research/README.md)
+- [Engineering docs](/root/.config/superpowers/worktrees/openprecedent/codex-issue-265-doc-chronology/docs/engineering/README.md)
+
 Engineering documentation is further organized by concern:
 
 - `engineering/cli/`: Rust public CLI design, implementation, and usage
 - `engineering/runtime/`: runtime boundaries, startup flows, tooling, and collector operations
 - `engineering/validation/`: live validation, rollout validation, and replay-quality evidence
 - `engineering/governance/`: harness policy, review rules, and repository workflow guidance
+
+## Documentation Conventions
+
+OpenPrecedent documentation should be organized primarily by topic tree, not by date-prefixed filenames alone.
+
+Repository-wide rules:
+
+- use a directory-level `README.md` when a doc category needs a recommended reading path, chronology cues, or canonical-vs-historical guidance
+- keep canonical current docs in stable topic locations such as `docs/product/` or `docs/architecture/`
+- mark drafts, historical notes, archived rounds, or superseded material explicitly in document metadata or directory indexes rather than expecting readers to infer status from filenames
+- include explicit date metadata when chronology matters for the document set, especially for research notes, evolving discussion docs, or historical drafts
+- keep English and Chinese entrypoints aligned when parallel documentation trees exist
+
+For the repository-level chronology and entrypoint guidance, see:
+
+- [Documentation governance](/root/.config/superpowers/worktrees/openprecedent/codex-issue-265-doc-chronology/docs/engineering/governance/documentation-governance.md)

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,22 @@
+# Architecture Docs
+
+Date: 2026-03-26
+
+This directory contains the current architecture reference for the shipped MVP and adjacent design notes.
+
+## Recommended Entry Point
+
+- Current shipped architecture: [OpenPrecedent 0.1.0 MVP architecture](/root/.config/superpowers/worktrees/openprecedent/codex-issue-265-doc-chronology/docs/architecture/mvp-design.md)
+
+## Entries
+
+- `mvp-design.md`
+  Status: current canonical architecture reference for the shipped MVP
+
+- `openclaw-silent-collection.md`
+  Status: focused design or operations note for the OpenClaw collection path
+
+## Reading Guidance
+
+- start with `mvp-design.md` for the current system boundary
+- use narrower design notes only after the main MVP architecture is clear

--- a/docs/engineering/governance/documentation-governance.md
+++ b/docs/engineering/governance/documentation-governance.md
@@ -1,0 +1,117 @@
+# Documentation Governance
+
+Date: 2026-03-26
+Status: Active
+
+## Purpose
+
+This document defines the repository-wide conventions for documentation chronology, canonical entrypoints, and lifecycle boundaries across `docs/` and `docs/zh/`.
+
+The goal is not to force every document into a date-prefixed naming scheme.
+The goal is to help readers answer three questions quickly:
+
+1. where should I start reading in this directory
+2. which document is the current canonical reference
+3. which documents are drafts, historical notes, archived rounds, or supporting evidence
+
+## Topic Tree First
+
+OpenPrecedent documentation should be organized primarily by topic tree:
+
+- `docs/product/`
+- `docs/architecture/`
+- `docs/research/`
+- `docs/engineering/`
+
+Time is still important, but it should usually be expressed through metadata and directory indexes rather than by encoding chronology only in filenames.
+
+## Directory Entrypoints
+
+Add a directory-level `README.md` when any of the following is true:
+
+- the directory contains multiple documents and readers need a recommended entrypoint
+- the directory contains both canonical and historical material
+- chronology matters for interpreting the document set
+- the directory has enough scope that file browsing alone is no longer clear
+
+The `README.md` should explain:
+
+- what the directory is for
+- which document is the current recommended starting point
+- which documents are current, historical, draft, or archival
+- any chronology cues that matter for reading order
+
+## Canonical Versus Historical Material
+
+When a directory contains evolving material, the repository should distinguish between:
+
+- canonical current docs
+- draft or exploratory notes
+- historical drafts
+- archive or evidence logs
+
+Use explicit wording such as:
+
+- `Active`
+- `Draft`
+- `Historical draft`
+- `Archive`
+- `Observation log`
+- `Closeout`
+
+Do not expect readers to infer lifecycle state only from prose or old filenames.
+
+## Date Metadata
+
+Include explicit date metadata when chronology affects interpretation.
+This is especially important for:
+
+- research note sets
+- evolving product discussion notes
+- validation logs and closeouts
+- historical drafts retained for reference
+
+Repository-acceptable patterns include:
+
+- `Date: YYYY-MM-DD`
+- `日期：YYYY-MM-DD`
+- structured document-info sections that include date and status
+
+The key requirement is not one exact syntax.
+The key requirement is that the date and lifecycle state are easy to find near the top of the document or in the directory index.
+
+## Canonical Discussion Notes
+
+For long-running discussion topics:
+
+- keep one stable canonical note when a topic needs a continuously maintained current view
+- avoid appending every future discussion round into the canonical note without restructuring
+- when historical discussion rounds matter on their own, separate them from the canonical note through archive or round-specific material
+
+Readers should not have to reverse-engineer chronology from a very long document alone.
+
+## Chinese And English Trees
+
+When English and Chinese documentation both exist:
+
+- keep directory entrypoints aligned where practical
+- keep chronology cues aligned across both trees
+- make it explicit when one side is canonical and the other is a companion or retained original-language reference
+
+## Current Repository Pattern
+
+The current repository pattern should be:
+
+- `docs/README.md` and `docs/zh/README.md` describe the top-level trees
+- category directories such as `docs/product/`, `docs/architecture/`, `docs/zh/product/`, and `docs/zh/architecture/` use local `README.md` entrypoints when they contain multiple or mixed-lifecycle documents
+- research directories continue to use dated indexes where chronology is part of the reading model
+
+## Non-Goals
+
+This convention does not require:
+
+- date-prefixed filenames for every document
+- a full static-site generator or Kubernetes-style website pipeline
+- mechanically rewriting all legacy docs in one pass
+
+The standard should stay lightweight enough for normal issue-scoped documentation work.

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -1,0 +1,40 @@
+# Product Docs
+
+Date: 2026-03-26
+
+This directory contains current product framing, MVP release documents, and longer-running product discussion notes.
+
+## Recommended Entry Points
+
+- Current repository phase and baseline: [MVP status note](/root/.config/superpowers/worktrees/openprecedent/codex-issue-265-doc-chronology/docs/product/mvp-status.md)
+- Current positioning summary: [OpenPrecedent strategy](/root/.config/superpowers/worktrees/openprecedent/codex-issue-265-doc-chronology/docs/product/strategy.md)
+- Current JTBD and wedge discussion note: [OpenPrecedent JTBD and competitive wedge](/root/.config/superpowers/worktrees/openprecedent/codex-issue-265-doc-chronology/docs/product/openprecedent-jtbd-and-competitive-wedge.md)
+
+## Current Canonical Docs
+
+- [MVP status note](/root/.config/superpowers/worktrees/openprecedent/codex-issue-265-doc-chronology/docs/product/mvp-status.md)
+- [OpenPrecedent strategy](/root/.config/superpowers/worktrees/openprecedent/codex-issue-265-doc-chronology/docs/product/strategy.md)
+- [MVP roadmap](/root/.config/superpowers/worktrees/openprecedent/codex-issue-265-doc-chronology/docs/product/mvp-roadmap.md)
+- [MVP PRD](/root/.config/superpowers/worktrees/openprecedent/codex-issue-265-doc-chronology/docs/product/mvp-prd.md)
+
+## Release-Facing Docs
+
+- [MVP release scope](/root/.config/superpowers/worktrees/openprecedent/codex-issue-265-doc-chronology/docs/product/mvp-release-scope.md)
+- [MVP release validation checklist](/root/.config/superpowers/worktrees/openprecedent/codex-issue-265-doc-chronology/docs/product/mvp-release-validation-checklist.md)
+- [MVP release publication flow](/root/.config/superpowers/worktrees/openprecedent/codex-issue-265-doc-chronology/docs/product/mvp-release-publication-flow.md)
+- [MVP release closeout](/root/.config/superpowers/worktrees/openprecedent/codex-issue-265-doc-chronology/docs/product/mvp-release-closeout.md)
+- [MVP release notes template](/root/.config/superpowers/worktrees/openprecedent/codex-issue-265-doc-chronology/docs/product/mvp-release-notes-template.md)
+
+## Ongoing Discussion Notes
+
+- `openprecedent-jtbd-and-competitive-wedge.md`
+  Date: `2026-03-26`
+  Status: active phase conclusion for the current JTBD round
+  Note: this is a maintained canonical discussion note, not an archive of every future round by default
+
+## Reading Guidance
+
+- start with the status note if you need the current repository phase
+- read the strategy note for concise positioning
+- read the JTBD note for the current deeper product discussion
+- use the release-facing docs when you need MVP publication or validation guidance

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -9,6 +9,12 @@
 - `engineering/`: 中文工程文档原稿
 - `research/`: 竞品与赛道研究
 
+目录入口：
+
+- [中文产品文档索引](/root/.config/superpowers/worktrees/openprecedent/codex-issue-265-doc-chronology/docs/zh/product/README.md)
+- [中文架构文档索引](/root/.config/superpowers/worktrees/openprecedent/codex-issue-265-doc-chronology/docs/zh/architecture/README.md)
+- [研究文档索引](/root/.config/superpowers/worktrees/openprecedent/codex-issue-265-doc-chronology/docs/zh/research/README.md)
+
 英文工程文档已经按职责细分为：
 
 - `docs/engineering/cli/`
@@ -21,3 +27,4 @@
 - 英文文档用于仓库内通用协作与对外开源表达
 - 中文文档用于保留完整判断过程和原始语义
 - 如中英文内容出现漂移，应优先人工对齐关键结论
+- 需要判断“当前入口”或“历史草稿”时，应优先查看目录级 `README.md` 或文档顶部日期、状态元数据，而不是只看文件名

--- a/docs/zh/architecture/README.md
+++ b/docs/zh/architecture/README.md
@@ -1,0 +1,23 @@
+# 中文架构文档索引
+
+日期：2026-03-26
+
+本目录保留当前 MVP 架构文档与历史中文设计稿。
+
+## 推荐入口
+
+- 当前 MVP 架构文档：[OpenPrecedent 0.1.0 MVP 架构文档](/root/.config/superpowers/worktrees/openprecedent/codex-issue-265-doc-chronology/docs/zh/architecture/mvp-design.md)
+
+## 条目
+
+- `mvp-design.md`
+  状态：当前中文 MVP 架构文档
+
+- `context-graph-mvp-design.md`
+  日期：`2026-03-09`
+  状态：Historical draft（已被当前 OpenPrecedent MVP 架构文档取代）
+
+## 阅读说明
+
+- 默认先读 `mvp-design.md`
+- 历史草稿保留用于追溯，不应被当作当前架构入口

--- a/docs/zh/product/README.md
+++ b/docs/zh/product/README.md
@@ -1,0 +1,32 @@
+# 中文产品文档索引
+
+日期：2026-03-26
+
+本目录保留当前中文产品文档、历史产品草稿和持续维护中的讨论文档。
+
+## 推荐入口
+
+- 当前仓库阶段基线：[OpenPrecedent MVP 状态说明](/root/.config/superpowers/worktrees/openprecedent/codex-issue-265-doc-chronology/docs/product/mvp-status.md)
+- 当前产品讨论主文档：[OpenPrecedent 待完成任务与竞争切入点](/root/.config/superpowers/worktrees/openprecedent/codex-issue-265-doc-chronology/docs/zh/product/openprecedent-jtbd-and-competitive-wedge.md)
+
+## 当前有效文档
+
+- `openprecedent-jtbd-and-competitive-wedge.md`
+  日期：`2026-03-26`
+  状态：当前 JTBD 轮次的阶段性结论文档
+
+## 历史草稿
+
+- `context-graph-mvp-prd.md`
+  日期：`2026-03-09`
+  状态：Historical draft（已被当前 OpenPrecedent MVP 文档取代）
+
+- `context-graph-product-strategy.md`
+  日期：`2026-03-08`
+  状态：Active
+  说明：保留为这一轮产品探索的重要中文工作文档，但不应被当作当前唯一入口
+
+## 阅读说明
+
+- 当前读者如果只想理解现在的产品判断，应先读 `openprecedent-jtbd-and-competitive-wedge.md`
+- `context-graph-*` 文档用于保留探索阶段判断与草稿，不应用文件名自行推断其是否仍是当前主入口


### PR DESCRIPTION
Closes #265

Define and document a repository-wide documentation convention for chronology, canonical entrypoints, and lifecycle boundaries across `docs/` and `docs/zh/`, then apply the minimal structural updates needed so readers can tell where to start and how to interpret document age and status.

Implementation notes:
- Prefer a topic-tree plus explicit metadata approach over a filename-only chronology scheme.
- Reuse existing directory `README.md` entrypoints where that pattern already exists or fits naturally.
- Keep the convention lightweight enough that future issue-scoped documentation updates can follow it without large mechanical overhead.
- Consider Kubernetes documentation organization as a reference pattern for topic-first structure, explicit entrypoints, and metadata-driven ordering, but adapt it pragmatically to this repository rather than copying its full site-generation model.

Validation:
- read the updated documentation-governance guidance and confirm it explains chronology, canonical entrypoints, and lifecycle boundaries clearly
- inspect the affected `docs/` and `docs/zh/` directories and confirm a reader can tell where to start and how to interpret document order or status
- verify the chosen convention does not conflict with existing repository documentation rules about naming, Chinese translation, and research-note date metadata
- `git diff --check; reviewed directory entrypoints, chronology guidance, and bilingual docs-tree alignment`