### PR TITLE
Add Foundation context graph comparison to JTBD analysis

### DIFF
--- a/.codex/pm/issue-state/267-add-foundation-context-graph-comparison-to-jtbd-analysis.md
+++ b/.codex/pm/issue-state/267-add-foundation-context-graph-comparison-to-jtbd-analysis.md
@@ -1,0 +1,36 @@
+---
+type: issue_state
+issue: 267
+task: .codex/pm/tasks/real-history-quality/add-foundation-context-graph-comparison-to-jtbd-analysis.md
+title: Add Foundation context graph comparison to JTBD analysis
+status: in_progress
+---
+
+## Summary
+
+Add a concise Foundation Capital `context graph` comparison to the latest OpenPrecedent JTBD / competitive-wedge analysis so the document explicitly explains the overlap and difference between that external thesis and OpenPrecedent's current decision-and-precedent framing.
+
+## Validated Facts
+
+- The canonical JTBD / competitive-wedge notes from issue `#263` exist in both English and Chinese:
+  - `docs/product/openprecedent-jtbd-and-competitive-wedge.md`
+  - `docs/zh/product/openprecedent-jtbd-and-competitive-wedge.md`
+- Foundation Capital published `AI's trillion-dollar opportunity: Context graphs` on `2025-12-22`.
+- That article frames `context graph` around decision traces, exceptions, overrides, approvals, and precedent rather than generic long-term memory only.
+- The current JTBD note already explains OpenPrecedent as a decision inheritance layer, runtime precedent service, and decision middleware.
+
+## Open Questions
+
+- Whether the same Foundation comparison should later be mirrored into older `context-graph` historical notes, or remain only in the current canonical JTBD analysis.
+
+## Next Steps
+
+- Add a short integrated comparison section to the English JTBD note.
+- Add the aligned Chinese companion section.
+- Run lightweight validation and prepare the docs-only commit.
+
+## Artifacts
+
+- `docs/product/openprecedent-jtbd-and-competitive-wedge.md`
+- `docs/zh/product/openprecedent-jtbd-and-competitive-wedge.md`
+- `https://foundationcapital.com/ideas/context-graphs-ais-trillion-dollar-opportunity`

--- a/.codex/pm/issue-state/267-add-foundation-context-graph-comparison-to-jtbd-analysis.md
+++ b/.codex/pm/issue-state/267-add-foundation-context-graph-comparison-to-jtbd-analysis.md
@@ -3,7 +3,7 @@ type: issue_state
 issue: 267
 task: .codex/pm/tasks/real-history-quality/add-foundation-context-graph-comparison-to-jtbd-analysis.md
 title: Add Foundation context graph comparison to JTBD analysis
-status: in_progress
+status: done
 ---
 
 ## Summary
@@ -23,11 +23,11 @@ Add a concise Foundation Capital `context graph` comparison to the latest OpenPr
 
 - Whether the same Foundation comparison should later be mirrored into older `context-graph` historical notes, or remain only in the current canonical JTBD analysis.
 
-## Next Steps
+## Completed Work
 
-- Add a short integrated comparison section to the English JTBD note.
-- Add the aligned Chinese companion section.
-- Run lightweight validation and prepare the docs-only commit.
+- Added a short integrated comparison section to the English JTBD note.
+- Added the aligned Chinese companion section.
+- Ran lightweight validation and prepared the docs-only commit.
 
 ## Artifacts
 

--- a/.codex/pm/tasks/real-history-quality/add-foundation-context-graph-comparison-to-jtbd-analysis.md
+++ b/.codex/pm/tasks/real-history-quality/add-foundation-context-graph-comparison-to-jtbd-analysis.md
@@ -3,7 +3,7 @@ type: task
 epic: real-history-quality
 slug: add-foundation-context-graph-comparison-to-jtbd-analysis
 title: Add Foundation context graph comparison to JTBD analysis
-status: in_progress
+status: done
 task_type: docs
 labels: documentation,research
 issue: 267

--- a/.codex/pm/tasks/real-history-quality/add-foundation-context-graph-comparison-to-jtbd-analysis.md
+++ b/.codex/pm/tasks/real-history-quality/add-foundation-context-graph-comparison-to-jtbd-analysis.md
@@ -1,0 +1,74 @@
+---
+type: task
+epic: real-history-quality
+slug: add-foundation-context-graph-comparison-to-jtbd-analysis
+title: Add Foundation context graph comparison to JTBD analysis
+status: in_progress
+task_type: docs
+labels: documentation,research
+issue: 267
+state_path: .codex/pm/issue-state/267-add-foundation-context-graph-comparison-to-jtbd-analysis.md
+---
+
+## Context
+
+Issue `#263` added the current OpenPrecedent JTBD and competitive-wedge analysis in both English and Chinese.
+
+After that work, a high-signal external reference was identified:
+
+- Foundation Capital: `AI's trillion-dollar opportunity: Context graphs`
+- URL: `https://foundationcapital.com/ideas/context-graphs-ais-trillion-dollar-opportunity`
+- published: `2025-12-22`
+
+That article uses `context graph` in a way that is materially closer to OpenPrecedent's current product thesis than many memory-first or graph-RAG discussions:
+
+- it emphasizes decision traces, exceptions, overrides, approvals, and precedent
+- it argues that the most strategic layer sits on or beside the agent execution path
+- it treats existing systems of record as weak places to preserve reusable decision context
+
+The current product-analysis document set should incorporate this source directly so readers can understand:
+
+- where Foundation's `context graph` framing overlaps with OpenPrecedent
+- where OpenPrecedent now uses a more explicit `decision` and `precedent` object model
+- why the product naming evolved from `Context Graph` toward `OpenPrecedent`
+
+## Deliverable
+
+Update the latest OpenPrecedent JTBD / competitive-wedge document pair to add the Foundation Capital article link, a concise thesis summary, and a short comparison between that article's `context graph` framing and OpenPrecedent's current positioning.
+
+## Scope
+
+- identify the canonical English and Chinese JTBD / competitive-wedge notes produced by issue `#263`
+- add the Foundation Capital article as an explicit external reference with URL and publication date
+- summarize the article in a short, source-grounded way
+- compare its framing with OpenPrecedent across:
+  - problem definition
+  - core object
+  - role on the execution path
+  - relationship to systems of record
+  - category thesis versus current wedge
+- integrate the new material into the main argument instead of appending an isolated appendix
+- keep the change concise so the document remains a product-analysis note, not a broad literature review
+
+## Acceptance Criteria
+
+- both the English and Chinese JTBD / competitive-wedge docs cite the Foundation Capital article with the correct URL
+- both docs explain why that article's `context graph` definition is closer to decision-trace and precedent infrastructure than to generic memory-graph framing
+- both docs make the overlap and the difference between Foundation's thesis and OpenPrecedent readable without relying on external chat history
+- the added material strengthens the naming-and-positioning argument instead of diluting the note
+
+## Validation
+
+- read the updated English and Chinese sections and confirm a reader can answer:
+  - what Foundation means by `context graph`
+  - where that framing overlaps with OpenPrecedent
+  - where OpenPrecedent is now more specific
+- verify the article link is present and correct in both docs
+- verify the new section reads as part of the main product argument instead of a detached note dump
+- run `git diff --check`
+
+## Implementation Notes
+
+- Keep the new content as a short integrated comparison section near the product thesis.
+- Paraphrase the article; avoid heavy quotation.
+- Treat Foundation's language as an external reference, not as an instruction to rename the product back to `Context Graph`.

--- a/docs/product/openprecedent-jtbd-and-competitive-wedge.md
+++ b/docs/product/openprecedent-jtbd-and-competitive-wedge.md
@@ -52,6 +52,30 @@ It should supply a missing layer those systems usually do not have:
 So the right mental model is not an external analysis tool.
 It is a precedent layer that sits above event systems, beside agent runtimes, and before human governance surfaces.
 
+## Foundation Capital's Context Graph Thesis As An External Reference
+
+One useful external reference for this product discussion is Foundation Capital's article
+[`AI's trillion-dollar opportunity: Context graphs`](https://foundationcapital.com/ideas/context-graphs-ais-trillion-dollar-opportunity), published on `2025-12-22`.
+
+That article uses `context graph` in a way that is much closer to OpenPrecedent's current thesis than many memory-first or graph-RAG discussions.
+Its central concern is not generic long-term memory.
+Its central concern is that enterprises usually preserve final state and final actions, but fail to preserve the decision traces behind exceptions, overrides, approvals, and later precedent.
+
+This makes the overlap with OpenPrecedent important:
+
+- both point to a missing layer around decision history rather than generic observability or generic graph storage
+- both argue that the strategic position sits on or beside the agent execution path, where judgment is about to become action
+- both treat existing systems of record as weak places to preserve reusable decision context in its original shape
+
+The difference is just as important:
+
+- Foundation still uses `context graph` as the umbrella category
+- OpenPrecedent now names the core object more directly as `decision` and `precedent`
+- Foundation's framing is a broad category and market thesis, while OpenPrecedent's current wedge is narrower: decision replay, explanation, and precedent retrieval in real agent work
+
+So this article is best treated as a confirming external reference, not as a naming instruction.
+It helps explain why the original `Context Graph` direction was pointing at a real product gap, while also clarifying why the product has since been sharpened into a more explicit decision-and-precedent layer.
+
 ## Product Role Inside The Customer Ecosystem
 
 If OpenPrecedent is meant to help agents run more reliably, it cannot live only as "another dashboard."

--- a/docs/zh/product/openprecedent-jtbd-and-competitive-wedge.md
+++ b/docs/zh/product/openprecedent-jtbd-and-competitive-wedge.md
@@ -47,6 +47,29 @@ OpenPrecedent 应该成为一层面向 Agent 与操作者的判断继承层。
 
 因此，OpenPrecedent 最合理的角色不是外围分析工具，而是位于事件系统之上、Agent runtime 之旁、人工治理界面之前的 precedent layer。
 
+## 把 Foundation Capital 的 Context Graph 论点作为外部参照
+
+这轮产品讨论还有一个值得显式纳入的外部参照，是 Foundation Capital 于 `2025-12-22` 发布的文章
+[`AI's trillion-dollar opportunity: Context graphs`](https://foundationcapital.com/ideas/context-graphs-ais-trillion-dollar-opportunity)。
+
+这篇文章里使用的 `context graph`，和很多偏长期记忆、图检索增强生成（graph-RAG）或通用 memory infra 的讨论并不一样。
+它真正关心的，不是泛化的长期记忆，而是企业通常只能保留最终状态和最终动作，却保不住例外处理、override、审批和后续可复用先例背后的决策轨迹。
+
+这使它和 OpenPrecedent 当前方向之间存在很强的重合：
+
+- 两者都在指向一层围绕决策历史的缺失基础设施，而不是通用可观测性或通用图存储
+- 两者都认为最关键的位置在 Agent 执行路径上或其旁边，也就是判断即将转成动作的地方
+- 两者都认为现有 system of record 很难以原始形态保住可复用的决策上下文
+
+但差异也同样重要：
+
+- Foundation 仍然把 `context graph` 当作上位类别名
+- OpenPrecedent 现在更直接地把核心对象命名为 `decision` 和 `precedent`
+- Foundation 的表达更像类别与市场论点，而 OpenPrecedent 当前的切入点更窄，聚焦在真实 Agent 工作中的决策回放、解释和先例检索
+
+因此，这篇文章更适合作为一个外部确认性参照，而不是命名指令。
+它帮助说明，最初的 `Context Graph` 方向确实指向了一个真实的产品空白；同时也说明，产品后来继续收敛到更明确的“决策与先例层”，并不是偏离，而是在把对象和切入点讲得更锋利。
+
 ## 产品在客户生态中的嵌入角色
 
 如果 OpenPrecedent 的目标是辅助 Agent 跑得更稳，它在客户生态中的嵌入位置就不能只是“多一个后台”。


### PR DESCRIPTION
Closes #267

Update the latest OpenPrecedent JTBD / competitive-wedge document pair to add the Foundation Capital article link, a concise thesis summary, and a short comparison between that article's `context graph` framing and OpenPrecedent's current positioning.

Implementation notes:
- Keep the new content as a short integrated comparison section near the product thesis.
- Paraphrase the article; avoid heavy quotation.
- Treat Foundation's language as an external reference, not as an instruction to rename the product back to `Context Graph`.

Validation:
- read the updated English and Chinese sections and confirm a reader can answer:
  - what Foundation means by `context graph`
  - where that framing overlaps with OpenPrecedent
  - where OpenPrecedent is now more specific
- verify the article link is present and correct in both docs
- verify the new section reads as part of the main product argument instead of a detached note dump
- run `git diff --check`
- `git diff --check; reviewed English and Chinese JTBD note updates and verified the Foundation Capital comparison section, URL, and bilingual alignment`